### PR TITLE
Resolved all of the compiler warnings

### DIFF
--- a/src/client/client_future.rs
+++ b/src/client/client_future.rs
@@ -704,24 +704,23 @@ pub mod test {
 
   use chrono::Duration;
   use futures;
-  use futures::{Async, Complete, Future, finished, Oneshot, Poll, task};
+  use futures::{Async, Future, finished, Poll};
   use futures::stream::{Fuse, Stream};
   use futures::task::park;
-  use openssl::crypto::pkey::{PKey, Role};
+  use openssl::crypto::pkey::PKey;
   use tokio_core::reactor::{Core, Handle};
-  use tokio_core::channel::{channel, Sender, Receiver};
+  use tokio_core::channel::{channel, Receiver};
 
   use super::{ClientFuture, ClientHandle, StreamHandle};
   use ::op::{Message, ResponseCode};
   use ::authority::Catalog;
-  use ::authority::authority_tests::{create_example, create_secure_example};
+  use ::authority::authority_tests::create_example;
   use ::rr::domain;
   use ::rr::{DNSClass, RData, Record, RecordType};
   use ::rr::dnssec::{Algorithm, Signer};
   use ::serialize::binary::{BinDecoder, BinEncoder, BinSerializable};
-  use ::error::*;
-  use ::udp::{UdpClientStream, UdpClientStreamHandle};
-  use ::tcp::{TcpClientStream, TcpClientStreamHandle};
+  use ::udp::UdpClientStream;
+  use ::tcp::TcpClientStream;
 
   pub struct TestClientStream {
     catalog: Catalog,

--- a/src/tcp/tcp_client_stream.rs
+++ b/src/tcp/tcp_client_stream.rs
@@ -6,7 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 use std::mem;
-use std::net::SocketAddr;
+#[allow(unused_imports)]
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::io;
 use std::io::{Read, Write};
 
@@ -246,11 +247,11 @@ fn tcp_client_stream_test(server_addr: IpAddr) {
     }
 
     println!("timeout");
-    std::process::exit(-1)
+    ::std::process::exit(-1)
   });
 
   // TODO: need a timeout on listen
-  let server = std::net::TcpListener::bind(SocketAddr::new(server_addr, 0)).unwrap();
+  let server = ::std::net::TcpListener::bind(SocketAddr::new(server_addr, 0)).unwrap();
   let server_addr = server.local_addr().unwrap();
 
   let send_recv_times = 4;

--- a/src/tcp/tcp_client_stream.rs
+++ b/src/tcp/tcp_client_stream.rs
@@ -5,21 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std;
 use std::mem;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::io;
 use std::io::{Read, Write};
 
-use futures::{AndThen, Async, BoxFuture, Flatten, Future, Poll};
+use futures::{Async, Future, Poll};
 use futures::stream::{Fuse, Peekable, Stream};
-use futures::task::park;
-use rand::Rng;
-use rand;
-use tokio_core;
 use tokio_core::net::TcpStream as TokioTcpStream;
 use tokio_core::channel::{channel, Sender, Receiver};
-use tokio_core::io::{read_exact, ReadExact, write_all, WriteAll};
 use tokio_core::reactor::{Handle};
 
 pub type TcpClientStreamHandle = Sender<Vec<u8>>;
@@ -35,6 +29,7 @@ enum ReadTcpState {
 }
 
 pub struct TcpClientStream {
+  #[allow(dead_code)]
   name_server: SocketAddr,
   socket: TokioTcpStream,
   outbound_messages: Peekable<Fuse<Receiver<Vec<u8>>>>,

--- a/src/udp/udp_client_stream.rs
+++ b/src/udp/udp_client_stream.rs
@@ -168,6 +168,7 @@ fn test_udp_client_stream_ipv6() {
 }
 
 #[cfg(test)]
+#[allow(unused_variables)]
 fn udp_client_stream_test(server_addr: IpAddr) {
   use std::time::Duration;
   use std::thread;
@@ -181,7 +182,7 @@ fn udp_client_stream_test(server_addr: IpAddr) {
 
   TrustDnsLogger::enable_logging(LogLevel::Debug);
 
-  let mut succeeded = Arc::new(AtomicBool::new(false));
+  let succeeded = Arc::new(AtomicBool::new(false));
   let succeeded_clone = succeeded.clone();
   let test_killer = thread::Builder::new().name("thread_killer".to_string()).spawn(move || {
     let succeeded = succeeded_clone.clone();


### PR DESCRIPTION
There were a handful of compiler warnings being generated mostly related to some unused functions and imports.  I removed the unused imports and set the `#[allow(dead_code)]` attribute on functions and struct fields that should be left in the library for users but not trigger warnings for their lack of use within the library itself.