### PR TITLE
Add an example of how to use Name::parse

### DIFF
--- a/src/rr/domain.rs
+++ b/src/rr/domain.rs
@@ -185,6 +185,17 @@ impl Name {
     self.labels.iter().fold(dots, |acc, item| acc + item.len())
   }
 
+  /// attempts to parse a name such as `"example.com."` or `"subdomain.example.com."`
+  ///
+  /// # Examples
+  ///
+  /// ```rust
+  /// use trust_dns::rr::domain::Name;
+  ///
+  /// let name = Name::parse("example.com.", None).unwrap();
+  /// assert_eq!(name.base_name(), Name::new().label("com"));
+  /// assert_eq!(*name[0], String::from("example"));
+  /// ```
   pub fn parse(local: &str, origin: Option<&Self>) -> ParseResult<Self> {
     let mut name = Name::new();
     let mut label = String::new();


### PR DESCRIPTION
The `rr::domain::Name::parse` function is one of the first things I reached for when I picked up the library.  Unfortunately, I had to do some digging to make sure that my usage was correct.  Since, in the generated documentation, [parse isn't very easy to pick out](https://docs.rs/trust-dns/0.7.3/trust_dns/rr/domain/struct.Name.html#method.parse) at present, I thought it could grab people's attention better and be clearer with a little documentation.