### PR TITLE
Rename client getter and setter methods

### DIFF
--- a/client/src/client/client_future.rs
+++ b/client/src/client/client_future.rs
@@ -540,11 +540,11 @@ pub trait ClientHandle: Clone {
     {
         // TODO: assert non-empty rrset?
         let rrset = rrset.into_record_set();
-        assert!(zone_origin.zone_of(rrset.get_name()));
+        assert!(zone_origin.zone_of(rrset.name()));
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.set_name(zone_origin).set_query_class(rrset.get_dns_class()).set_query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(rrset.dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -554,7 +554,7 @@ pub trait ClientHandle: Clone {
             .set_recursion_desired(false);
         message.add_zone(zone);
 
-        let mut prerequisite = Record::with(rrset.get_name().clone(), rrset.get_record_type(), 0);
+        let mut prerequisite = Record::with(rrset.name().clone(), rrset.record_type(), 0);
         prerequisite.set_dns_class(DNSClass::NONE);
         message.add_pre_requisite(prerequisite);
         message.add_updates(rrset);
@@ -611,11 +611,11 @@ pub trait ClientHandle: Clone {
         where R: IntoRecordSet
     {
         let rrset = rrset.into_record_set();
-        assert!(zone_origin.zone_of(rrset.get_name()));
+        assert!(zone_origin.zone_of(rrset.name()));
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.set_name(zone_origin).set_query_class(rrset.get_dns_class()).set_query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(rrset.dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -627,7 +627,7 @@ pub trait ClientHandle: Clone {
 
         if must_exist {
             let mut prerequisite =
-                Record::with(rrset.get_name().clone(), rrset.get_record_type(), 0);
+                Record::with(rrset.name().clone(), rrset.record_type(), 0);
             prerequisite.set_dns_class(DNSClass::ANY);
             message.add_pre_requisite(prerequisite);
         }
@@ -696,12 +696,12 @@ pub trait ClientHandle: Clone {
         let current = current.into_record_set();
         let new = new.into_record_set();
 
-        assert!(zone_origin.zone_of(current.get_name()));
-        assert!(zone_origin.zone_of(new.get_name()));
+        assert!(zone_origin.zone_of(current.name()));
+        assert!(zone_origin.zone_of(new.name()));
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.set_name(zone_origin).set_query_class(new.get_dns_class()).set_query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(new.dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -780,11 +780,11 @@ pub trait ClientHandle: Clone {
         where R: IntoRecordSet
     {
         let mut rrset = rrset.into_record_set();
-        assert!(zone_origin.zone_of(rrset.get_name()));
+        assert!(zone_origin.zone_of(rrset.name()));
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.set_name(zone_origin).set_query_class(rrset.get_dns_class()).set_query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(rrset.dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();

--- a/client/src/client/client_future.rs
+++ b/client/src/client/client_future.rs
@@ -390,7 +390,7 @@ pub trait ClientHandle: Clone {
 
         // add the query
         let mut query: Query = Query::new();
-        query.name(name.clone()).query_class(query_class).query_type(query_type);
+        query.set_name(name.clone()).set_query_class(query_class).set_query_type(query_type);
         message.add_query(query);
 
         self.send(message)
@@ -488,7 +488,7 @@ pub trait ClientHandle: Clone {
 
         // add the query
         let mut query: Query = Query::new();
-        query.name(name.clone()).query_class(query_class).query_type(query_type);
+        query.set_name(name.clone()).set_query_class(query_class).set_query_type(query_type);
         message.add_query(query);
 
         // add the notify message, see https://tools.ietf.org/html/rfc1996, section 3.7
@@ -544,7 +544,7 @@ pub trait ClientHandle: Clone {
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.name(zone_origin).query_class(rrset.get_dns_class()).query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(rrset.get_dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -615,7 +615,7 @@ pub trait ClientHandle: Clone {
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.name(zone_origin).query_class(rrset.get_dns_class()).query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(rrset.get_dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -701,7 +701,7 @@ pub trait ClientHandle: Clone {
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.name(zone_origin).query_class(new.get_dns_class()).query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(new.get_dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -784,7 +784,7 @@ pub trait ClientHandle: Clone {
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.name(zone_origin).query_class(rrset.get_dns_class()).query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(rrset.get_dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -852,7 +852,7 @@ pub trait ClientHandle: Clone {
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.name(zone_origin).query_class(record.get_dns_class()).query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(record.get_dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -913,7 +913,7 @@ pub trait ClientHandle: Clone {
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.name(zone_origin).query_class(dns_class).query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(dns_class).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();

--- a/client/src/client/client_future.rs
+++ b/client/src/client/client_future.rs
@@ -213,10 +213,10 @@ impl<S: Stream<Item = Vec<u8>, Error = io::Error> + 'static> Future for ClientFu
                     // getting a random query id, this mitigates potential cache poisoning.
                     // TODO: for SIG0 we can't change the message id after signing.
                     let query_id = query_id.expect("query_id should have been set above");
-                    message.id(query_id);
+                    message.set_id(query_id);
 
                     // update messages need to be signed.
-                    if let OpCode::Update = message.get_op_code() {
+                    if let OpCode::Update = message.op_code() {
                         if let Some(ref signer) = self.signer {
                             // TODO: it's too bad this happens here...
                             if let Err(e) = message.sign(signer, UTC::now().timestamp() as u32) {
@@ -244,7 +244,7 @@ impl<S: Stream<Item = Vec<u8>, Error = io::Error> + 'static> Future for ClientFu
                             try!(self.stream_handle.send(buffer));
                             // add to the map -after- the client send b/c we don't want to put it in the map if
                             //  we ended up returning from the send.
-                            self.active_requests.insert(message.get_id(), (complete, timeout));
+                            self.active_requests.insert(message.id(), (complete, timeout));
                         }
                         Err(e) => {
                             debug!("error message id: {} error: {}", query_id, e);
@@ -273,9 +273,9 @@ impl<S: Stream<Item = Vec<u8>, Error = io::Error> + 'static> Future for ClientFu
                     //   deserialize or log decode_error
                     match Message::from_vec(&buffer) {
                         Ok(message) => {
-                            match self.active_requests.remove(&message.get_id()) {
+                            match self.active_requests.remove(&message.id()) {
                                 Some((complete, _)) => complete.complete(Ok(message)),
-                                None => debug!("unexpected request_id: {}", message.get_id()),
+                                None => debug!("unexpected request_id: {}", message.id()),
                             }
                         }
                         // TODO: return src address for diagnostics
@@ -376,14 +376,14 @@ pub trait ClientHandle: Clone {
         let mut message: Message = Message::new();
         let id: u16 = rand::random();
         // TODO make recursion a parameter
-        message.id(id)
-            .message_type(MessageType::Query)
-            .op_code(OpCode::Query)
-            .recursion_desired(true);
+        message.set_id(id)
+            .set_message_type(MessageType::Query)
+            .set_op_code(OpCode::Query)
+            .set_recursion_desired(true);
 
         // Extended dns
         {
-            let edns = message.get_edns_mut();
+            let edns = message.edns_mut();
             edns.set_max_payload(1500);
             edns.set_version(0);
         }
@@ -469,19 +469,19 @@ pub trait ClientHandle: Clone {
         // build the message
         let mut message: Message = Message::new();
         let id: u16 = rand::random();
-        message.id(id)
+        message.set_id(id)
            // 3.3. NOTIFY is similar to QUERY in that it has a request message with
            // the header QR flag "clear" and a response message with QR "set".  The
            // response message contains no useful information, but its reception by
            // the master is an indication that the slave has received the NOTIFY
            // and that the master can remove the slave from any retry queue for
            // this NOTIFY event.
-           .message_type(MessageType::Query)
-           .op_code(OpCode::Notify);
+           .set_message_type(MessageType::Query)
+           .set_op_code(OpCode::Notify);
 
         // Extended dns
         {
-            let edns = message.get_edns_mut();
+            let edns = message.edns_mut();
             edns.set_max_payload(1500);
             edns.set_version(0);
         }
@@ -548,10 +548,10 @@ pub trait ClientHandle: Clone {
 
         // build the message
         let mut message: Message = Message::new();
-        message.id(rand::random())
-            .message_type(MessageType::Query)
-            .op_code(OpCode::Update)
-            .recursion_desired(false);
+        message.set_id(rand::random())
+            .set_message_type(MessageType::Query)
+            .set_op_code(OpCode::Update)
+            .set_recursion_desired(false);
         message.add_zone(zone);
 
         let mut prerequisite = Record::with(rrset.get_name().clone(), rrset.get_record_type(), 0);
@@ -561,7 +561,7 @@ pub trait ClientHandle: Clone {
 
         // Extended dns
         {
-            let edns = message.get_edns_mut();
+            let edns = message.edns_mut();
             edns.set_max_payload(1500);
             edns.set_version(0);
         }
@@ -619,10 +619,10 @@ pub trait ClientHandle: Clone {
 
         // build the message
         let mut message: Message = Message::new();
-        message.id(rand::random())
-            .message_type(MessageType::Query)
-            .op_code(OpCode::Update)
-            .recursion_desired(false);
+        message.set_id(rand::random())
+            .set_message_type(MessageType::Query)
+            .set_op_code(OpCode::Update)
+            .set_recursion_desired(false);
         message.add_zone(zone);
 
         if must_exist {
@@ -636,7 +636,7 @@ pub trait ClientHandle: Clone {
 
         // Extended dns
         {
-            let edns = message.get_edns_mut();
+            let edns = message.edns_mut();
             edns.set_max_payload(1500);
             edns.set_version(0);
         }
@@ -705,10 +705,10 @@ pub trait ClientHandle: Clone {
 
         // build the message
         let mut message: Message = Message::new();
-        message.id(rand::random())
-            .message_type(MessageType::Query)
-            .op_code(OpCode::Update)
-            .recursion_desired(false);
+        message.set_id(rand::random())
+            .set_message_type(MessageType::Query)
+            .set_op_code(OpCode::Update)
+            .set_recursion_desired(false);
         message.add_zone(zone);
 
         // make sure the record is what is expected
@@ -729,7 +729,7 @@ pub trait ClientHandle: Clone {
 
         // Extended dns
         {
-            let edns = message.get_edns_mut();
+            let edns = message.edns_mut();
             edns.set_max_payload(1500);
             edns.set_version(0);
         }
@@ -788,10 +788,10 @@ pub trait ClientHandle: Clone {
 
         // build the message
         let mut message: Message = Message::new();
-        message.id(rand::random())
-            .message_type(MessageType::Query)
-            .op_code(OpCode::Update)
-            .recursion_desired(false);
+        message.set_id(rand::random())
+            .set_message_type(MessageType::Query)
+            .set_op_code(OpCode::Update)
+            .set_recursion_desired(false);
         message.add_zone(zone);
 
         // the class must be none for delete
@@ -802,7 +802,7 @@ pub trait ClientHandle: Clone {
 
         // Extended dns
         {
-            let edns = message.get_edns_mut();
+            let edns = message.edns_mut();
             edns.set_max_payload(1500);
             edns.set_version(0);
         }
@@ -856,10 +856,10 @@ pub trait ClientHandle: Clone {
 
         // build the message
         let mut message: Message = Message::new();
-        message.id(rand::random())
-            .message_type(MessageType::Query)
-            .op_code(OpCode::Update)
-            .recursion_desired(false);
+        message.set_id(rand::random())
+            .set_message_type(MessageType::Query)
+            .set_op_code(OpCode::Update)
+            .set_recursion_desired(false);
         message.add_zone(zone);
 
         // the class must be none for an rrset delete
@@ -872,7 +872,7 @@ pub trait ClientHandle: Clone {
 
         // Extended dns
         {
-            let edns = message.get_edns_mut();
+            let edns = message.edns_mut();
             edns.set_max_payload(1500);
             edns.set_version(0);
         }
@@ -917,10 +917,10 @@ pub trait ClientHandle: Clone {
 
         // build the message
         let mut message: Message = Message::new();
-        message.id(rand::random())
-            .message_type(MessageType::Query)
-            .op_code(OpCode::Update)
-            .recursion_desired(false);
+        message.set_id(rand::random())
+            .set_message_type(MessageType::Query)
+            .set_op_code(OpCode::Update)
+            .set_recursion_desired(false);
         message.add_zone(zone);
 
         // the TTL shoudl be 0
@@ -935,7 +935,7 @@ pub trait ClientHandle: Clone {
 
         // Extended dns
         {
-            let edns = message.get_edns_mut();
+            let edns = message.edns_mut();
             edns.set_max_payload(1500);
             edns.set_version(0);
         }

--- a/client/src/client/client_future.rs
+++ b/client/src/client/client_future.rs
@@ -555,7 +555,7 @@ pub trait ClientHandle: Clone {
         message.add_zone(zone);
 
         let mut prerequisite = Record::with(rrset.get_name().clone(), rrset.get_record_type(), 0);
-        prerequisite.dns_class(DNSClass::NONE);
+        prerequisite.set_dns_class(DNSClass::NONE);
         message.add_pre_requisite(prerequisite);
         message.add_updates(rrset);
 
@@ -628,7 +628,7 @@ pub trait ClientHandle: Clone {
         if must_exist {
             let mut prerequisite =
                 Record::with(rrset.get_name().clone(), rrset.get_record_type(), 0);
-            prerequisite.dns_class(DNSClass::ANY);
+            prerequisite.set_dns_class(DNSClass::ANY);
             message.add_pre_requisite(prerequisite);
         }
 
@@ -848,11 +848,11 @@ pub trait ClientHandle: Clone {
                     mut record: Record,
                     zone_origin: domain::Name)
                     -> Box<Future<Item = Message, Error = ClientError>> {
-        assert!(zone_origin.zone_of(record.get_name()));
+        assert!(zone_origin.zone_of(record.name()));
 
         // for updates, the query section is used for the zone
         let mut zone: Query = Query::new();
-        zone.set_name(zone_origin).set_query_class(record.get_dns_class()).set_query_type(RecordType::SOA);
+        zone.set_name(zone_origin).set_query_class(record.dns_class()).set_query_type(RecordType::SOA);
 
         // build the message
         let mut message: Message = Message::new();
@@ -863,11 +863,11 @@ pub trait ClientHandle: Clone {
         message.add_zone(zone);
 
         // the class must be none for an rrset delete
-        record.dns_class(DNSClass::ANY);
+        record.set_dns_class(DNSClass::ANY);
         // the TTL shoudl be 0
-        record.ttl(0);
+        record.set_ttl(0);
         // the rdata must be null to delete all rrsets
-        record.rdata(RData::NULL(NULL::new()));
+        record.set_rdata(RData::NULL(NULL::new()));
         message.add_update(record);
 
         // Extended dns
@@ -929,7 +929,7 @@ pub trait ClientHandle: Clone {
         let mut record = Record::with(name_of_records, RecordType::ANY, 0);
 
         // the class must be none for an rrset delete
-        record.dns_class(DNSClass::ANY);
+        record.set_dns_class(DNSClass::ANY);
 
         message.add_update(record);
 

--- a/client/src/client/memoize_client_handle.rs
+++ b/client/src/client/memoize_client_handle.rs
@@ -45,7 +45,7 @@ impl<H> ClientHandle for MemoizeClientHandle<H>
     where H: ClientHandle
 {
     fn send(&mut self, message: Message) -> Box<Future<Item = Message, Error = ClientError>> {
-        let query = message.get_queries().first().expect("no query!").clone();
+        let query = message.queries().first().expect("no query!").clone();
 
         if let Some(rc_future) = self.active_queries.borrow().get(&query) {
             // FIXME check TTLs?
@@ -88,7 +88,7 @@ mod test {
             let mut message = Message::new();
             let i = self.i.get();
 
-            message.id(i);
+            message.set_id(i);
             self.i.set(i + 1);
 
             Box::new(finished(message))

--- a/client/src/client/memoize_client_handle.rs
+++ b/client/src/client/memoize_client_handle.rs
@@ -106,17 +106,17 @@ mod test {
         test2.add_query(Query::new().set_query_type(RecordType::AAAA).clone());
 
         let result = client.send(test1.clone()).wait().ok().unwrap();
-        assert_eq!(result.get_id(), 0);
+        assert_eq!(result.id(), 0);
 
         let result = client.send(test2.clone()).wait().ok().unwrap();
-        assert_eq!(result.get_id(), 1);
+        assert_eq!(result.id(), 1);
 
         // should get the same result for each...
         let result = client.send(test1).wait().ok().unwrap();
-        assert_eq!(result.get_id(), 0);
+        assert_eq!(result.id(), 0);
 
         let result = client.send(test2).wait().ok().unwrap();
-        assert_eq!(result.get_id(), 1);
+        assert_eq!(result.id(), 1);
     }
 
 }

--- a/client/src/client/memoize_client_handle.rs
+++ b/client/src/client/memoize_client_handle.rs
@@ -100,10 +100,10 @@ mod test {
         let mut client = MemoizeClientHandle::new(TestClient { i: Cell::new(0) });
 
         let mut test1 = Message::new();
-        test1.add_query(Query::new().query_type(RecordType::A).clone());
+        test1.add_query(Query::new().set_query_type(RecordType::A).clone());
 
         let mut test2 = Message::new();
-        test2.add_query(Query::new().query_type(RecordType::AAAA).clone());
+        test2.add_query(Query::new().set_query_type(RecordType::AAAA).clone());
 
         let result = client.send(test1.clone()).wait().ok().unwrap();
         assert_eq!(result.get_id(), 0);

--- a/client/src/client/retry_client_handle.rs
+++ b/client/src/client/retry_client_handle.rs
@@ -126,7 +126,7 @@ mod test {
                                                 2);
         let test1 = Message::new();
         let result = client.send(test1).wait().ok().expect("should have succeeded");
-        assert_eq!(result.get_id(), 1); // this is checking the number of iterations the TestCient ran
+        assert_eq!(result.id(), 1); // this is checking the number of iterations the TestCient ran
     }
 
     #[test]

--- a/client/src/client/retry_client_handle.rs
+++ b/client/src/client/retry_client_handle.rs
@@ -106,7 +106,7 @@ mod test {
             if i > self.retries || self.retries - i == 0 {
                 if self.last_succeed {
                     let mut message = Message::new();
-                    message.id(i);
+                    message.set_id(i);
                     return Box::new(finished(message));
                 }
             }

--- a/client/src/client/secure_client_handle.rs
+++ b/client/src/client/secure_client_handle.rs
@@ -133,7 +133,7 @@ impl<H> ClientHandle for SecureClientHandle<H>
             message.set_authentic_data(true);
             message.set_checking_disabled(false);
             let dns_class =
-                message.queries().first().map_or(DNSClass::IN, |q| q.get_query_class());
+                message.queries().first().map_or(DNSClass::IN, |q| q.query_class());
 
             return Box::new(self.client
                 .send(message)
@@ -769,9 +769,9 @@ fn verify_nsec(query: &Query, nsecs: Vec<&Record>) -> bool {
     //  if they are, then the query_type should not exist in the NSEC record.
     //  if we got an NSEC record of the same name, but it is listed in the NSEC types,
     //    WTF? is that bad server, bad record
-    if nsecs.iter().any(|r| query.get_name() == r.get_name() && {
+    if nsecs.iter().any(|r| query.name() == r.get_name() && {
     if let &RData::NSEC(ref rdata) = r.get_rdata() {
-      !rdata.get_type_bit_maps().contains(&query.get_query_type())
+      !rdata.get_type_bit_maps().contains(&query.query_type())
     } else {
       panic!("expected NSEC was {:?}", r.get_rr_type()) // valid panic, never should happen
     }
@@ -779,10 +779,10 @@ fn verify_nsec(query: &Query, nsecs: Vec<&Record>) -> bool {
 
     // based on the WTF? above, we will ignore any NSEC records of the same name
     if nsecs.iter()
-          .filter(|r| query.get_name() != r.get_name())
-          .any(|r| query.get_name() > r.get_name() && {
+          .filter(|r| query.name() != r.get_name())
+          .any(|r| query.name() > r.get_name() && {
     if let &RData::NSEC(ref rdata) = r.get_rdata() {
-      query.get_name() < rdata.get_next_domain_name()
+      query.name() < rdata.get_next_domain_name()
     } else {
       panic!("expected NSEC was {:?}", r.get_rr_type()) // valid panic, never should happen
     }

--- a/client/src/client/secure_client_handle.rs
+++ b/client/src/client/secure_client_handle.rs
@@ -771,7 +771,7 @@ fn verify_nsec(query: &Query, nsecs: Vec<&Record>) -> bool {
     //    WTF? is that bad server, bad record
     if nsecs.iter().any(|r| query.name() == r.get_name() && {
     if let &RData::NSEC(ref rdata) = r.get_rdata() {
-      !rdata.get_type_bit_maps().contains(&query.query_type())
+      !rdata.type_bit_maps().contains(&query.query_type())
     } else {
       panic!("expected NSEC was {:?}", r.get_rr_type()) // valid panic, never should happen
     }
@@ -782,7 +782,7 @@ fn verify_nsec(query: &Query, nsecs: Vec<&Record>) -> bool {
           .filter(|r| query.name() != r.get_name())
           .any(|r| query.name() > r.get_name() && {
     if let &RData::NSEC(ref rdata) = r.get_rdata() {
-      query.name() < rdata.get_next_domain_name()
+      query.name() < rdata.next_domain_name()
     } else {
       panic!("expected NSEC was {:?}", r.get_rr_type()) // valid panic, never should happen
     }

--- a/client/src/op/edns.rs
+++ b/client/src/op/edns.rs
@@ -48,22 +48,22 @@ impl Edns {
         }
     }
 
-    pub fn get_rcode_high(&self) -> u8 {
+    pub fn rcode_high(&self) -> u8 {
         self.rcode_high
     }
-    pub fn get_version(&self) -> u8 {
+    pub fn version(&self) -> u8 {
         self.version
     }
-    pub fn is_dnssec_ok(&self) -> bool {
+    pub fn dnssec_ok(&self) -> bool {
         self.dnssec_ok
     }
-    pub fn get_max_payload(&self) -> u16 {
+    pub fn max_payload(&self) -> u16 {
         self.max_payload
     }
-    pub fn get_option(&self, code: &EdnsCode) -> Option<&EdnsOption> {
+    pub fn option(&self, code: &EdnsCode) -> Option<&EdnsOption> {
         self.options.get(code)
     }
-    pub fn get_options(&self) -> &OPT {
+    pub fn options(&self) -> &OPT {
         &self.options
     }
 
@@ -129,13 +129,13 @@ impl<'a> From<&'a Edns> for Record {
 
         record.name(Name::root());
         record.rr_type(RecordType::OPT);
-        record.dns_class(DNSClass::OPT(value.get_max_payload()));
+        record.dns_class(DNSClass::OPT(value.max_payload()));
 
         // rebuild the TTL field
-        let mut ttl: u32 = (value.get_rcode_high() as u32) << 24;
-        ttl |= (value.get_version() as u32) << 16;
+        let mut ttl: u32 = (value.rcode_high() as u32) << 24;
+        ttl |= (value.version() as u32) << 16;
 
-        if value.is_dnssec_ok() {
+        if value.dnssec_ok() {
             ttl |= 0x00008000;
         }
         record.ttl(ttl);
@@ -144,7 +144,7 @@ impl<'a> From<&'a Edns> for Record {
         //  also, since this is a hash, there is no guarantee that ordering will be preserved from
         //  the original binary format.
         // maybe switch to: https://crates.io/crates/linked-hash-map/
-        record.rdata(RData::OPT(value.get_options().clone()));
+        record.rdata(RData::OPT(value.options().clone()));
 
         record
     }
@@ -165,9 +165,9 @@ fn test_encode_decode() {
     let record: Record = (&edns).into();
     let edns_decode: Edns = (&record).into();
 
-    assert_eq!(edns.is_dnssec_ok(), edns_decode.is_dnssec_ok());
-    assert_eq!(edns.get_max_payload(), edns_decode.get_max_payload());
-    assert_eq!(edns.get_version(), edns_decode.get_version());
-    assert_eq!(edns.get_rcode_high(), edns_decode.get_rcode_high());
-    assert_eq!(edns.get_options(), edns_decode.get_options());
+    assert_eq!(edns.dnssec_ok(), edns_decode.dnssec_ok());
+    assert_eq!(edns.max_payload(), edns_decode.max_payload());
+    assert_eq!(edns.version(), edns_decode.version());
+    assert_eq!(edns.rcode_high(), edns_decode.rcode_high());
+    assert_eq!(edns.options(), edns_decode.options());
 }

--- a/client/src/op/edns.rs
+++ b/client/src/op/edns.rs
@@ -86,18 +86,18 @@ impl Edns {
 
 impl<'a> From<&'a Record> for Edns {
     fn from(value: &'a Record) -> Self {
-        assert!(value.get_rr_type() == RecordType::OPT);
+        assert!(value.rr_type() == RecordType::OPT);
 
-        let rcode_high: u8 = ((value.get_ttl() & 0xFF000000u32) >> 24) as u8;
-        let version: u8 = ((value.get_ttl() & 0x00FF0000u32) >> 16) as u8;
-        let dnssec_ok: bool = value.get_ttl() & 0x00008000 == 0x00008000;
-        let max_payload: u16 = if u16::from(value.get_dns_class()) < 512 {
+        let rcode_high: u8 = ((value.ttl() & 0xFF000000u32) >> 24) as u8;
+        let version: u8 = ((value.ttl() & 0x00FF0000u32) >> 16) as u8;
+        let dnssec_ok: bool = value.ttl() & 0x00008000 == 0x00008000;
+        let max_payload: u16 = if u16::from(value.dns_class()) < 512 {
             512
         } else {
-            value.get_dns_class().into()
+            value.dns_class().into()
         };
 
-        let options: OPT = match value.get_rdata() {
+        let options: OPT = match value.rdata() {
             &RData::NULL(..) => {
                 // NULL, there was no data in the OPT
                 OPT::default()
@@ -107,7 +107,7 @@ impl<'a> From<&'a Record> for Edns {
             }
             _ => {
                 // this should be a coding error, as opposed to a parsing error.
-                panic!("rr_type doesn't match the RData: {:?}", value.get_rdata()); // valid panic, never should happen
+                panic!("rr_type doesn't match the RData: {:?}", value.rdata()); // valid panic, never should happen
             }
         };
 
@@ -127,9 +127,9 @@ impl<'a> From<&'a Edns> for Record {
     fn from(value: &'a Edns) -> Record {
         let mut record: Record = Record::new();
 
-        record.name(Name::root());
-        record.rr_type(RecordType::OPT);
-        record.dns_class(DNSClass::OPT(value.max_payload()));
+        record.set_name(Name::root());
+        record.set_rr_type(RecordType::OPT);
+        record.set_dns_class(DNSClass::OPT(value.max_payload()));
 
         // rebuild the TTL field
         let mut ttl: u32 = (value.rcode_high() as u32) << 24;
@@ -138,13 +138,13 @@ impl<'a> From<&'a Edns> for Record {
         if value.dnssec_ok() {
             ttl |= 0x00008000;
         }
-        record.ttl(ttl);
+        record.set_ttl(ttl);
 
         // now for each option, write out the option array
         //  also, since this is a hash, there is no guarantee that ordering will be preserved from
         //  the original binary format.
         // maybe switch to: https://crates.io/crates/linked-hash-map/
-        record.rdata(RData::OPT(value.options().clone()));
+        record.set_rdata(RData::OPT(value.options().clone()));
 
         record
     }

--- a/client/src/op/header.rs
+++ b/client/src/op/header.rs
@@ -106,59 +106,59 @@ impl Header {
         12 /* this is always 12 bytes */
     }
 
-    pub fn id(&mut self, id: u16) -> &mut Self {
+    pub fn set_id(&mut self, id: u16) -> &mut Self {
         self.id = id;
         self
     }
-    pub fn message_type(&mut self, message_type: MessageType) -> &mut Self {
+    pub fn set_message_type(&mut self, message_type: MessageType) -> &mut Self {
         self.message_type = message_type;
         self
     }
-    pub fn op_code(&mut self, op_code: OpCode) -> &mut Self {
+    pub fn set_op_code(&mut self, op_code: OpCode) -> &mut Self {
         self.op_code = op_code;
         self
     }
-    pub fn authoritative(&mut self, authoritative: bool) -> &mut Self {
+    pub fn set_authoritative(&mut self, authoritative: bool) -> &mut Self {
         self.authoritative = authoritative;
         self
     }
-    pub fn truncated(&mut self, truncated: bool) -> &mut Self {
+    pub fn set_truncated(&mut self, truncated: bool) -> &mut Self {
         self.truncation = truncated;
         self
     }
-    pub fn recursion_desired(&mut self, recursion_desired: bool) -> &mut Self {
+    pub fn set_recursion_desired(&mut self, recursion_desired: bool) -> &mut Self {
         self.recursion_desired = recursion_desired;
         self
     }
-    pub fn recursion_available(&mut self, recursion_available: bool) -> &mut Self {
+    pub fn set_recursion_available(&mut self, recursion_available: bool) -> &mut Self {
         self.recursion_available = recursion_available;
         self
     }
-    pub fn authentic_data(&mut self, authentic_data: bool) -> &mut Self {
+    pub fn set_authentic_data(&mut self, authentic_data: bool) -> &mut Self {
         self.authentic_data = authentic_data;
         self
     }
-    pub fn checking_disabled(&mut self, checking_disabled: bool) -> &mut Self {
+    pub fn set_checking_disabled(&mut self, checking_disabled: bool) -> &mut Self {
         self.checking_disabled = checking_disabled;
         self
     }
-    pub fn response_code(&mut self, response_code: ResponseCode) -> &mut Self {
+    pub fn set_response_code(&mut self, response_code: ResponseCode) -> &mut Self {
         self.response_code = response_code.low();
         self
     }
-    pub fn query_count(&mut self, query_count: u16) -> &mut Self {
+    pub fn set_query_count(&mut self, query_count: u16) -> &mut Self {
         self.query_count = query_count;
         self
     }
-    pub fn answer_count(&mut self, answer_count: u16) -> &mut Self {
+    pub fn set_answer_count(&mut self, answer_count: u16) -> &mut Self {
         self.answer_count = answer_count;
         self
     }
-    pub fn name_server_count(&mut self, name_server_count: u16) -> &mut Self {
+    pub fn set_name_server_count(&mut self, name_server_count: u16) -> &mut Self {
         self.name_server_count = name_server_count;
         self
     }
-    pub fn additional_count(&mut self, additional_count: u16) -> &mut Self {
+    pub fn set_additional_count(&mut self, additional_count: u16) -> &mut Self {
         self.additional_count = additional_count;
         self
     }
@@ -169,7 +169,7 @@ impl Header {
     ///                 the corresponding reply and can be used by the requester
     ///                 to match up replies to outstanding queries.
     /// ```
-    pub fn get_id(&self) -> u16 {
+    pub fn id(&self) -> u16 {
         self.id
     }
 
@@ -177,7 +177,7 @@ impl Header {
     /// QR              A one bit field that specifies whether this message is a
     ///                 query (0), or a response (1).
     /// ```
-    pub fn get_message_type(&self) -> MessageType {
+    pub fn message_type(&self) -> MessageType {
         self.message_type
     }
 
@@ -186,7 +186,7 @@ impl Header {
     ///                 message.  This value is set by the originator of a query
     ///                 and copied into the response.  The values are: <see super::op_code>
     /// ```
-    pub fn get_op_code(&self) -> OpCode {
+    pub fn op_code(&self) -> OpCode {
         self.op_code
     }
 
@@ -200,7 +200,7 @@ impl Header {
     ///                 corresponds to the name which matches the query name, or
     ///                 the first owner name in the answer section.
     /// ```
-    pub fn is_authoritative(&self) -> bool {
+    pub fn authoritative(&self) -> bool {
         self.authoritative
     }
 
@@ -209,7 +209,7 @@ impl Header {
     ///                 due to length greater than that permitted on the
     ///                 transmission channel.
     /// ```
-    pub fn is_truncated(&self) -> bool {
+    pub fn truncated(&self) -> bool {
         self.truncation
     }
 
@@ -219,7 +219,7 @@ impl Header {
     ///                 the name server to pursue the query recursively.
     ///                 Recursive query support is optional.
     /// ```
-    pub fn is_recursion_desired(&self) -> bool {
+    pub fn recursion_desired(&self) -> bool {
         self.recursion_desired
     }
 
@@ -228,7 +228,7 @@ impl Header {
     ///                 response, and denotes whether recursive query support is
     ///                 available in the name server.
     /// ```
-    pub fn is_recursion_available(&self) -> bool {
+    pub fn recursion_available(&self) -> bool {
         self.recursion_available
     }
 
@@ -262,12 +262,12 @@ impl Header {
     ///   rules for the CD and AD bits given in Section 3.2 when generating a
     ///   response that involves data obtained via recursion.
     /// ```
-    pub fn is_authentic_data(&self) -> bool {
+    pub fn authentic_data(&self) -> bool {
         self.authentic_data
     }
 
     /// see `is_authentic_data()`
-    pub fn is_checking_disabled(&self) -> bool {
+    pub fn checking_disabled(&self) -> bool {
         self.checking_disabled
     }
 
@@ -276,7 +276,7 @@ impl Header {
     ///                 responses.  The values have the following
     ///                 interpretation: <see super::response_code>
     /// ```
-    pub fn get_response_code(&self) -> u8 {
+    pub fn response_code(&self) -> u8 {
         self.response_code
     }
 
@@ -289,7 +289,7 @@ impl Header {
     ///
     /// If this is a query, this will return the number of queries in the query section of the
     //   message, fo updates this represents the zone count (must be no more than 1).
-    pub fn get_query_count(&self) -> u16 {
+    pub fn query_count(&self) -> u16 {
         self.query_count
     }
 
@@ -302,7 +302,7 @@ impl Header {
     ///
     /// For query responses this is the number of records in the answer section, should be 0 for
     ///  requests, for updates this is the count of prerequisite records.
-    pub fn get_answer_count(&self) -> u16 {
+    pub fn answer_count(&self) -> u16 {
         self.answer_count
     }
 
@@ -318,7 +318,7 @@ impl Header {
     ///
     /// For query responses this is the number of authorities, or nameservers, in the name server
     ///  section, for updates this is the number of update records being sent.
-    pub fn get_name_server_count(&self) -> u16 {
+    pub fn name_server_count(&self) -> u16 {
         self.name_server_count
     }
 
@@ -330,7 +330,7 @@ impl Header {
     /// # Return value
     ///
     /// This is the additional record section count, this section may include EDNS options.
-    pub fn get_additional_count(&self) -> u16 {
+    pub fn additional_count(&self) -> u16 {
         self.additional_count
     }
 

--- a/client/src/op/message.rs
+++ b/client/src/op/message.rs
@@ -124,43 +124,43 @@ impl Message {
     }
 
     pub fn set_id(&mut self, id: u16) -> &mut Self {
-        self.header.id(id);
+        self.header.set_id(id);
         self
     }
     pub fn set_message_type(&mut self, message_type: MessageType) -> &mut Self {
-        self.header.message_type(message_type);
+        self.header.set_message_type(message_type);
         self
     }
     pub fn set_op_code(&mut self, op_code: OpCode) -> &mut Self {
-        self.header.op_code(op_code);
+        self.header.set_op_code(op_code);
         self
     }
     pub fn set_authoritative(&mut self, authoritative: bool) -> &mut Self {
-        self.header.authoritative(authoritative);
+        self.header.set_authoritative(authoritative);
         self
     }
     pub fn set_truncated(&mut self, truncated: bool) -> &mut Self {
-        self.header.truncated(truncated);
+        self.header.set_truncated(truncated);
         self
     }
     pub fn set_recursion_desired(&mut self, recursion_desired: bool) -> &mut Self {
-        self.header.recursion_desired(recursion_desired);
+        self.header.set_recursion_desired(recursion_desired);
         self
     }
     pub fn set_recursion_available(&mut self, recursion_available: bool) -> &mut Self {
-        self.header.recursion_available(recursion_available);
+        self.header.set_recursion_available(recursion_available);
         self
     }
     pub fn set_authentic_data(&mut self, authentic_data: bool) -> &mut Self {
-        self.header.authentic_data(authentic_data);
+        self.header.set_authentic_data(authentic_data);
         self
     }
     pub fn set_checking_disabled(&mut self, checking_disabled: bool) -> &mut Self {
-        self.header.checking_disabled(checking_disabled);
+        self.header.set_checking_disabled(checking_disabled);
         self
     }
     pub fn set_response_code(&mut self, response_code: ResponseCode) -> &mut Self {
-        self.header.response_code(response_code);
+        self.header.set_response_code(response_code);
         self
     }
 
@@ -284,49 +284,49 @@ impl Message {
         self
     }
 
-    /// see `Header::get_id()`
+    /// see `Header::id()`
     pub fn id(&self) -> u16 {
-        self.header.get_id()
+        self.header.id()
     }
 
-    /// see `Header::get_message_type()`
+    /// see `Header::message_type()`
     pub fn message_type(&self) -> MessageType {
-        self.header.get_message_type()
+        self.header.message_type()
     }
 
-    /// see `Header::get_op_code()`
+    /// see `Header::op_code()`
     pub fn op_code(&self) -> OpCode {
-        self.header.get_op_code()
+        self.header.op_code()
     }
 
-    /// see `Header::is_authoritative()`
+    /// see `Header::authoritative()`
     pub fn authoritative(&self) -> bool {
-        self.header.is_authoritative()
+        self.header.authoritative()
     }
 
-    /// see `Header::is_truncated()`
+    /// see `Header::truncated()`
     pub fn truncated(&self) -> bool {
-        self.header.is_truncated()
+        self.header.truncated()
     }
 
-    /// see `Header::is_recursion_desired()`
+    /// see `Header::recursion_desired()`
     pub fn recursion_desired(&self) -> bool {
-        self.header.is_recursion_desired()
+        self.header.recursion_desired()
     }
 
-    /// see `Header::is_recursion_available()`
+    /// see `Header::recursion_available()`
     pub fn recursion_available(&self) -> bool {
-        self.header.is_recursion_available()
+        self.header.recursion_available()
     }
 
-    /// see `Header::is_authentic_data()`
+    /// see `Header::authentic_data()`
     pub fn authentic_data(&self) -> bool {
-        self.header.is_authentic_data()
+        self.header.authentic_data()
     }
 
-    /// see `Header::is_checking_disabled()`
+    /// see `Header::checking_disabled()`
     pub fn checking_disabled(&self) -> bool {
-        self.header.is_checking_disabled()
+        self.header.checking_disabled()
     }
 
     /// # Return value
@@ -335,7 +335,7 @@ impl Message {
     ///  record to create the EDNS `ResponseCode`
     pub fn response_code(&self) -> ResponseCode {
         ResponseCode::from(self.edns.as_ref().map_or(0, |e| e.get_rcode_high()),
-                           self.header.get_response_code())
+                           self.header.response_code())
     }
 
     /// ```text
@@ -720,16 +720,16 @@ impl BinSerializable<Message> for Message {
         //  this could improve error detection while decoding.
 
         // get the questions
-        let count = header.get_query_count() as usize;
+        let count = header.query_count() as usize;
         let mut queries = Vec::with_capacity(count);
         for _ in 0..count {
             queries.push(try!(Query::read(decoder)));
         }
 
         // get all counts before header moves
-        let answer_count = header.get_answer_count() as usize;
-        let name_server_count = header.get_name_server_count() as usize;
-        let additional_count = header.get_additional_count() as usize;
+        let answer_count = header.answer_count() as usize;
+        let name_server_count = header.name_server_count() as usize;
+        let additional_count = header.additional_count() as usize;
 
         let (answers, _, _) = try!(Self::read_records(decoder, answer_count, false));
         let (name_servers, _, _) = try!(Self::read_records(decoder, name_server_count, false));

--- a/client/src/op/message.rs
+++ b/client/src/op/message.rs
@@ -589,21 +589,21 @@ impl Message {
         sig0.rr_type(RecordType::SIG);
         sig0.rdata(
       RData::SIG(SIG::new(
-        // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
+          // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
         RecordType::NULL,
-        signer.get_algorithm(),
-        num_labels,
-        // see above, original_ttl is meaningless, The TTL fields SHOULD be zero
+          signer.algorithm(),
+          num_labels,
+          // see above, original_ttl is meaningless, The TTL fields SHOULD be zero
         0,
-        // recommended time is +5 minutes from now, to prevent timing attacks, 2 is probably good
+          // recommended time is +5 minutes from now, to prevent timing attacks, 2 is probably good
         expiration_time,
-        // current time, this should be UTC
+          // current time, this should be UTC
         // unsigned numbers of seconds since the start of 1 January 1970, GMT
         inception_time,
-        key_tag,
-        // can probably get rid of this clone if the owndership is correct
-        signer.get_signer_name().clone(),
-        signature,
+          key_tag,
+          // can probably get rid of this clone if the owndership is correct
+        signer.signer_name().clone(),
+          signature,
       )
     ));
 

--- a/client/src/op/message.rs
+++ b/client/src/op/message.rs
@@ -97,69 +97,69 @@ impl Message {
 
     pub fn error_msg(id: u16, op_code: OpCode, response_code: ResponseCode) -> Message {
         let mut message: Message = Message::new();
-        message.message_type(MessageType::Response);
-        message.id(id);
-        message.response_code(response_code);
-        message.op_code(op_code);
+        message.set_message_type(MessageType::Response);
+        message.set_id(id);
+        message.set_response_code(response_code);
+        message.set_op_code(op_code);
 
         message
     }
 
     pub fn truncate(&self) -> Self {
         let mut truncated: Message = Message::new();
-        truncated.id(self.get_id());
-        truncated.message_type(self.get_message_type());
-        truncated.op_code(self.get_op_code());
-        truncated.authoritative(self.is_authoritative());
-        truncated.truncated(true);
-        truncated.recursion_desired(self.is_recursion_desired());
-        truncated.recursion_available(self.is_recursion_available());
-        truncated.response_code(self.get_response_code());
-        if self.get_edns().is_some() {
-            truncated.set_edns(self.get_edns().unwrap().clone());
+        truncated.set_id(self.id());
+        truncated.set_message_type(self.message_type());
+        truncated.set_op_code(self.op_code());
+        truncated.set_authoritative(self.authoritative());
+        truncated.set_truncated(true);
+        truncated.set_recursion_desired(self.recursion_desired());
+        truncated.set_recursion_available(self.recursion_available());
+        truncated.set_response_code(self.response_code());
+        if self.edns().is_some() {
+            truncated.set_edns(self.edns().unwrap().clone());
         }
 
         // TODO, perhaps just quickly add a few response records here? that we know would fit?
         truncated
     }
 
-    pub fn id(&mut self, id: u16) -> &mut Self {
+    pub fn set_id(&mut self, id: u16) -> &mut Self {
         self.header.id(id);
         self
     }
-    pub fn message_type(&mut self, message_type: MessageType) -> &mut Self {
+    pub fn set_message_type(&mut self, message_type: MessageType) -> &mut Self {
         self.header.message_type(message_type);
         self
     }
-    pub fn op_code(&mut self, op_code: OpCode) -> &mut Self {
+    pub fn set_op_code(&mut self, op_code: OpCode) -> &mut Self {
         self.header.op_code(op_code);
         self
     }
-    pub fn authoritative(&mut self, authoritative: bool) -> &mut Self {
+    pub fn set_authoritative(&mut self, authoritative: bool) -> &mut Self {
         self.header.authoritative(authoritative);
         self
     }
-    pub fn truncated(&mut self, truncated: bool) -> &mut Self {
+    pub fn set_truncated(&mut self, truncated: bool) -> &mut Self {
         self.header.truncated(truncated);
         self
     }
-    pub fn recursion_desired(&mut self, recursion_desired: bool) -> &mut Self {
+    pub fn set_recursion_desired(&mut self, recursion_desired: bool) -> &mut Self {
         self.header.recursion_desired(recursion_desired);
         self
     }
-    pub fn recursion_available(&mut self, recursion_available: bool) -> &mut Self {
+    pub fn set_recursion_available(&mut self, recursion_available: bool) -> &mut Self {
         self.header.recursion_available(recursion_available);
         self
     }
-    pub fn authentic_data(&mut self, authentic_data: bool) -> &mut Self {
+    pub fn set_authentic_data(&mut self, authentic_data: bool) -> &mut Self {
         self.header.authentic_data(authentic_data);
         self
     }
-    pub fn checking_disabled(&mut self, checking_disabled: bool) -> &mut Self {
+    pub fn set_checking_disabled(&mut self, checking_disabled: bool) -> &mut Self {
         self.header.checking_disabled(checking_disabled);
         self
     }
-    pub fn response_code(&mut self, response_code: ResponseCode) -> &mut Self {
+    pub fn set_response_code(&mut self, response_code: ResponseCode) -> &mut Self {
         self.header.response_code(response_code);
         self
     }
@@ -285,47 +285,47 @@ impl Message {
     }
 
     /// see `Header::get_id()`
-    pub fn get_id(&self) -> u16 {
+    pub fn id(&self) -> u16 {
         self.header.get_id()
     }
 
     /// see `Header::get_message_type()`
-    pub fn get_message_type(&self) -> MessageType {
+    pub fn message_type(&self) -> MessageType {
         self.header.get_message_type()
     }
 
     /// see `Header::get_op_code()`
-    pub fn get_op_code(&self) -> OpCode {
+    pub fn op_code(&self) -> OpCode {
         self.header.get_op_code()
     }
 
     /// see `Header::is_authoritative()`
-    pub fn is_authoritative(&self) -> bool {
+    pub fn authoritative(&self) -> bool {
         self.header.is_authoritative()
     }
 
     /// see `Header::is_truncated()`
-    pub fn is_truncated(&self) -> bool {
+    pub fn truncated(&self) -> bool {
         self.header.is_truncated()
     }
 
     /// see `Header::is_recursion_desired()`
-    pub fn is_recursion_desired(&self) -> bool {
+    pub fn recursion_desired(&self) -> bool {
         self.header.is_recursion_desired()
     }
 
     /// see `Header::is_recursion_available()`
-    pub fn is_recursion_available(&self) -> bool {
+    pub fn recursion_available(&self) -> bool {
         self.header.is_recursion_available()
     }
 
     /// see `Header::is_authentic_data()`
-    pub fn is_authentic_data(&self) -> bool {
+    pub fn authentic_data(&self) -> bool {
         self.header.is_authentic_data()
     }
 
     /// see `Header::is_checking_disabled()`
-    pub fn is_checking_disabled(&self) -> bool {
+    pub fn checking_disabled(&self) -> bool {
         self.header.is_checking_disabled()
     }
 
@@ -333,7 +333,7 @@ impl Message {
     ///
     /// The `ResponseCode`, if this is an EDNS message then this will join the section from the OPT
     ///  record to create the EDNS `ResponseCode`
-    pub fn get_response_code(&self) -> ResponseCode {
+    pub fn response_code(&self) -> ResponseCode {
         ResponseCode::from(self.edns.as_ref().map_or(0, |e| e.get_rcode_high()),
                            self.header.get_response_code())
     }
@@ -341,14 +341,14 @@ impl Message {
     /// ```text
     /// Question        Carries the query name and other query parameters.
     /// ```
-    pub fn get_queries(&self) -> &[Query] {
+    pub fn queries(&self) -> &[Query] {
         &self.queries
     }
 
     /// ```text
     /// Answer          Carries RRs which directly answer the query.
     /// ```
-    pub fn get_answers(&self) -> &[Record] {
+    pub fn answers(&self) -> &[Record] {
         &self.answers
     }
 
@@ -361,7 +361,7 @@ impl Message {
     ///                 May optionally carry the SOA RR for the authoritative
     ///                 data in the answer section.
     /// ```
-    pub fn get_name_servers(&self) -> &[Record] {
+    pub fn name_servers(&self) -> &[Record] {
         &self.name_servers
     }
 
@@ -373,7 +373,7 @@ impl Message {
     /// Additional      Carries RRs which may be helpful in using the RRs in the
     ///                 other sections.
     /// ```
-    pub fn get_additionals(&self) -> &[Record] {
+    pub fn additionals(&self) -> &[Record] {
         &self.additionals
     }
 
@@ -410,12 +410,12 @@ impl Message {
     /// # Return value
     ///
     /// Returns the EDNS record if it was found in the additional section.
-    pub fn get_edns(&self) -> Option<&Edns> {
+    pub fn edns(&self) -> Option<&Edns> {
         self.edns.as_ref()
     }
 
     /// If edns is_none, this will create a new default Edns.
-    pub fn get_edns_mut(&mut self) -> &mut Edns {
+    pub fn edns_mut(&mut self) -> &mut Edns {
         if self.edns.is_none() {
             self.edns = Some(Edns::new());
         }
@@ -426,7 +426,7 @@ impl Message {
     /// # Return value
     ///
     /// the max payload value as it's defined in the EDNS section.
-    pub fn get_max_payload(&self) -> u16 {
+    pub fn max_payload(&self) -> u16 {
         let max_size = self.edns.as_ref().map_or(512, |e| e.get_max_payload());
         if max_size < 512 { 512 } else { max_size }
     }
@@ -434,7 +434,7 @@ impl Message {
     /// # Return value
     ///
     /// the version as defined in the EDNS record
-    pub fn get_version(&self) -> u8 {
+    pub fn version(&self) -> u8 {
         self.edns.as_ref().map_or(0, |e| e.get_version())
     }
 
@@ -452,7 +452,7 @@ impl Message {
     /// # Return value
     ///
     /// The sig0, i.e. signed record, for verifying the sending and package integrity
-    fn get_sig0(&self) -> &[Record] {
+    fn sig0(&self) -> &[Record] {
         &self.sig0
     }
 
@@ -622,7 +622,7 @@ impl Message {
 /// to reduce errors in using the Message struct as an Update, this will do the call throughs
 ///   to properly do that.
 pub trait UpdateMessage: Debug {
-    fn get_id(&self) -> u16;
+    fn id(&self) -> u16;
     fn add_zone(&mut self, query: Query);
     fn add_pre_requisite(&mut self, record: Record);
     #[deprecated = "will be removed post 0.9.x"]
@@ -638,15 +638,15 @@ pub trait UpdateMessage: Debug {
               I: Iterator<Item = Record>;
     fn add_additional(&mut self, record: Record);
 
-    fn get_zones(&self) -> &[Query];
-    fn get_pre_requisites(&self) -> &[Record];
-    fn get_updates(&self) -> &[Record];
-    fn get_additionals(&self) -> &[Record];
+    fn zones(&self) -> &[Query];
+    fn prerequisites(&self) -> &[Record];
+    fn updates(&self) -> &[Record];
+    fn additionals(&self) -> &[Record];
 
     /// This is used to authenticate update messages.
     ///
-    /// see `Message::get_sig0()` for more information.
-    fn get_sig0(&self) -> &[Record];
+    /// see `Message::sig0()` for more information.
+    fn sig0(&self) -> &[Record];
 
     fn sign(&mut self, signer: &Signer, inception_time: u32) -> DnsSecResult<()>;
 }
@@ -654,8 +654,8 @@ pub trait UpdateMessage: Debug {
 /// to reduce errors in using the Message struct as an Update, this will do the call throughs
 ///   to properly do that.
 impl UpdateMessage for Message {
-    fn get_id(&self) -> u16 {
-        self.get_id()
+    fn id(&self) -> u16 {
+        self.id()
     }
     fn add_zone(&mut self, query: Query) {
         self.add_query(query);
@@ -688,21 +688,21 @@ impl UpdateMessage for Message {
         self.add_additional(record);
     }
 
-    fn get_zones(&self) -> &[Query] {
-        self.get_queries()
+    fn zones(&self) -> &[Query] {
+        self.queries()
     }
-    fn get_pre_requisites(&self) -> &[Record] {
-        self.get_answers()
+    fn prerequisites(&self) -> &[Record] {
+        self.answers()
     }
-    fn get_updates(&self) -> &[Record] {
-        self.get_name_servers()
+    fn updates(&self) -> &[Record] {
+        self.name_servers()
     }
-    fn get_additionals(&self) -> &[Record] {
-        self.get_additionals()
+    fn additionals(&self) -> &[Record] {
+        self.additionals()
     }
 
-    fn get_sig0(&self) -> &[Record] {
-        self.get_sig0()
+    fn sig0(&self) -> &[Record] {
+        self.sig0()
     }
 
     // TODO: where's the 'right' spot for this function
@@ -762,7 +762,7 @@ impl BinSerializable<Message> for Message {
         try!(Self::emit_records(encoder, &self.name_servers));
         try!(Self::emit_records(encoder, &self.additionals));
 
-        if let Some(edns) = self.get_edns() {
+        if let Some(edns) = self.edns() {
             // need to commit the error code
             try!(Record::from(edns).emit(encoder));
         }
@@ -780,14 +780,14 @@ impl BinSerializable<Message> for Message {
 #[test]
 fn test_emit_and_read_header() {
     let mut message = Message::new();
-    message.id(10)
-        .message_type(MessageType::Response)
-        .op_code(OpCode::Update)
-        .authoritative(true)
-        .truncated(true)
-        .recursion_desired(true)
-        .recursion_available(true)
-        .response_code(ResponseCode::ServFail);
+    message.set_id(10)
+        .set_message_type(MessageType::Response)
+        .set_op_code(OpCode::Update)
+        .set_authoritative(true)
+        .set_truncated(true)
+        .set_recursion_desired(true)
+        .set_recursion_available(true)
+        .set_response_code(ResponseCode::ServFail);
 
     test_emit_and_read(message);
 }
@@ -795,14 +795,14 @@ fn test_emit_and_read_header() {
 #[test]
 fn test_emit_and_read_query() {
     let mut message = Message::new();
-    message.id(10)
-        .message_type(MessageType::Response)
-        .op_code(OpCode::Update)
-        .authoritative(true)
-        .truncated(true)
-        .recursion_desired(true)
-        .recursion_available(true)
-        .response_code(ResponseCode::ServFail)
+    message.set_id(10)
+        .set_message_type(MessageType::Response)
+        .set_op_code(OpCode::Update)
+        .set_authoritative(true)
+        .set_truncated(true)
+        .set_recursion_desired(true)
+        .set_recursion_available(true)
+        .set_response_code(ResponseCode::ServFail)
         .add_query(Query::new())
         .update_counts(); // we're not testing the query parsing, just message
 
@@ -812,16 +812,16 @@ fn test_emit_and_read_query() {
 #[test]
 fn test_emit_and_read_records() {
     let mut message = Message::new();
-    message.id(10)
-        .message_type(MessageType::Response)
-        .op_code(OpCode::Update)
-        .authoritative(true)
-        .truncated(true)
-        .recursion_desired(true)
-        .recursion_available(true)
-        .authentic_data(true)
-        .checking_disabled(true)
-        .response_code(ResponseCode::ServFail);
+    message.set_id(10)
+        .set_message_type(MessageType::Response)
+        .set_op_code(OpCode::Update)
+        .set_authoritative(true)
+        .set_truncated(true)
+        .set_recursion_desired(true)
+        .set_recursion_available(true)
+        .set_authentic_data(true)
+        .set_checking_disabled(true)
+        .set_response_code(ResponseCode::ServFail);
 
     message.add_answer(Record::new());
     message.add_name_server(Record::new());

--- a/client/src/op/message.rs
+++ b/client/src/op/message.rs
@@ -279,7 +279,7 @@ impl Message {
     }
 
     pub fn add_sig0(&mut self, record: Record) -> &mut Self {
-        assert_eq!(RecordType::SIG, record.get_rr_type());
+        assert_eq!(RecordType::SIG, record.rr_type());
         self.sig0.push(record);
         self
     }
@@ -506,7 +506,7 @@ impl Message {
                 } // SIG0 must be last
                 records.push(record)
             } else {
-                match record.get_rr_type() {
+                match record.rr_type() {
                     RecordType::SIG => {
                         saw_sig0 = true;
                         sig0s.push(record);
@@ -575,19 +575,19 @@ impl Message {
         let mut sig0 = Record::new();
 
         // The TTL fields SHOULD be zero
-        sig0.ttl(0);
+        sig0.set_ttl(0);
 
         // The CLASS field SHOULD be ANY
-        sig0.dns_class(DNSClass::ANY);
+        sig0.set_dns_class(DNSClass::ANY);
 
         // The owner name SHOULD be root (a single zero octet).
-        sig0.name(Name::root());
-        let num_labels = sig0.get_name().num_labels();
+        sig0.set_name(Name::root());
+        let num_labels = sig0.name().num_labels();
 
         let expiration_time: u32 = inception_time + (5 * 60); // +5 minutes in seconds
 
-        sig0.rr_type(RecordType::SIG);
-        sig0.rdata(
+        sig0.set_rr_type(RecordType::SIG);
+        sig0.set_rdata(
       RData::SIG(SIG::new(
           // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
         RecordType::NULL,

--- a/client/src/op/message.rs
+++ b/client/src/op/message.rs
@@ -869,7 +869,7 @@ fn test_legit_message() {
     let mut decoder = BinDecoder::new(&buf);
     let message = Message::read(&mut decoder).unwrap();
 
-    assert_eq!(message.get_id(), 4096);
+    assert_eq!(message.id(), 4096);
 
     let mut buf: Vec<u8> = Vec::with_capacity(512);
     {
@@ -880,5 +880,5 @@ fn test_legit_message() {
     let mut decoder = BinDecoder::new(&buf);
     let message = Message::read(&mut decoder).unwrap();
 
-    assert_eq!(message.get_id(), 4096);
+    assert_eq!(message.id(), 4096);
 }

--- a/client/src/op/message.rs
+++ b/client/src/op/message.rs
@@ -334,7 +334,7 @@ impl Message {
     /// The `ResponseCode`, if this is an EDNS message then this will join the section from the OPT
     ///  record to create the EDNS `ResponseCode`
     pub fn response_code(&self) -> ResponseCode {
-        ResponseCode::from(self.edns.as_ref().map_or(0, |e| e.get_rcode_high()),
+        ResponseCode::from(self.edns.as_ref().map_or(0, |e| e.rcode_high()),
                            self.header.response_code())
     }
 
@@ -427,7 +427,7 @@ impl Message {
     ///
     /// the max payload value as it's defined in the EDNS section.
     pub fn max_payload(&self) -> u16 {
-        let max_size = self.edns.as_ref().map_or(512, |e| e.get_max_payload());
+        let max_size = self.edns.as_ref().map_or(512, |e| e.max_payload());
         if max_size < 512 { 512 } else { max_size }
     }
 
@@ -435,7 +435,7 @@ impl Message {
     ///
     /// the version as defined in the EDNS record
     pub fn version(&self) -> u8 {
-        self.edns.as_ref().map_or(0, |e| e.get_version())
+        self.edns.as_ref().map_or(0, |e| e.version())
     }
 
     /// [RFC 2535, Domain Name System Security Extensions, March 1999](https://tools.ietf.org/html/rfc2535#section-4)

--- a/client/src/op/query.rs
+++ b/client/src/op/query.rs
@@ -64,15 +64,15 @@ impl Query {
     }
 
     /// replaces name with the new name
-    pub fn name(&mut self, name: Name) -> &mut Self {
+    pub fn set_name(&mut self, name: Name) -> &mut Self {
         self.name = name;
         self
     }
-    pub fn query_type(&mut self, query_type: RecordType) -> &mut Self {
+    pub fn set_query_type(&mut self, query_type: RecordType) -> &mut Self {
         self.query_type = query_type;
         self
     }
-    pub fn query_class(&mut self, query_class: DNSClass) -> &mut Self {
+    pub fn set_query_class(&mut self, query_class: DNSClass) -> &mut Self {
         self.query_class = query_class;
         self
     }
@@ -85,7 +85,7 @@ impl Query {
     ///                 that this field may be an odd number of octets; no
     ///                 padding is used.
     /// ```
-    pub fn get_name(&self) -> &Name {
+    pub fn name(&self) -> &Name {
         &self.name
     }
 
@@ -95,7 +95,7 @@ impl Query {
     ///                 TYPE field, together with some more general codes which
     ///                 can match more than one type of RR.
     /// ```
-    pub fn get_query_type(&self) -> RecordType {
+    pub fn query_type(&self) -> RecordType {
         self.query_type
     }
 
@@ -103,7 +103,7 @@ impl Query {
     /// QCLASS          a two octet code that specifies the class of the query.
     ///                 For example, the QCLASS field is IN for the Internet.
     /// ```
-    pub fn get_query_class(&self) -> DNSClass {
+    pub fn query_class(&self) -> DNSClass {
         self.query_class
     }
 }

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -611,14 +611,14 @@ impl Signer {
                                -> DnsSecResult<Vec<u8>> {
         self.hash_rrset(name,
                         dns_class,
-                        sig.get_num_labels(),
-                        sig.get_type_covered(),
-                        sig.get_algorithm(),
-                        sig.get_original_ttl(),
-                        sig.get_sig_expiration(),
-                        sig.get_sig_inception(),
-                        sig.get_key_tag(),
-                        sig.get_signer_name(),
+                        sig.num_labels(),
+                        sig.type_covered(),
+                        sig.algorithm(),
+                        sig.original_ttl(),
+                        sig.sig_expiration(),
+                        sig.sig_inception(),
+                        sig.key_tag(),
+                        sig.signer_name(),
                         records)
     }
 
@@ -727,7 +727,7 @@ fn test_sign_and_verify_message_sig0() {
     println!("sig after sign: {:?}", sig);
 
     if let &RData::SIG(ref sig) = question.sig0()[0].get_rdata() {
-        assert!(signer.verify_message(&question, sig.get_sig()).is_ok());
+        assert!(signer.verify_message(&question, sig.sig()).is_ok());
     }
 }
 

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -700,7 +700,7 @@ fn test_sign_and_verify_message_sig0() {
     let origin: Name = Name::parse("example.com.", None).unwrap();
     let mut question: Message = Message::new();
     let mut query: Query = Query::new();
-    query.name(origin.clone());
+    query.set_name(origin.clone());
     question.add_query(query);
 
     let rsa = Rsa::generate(512).unwrap();

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -719,14 +719,14 @@ fn test_sign_and_verify_message_sig0() {
     assert!(signer.verify_message(&question, &sig).is_ok());
 
     // now test that the sig0 record works correctly.
-    assert!(question.get_sig0().is_empty());
+    assert!(question.sig0().is_empty());
     question.sign(&signer, 0).expect("should have signed");
-    assert!(!question.get_sig0().is_empty());
+    assert!(!question.sig0().is_empty());
 
     let sig = signer.sign_message(&question);
     println!("sig after sign: {:?}", sig);
 
-    if let &RData::SIG(ref sig) = question.get_sig0()[0].get_rdata() {
+    if let &RData::SIG(ref sig) = question.sig0()[0].get_rdata() {
         assert!(signer.verify_message(&question, sig.get_sig()).is_ok());
     }
 }

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -279,16 +279,16 @@ impl Signer {
         }
     }
 
-    pub fn get_algorithm(&self) -> Algorithm {
+    pub fn algorithm(&self) -> Algorithm {
         self.algorithm
     }
-    pub fn get_key(&self) -> &KeyPair {
+    pub fn key(&self) -> &KeyPair {
         &self.key
     }
-    pub fn get_sig_duration(&self) -> Duration {
+    pub fn sig_duration(&self) -> Duration {
         self.sig_duration
     }
-    pub fn get_signer_name(&self) -> &Name {
+    pub fn signer_name(&self) -> &Name {
         &self.signer_name
     }
     pub fn is_zone_signing_key(&self) -> bool {

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -491,8 +491,8 @@ impl Signer {
 
         // collect only the records for this rrset
         for record in records {
-            if dns_class == record.get_dns_class() && type_covered == record.get_rr_type() &&
-               name == record.get_name() {
+            if dns_class == record.dns_class() && type_covered == record.rr_type() &&
+               name == record.name() {
                 rrset.push(record);
             }
         }
@@ -554,7 +554,7 @@ impl Signer {
                 {
                     let mut rdata_encoder = BinEncoder::new(&mut rdata_buf);
                     rdata_encoder.set_canonical_names(true);
-                    assert!(record.get_rdata().emit(&mut rdata_encoder).is_ok());
+                    assert!(record.rdata().emit(&mut rdata_encoder).is_ok());
                 }
                 assert!(encoder.emit_u16(rdata_buf.len() as u16).is_ok());
                 //
@@ -582,11 +582,11 @@ impl Signer {
                                  rrsig: &Record,
                                  records: &[Record])
                                  -> DnsSecResult<Vec<u8>> {
-        if let &RData::SIG(ref sig) = rrsig.get_rdata() {
-            self.hash_rrset_with_sig(rrsig.get_name(), rrsig.get_dns_class(), sig, records)
+        if let &RData::SIG(ref sig) = rrsig.rdata() {
+            self.hash_rrset_with_sig(rrsig.name(), rrsig.dns_class(), sig, records)
         } else {
             return Err(DnsSecErrorKind::Msg(format!("could not determine name from {}",
-                                                    rrsig.get_name()))
+                                                    rrsig.name()))
                 .into());
         }
     }
@@ -726,7 +726,7 @@ fn test_sign_and_verify_message_sig0() {
     let sig = signer.sign_message(&question);
     println!("sig after sign: {:?}", sig);
 
-    if let &RData::SIG(ref sig) = question.sig0()[0].get_rdata() {
+    if let &RData::SIG(ref sig) = question.sig0()[0].rdata() {
         assert!(signer.verify_message(&question, sig.sig()).is_ok());
     }
 }
@@ -749,72 +749,72 @@ fn test_hash_rrset() {
 
     let origin: Name = Name::parse("example.com.", None).unwrap();
     let rrsig = Record::new()
-        .name(origin.clone())
-        .ttl(86400)
-        .rr_type(RecordType::NS)
-        .dns_class(DNSClass::IN)
-        .rdata(RData::SIG(SIG::new(RecordType::NS,
-                                   Algorithm::RSASHA256,
-                                   origin.num_labels(),
-                                   86400,
-                                   5,
-                                   0,
-                                   signer.calculate_key_tag().unwrap(),
-                                   origin.clone(),
-                                   vec![])))
+        .set_name(origin.clone())
+        .set_ttl(86400)
+        .set_rr_type(RecordType::NS)
+        .set_dns_class(DNSClass::IN)
+        .set_rdata(RData::SIG(SIG::new(RecordType::NS,
+                                       Algorithm::RSASHA256,
+                                       origin.num_labels(),
+                                       86400,
+                                       5,
+                                       0,
+                                       signer.calculate_key_tag().unwrap(),
+                                       origin.clone(),
+                                       vec![])))
         .clone();
     let rrset = vec![Record::new()
-                         .name(origin.clone())
-                         .ttl(86400)
-                         .rr_type(RecordType::NS)
-                         .dns_class(DNSClass::IN)
-                         .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                         .set_name(origin.clone())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::NS)
+                         .set_dns_class(DNSClass::IN)
+                         .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                          .clone(),
                      Record::new()
-                         .name(origin.clone())
-                         .ttl(86400)
-                         .rr_type(RecordType::NS)
-                         .dns_class(DNSClass::IN)
-                         .rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                         .set_name(origin.clone())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::NS)
+                         .set_dns_class(DNSClass::IN)
+                         .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
                          .clone()];
 
     let hash = signer.hash_rrset_with_rrsig(&rrsig, &rrset).unwrap();
     assert!(!hash.is_empty());
 
     let rrset = vec![Record::new()
-                         .name(origin.clone())
-                         .ttl(86400)
-                         .rr_type(RecordType::CNAME)
-                         .dns_class(DNSClass::IN)
-                         .rdata(RData::CNAME(Name::parse("a.iana-servers.net.", None).unwrap()))
+                         .set_name(origin.clone())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::CNAME)
+                         .set_dns_class(DNSClass::IN)
+                         .set_rdata(RData::CNAME(Name::parse("a.iana-servers.net.", None).unwrap()))
                          .clone(), // different type
                      Record::new()
-                         .name(Name::parse("www.example.com.", None).unwrap())
-                         .ttl(86400)
-                         .rr_type(RecordType::NS)
-                         .dns_class(DNSClass::IN)
-                         .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                         .set_name(Name::parse("www.example.com.", None).unwrap())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::NS)
+                         .set_dns_class(DNSClass::IN)
+                         .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                          .clone(), // different name
                      Record::new()
-                         .name(origin.clone())
-                         .ttl(86400)
-                         .rr_type(RecordType::NS)
-                         .dns_class(DNSClass::CH)
-                         .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                         .set_name(origin.clone())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::NS)
+                         .set_dns_class(DNSClass::CH)
+                         .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                          .clone(), // different class
                      Record::new()
-                         .name(origin.clone())
-                         .ttl(86400)
-                         .rr_type(RecordType::NS)
-                         .dns_class(DNSClass::IN)
-                         .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                         .set_name(origin.clone())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::NS)
+                         .set_dns_class(DNSClass::IN)
+                         .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                          .clone(),
                      Record::new()
-                         .name(origin.clone())
-                         .ttl(86400)
-                         .rr_type(RecordType::NS)
-                         .dns_class(DNSClass::IN)
-                         .rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                         .set_name(origin.clone())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::NS)
+                         .set_dns_class(DNSClass::IN)
+                         .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
                          .clone()];
 
     let filtered_hash = signer.hash_rrset_with_rrsig(&rrsig, &rrset).unwrap();
@@ -841,33 +841,33 @@ fn test_sign_and_verify_rrset() {
 
     let origin: Name = Name::parse("example.com.", None).unwrap();
     let rrsig = Record::new()
-        .name(origin.clone())
-        .ttl(86400)
-        .rr_type(RecordType::NS)
-        .dns_class(DNSClass::IN)
-        .rdata(RData::SIG(SIG::new(RecordType::NS,
-                                   Algorithm::RSASHA256,
-                                   origin.num_labels(),
-                                   86400,
-                                   5,
-                                   0,
-                                   signer.calculate_key_tag().unwrap(),
-                                   origin.clone(),
-                                   vec![])))
+        .set_name(origin.clone())
+        .set_ttl(86400)
+        .set_rr_type(RecordType::NS)
+        .set_dns_class(DNSClass::IN)
+        .set_rdata(RData::SIG(SIG::new(RecordType::NS,
+                                       Algorithm::RSASHA256,
+                                       origin.num_labels(),
+                                       86400,
+                                       5,
+                                       0,
+                                       signer.calculate_key_tag().unwrap(),
+                                       origin.clone(),
+                                       vec![])))
         .clone();
     let rrset = vec![Record::new()
-                         .name(origin.clone())
-                         .ttl(86400)
-                         .rr_type(RecordType::NS)
-                         .dns_class(DNSClass::IN)
-                         .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                         .set_name(origin.clone())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::NS)
+                         .set_dns_class(DNSClass::IN)
+                         .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                          .clone(),
                      Record::new()
-                         .name(origin.clone())
-                         .ttl(86400)
-                         .rr_type(RecordType::NS)
-                         .dns_class(DNSClass::IN)
-                         .rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                         .set_name(origin.clone())
+                         .set_ttl(86400)
+                         .set_rr_type(RecordType::NS)
+                         .set_dns_class(DNSClass::IN)
+                         .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
                          .clone()];
 
     let hash = signer.hash_rrset_with_rrsig(&rrsig, &rrset).unwrap();

--- a/client/src/rr/rdata/dnskey.rs
+++ b/client/src/rr/rdata/dnskey.rs
@@ -107,7 +107,7 @@ impl DNSKEY {
     ///    Bits 0-6 and 8-14 are reserved: these bits MUST have value 0 upon
     ///    creation of the DNSKEY RR and MUST be ignored upon receipt.
     /// ```
-    pub fn is_zone_key(&self) -> bool {
+    pub fn zone_key(&self) -> bool {
         self.zone_key
     }
 
@@ -128,7 +128,7 @@ impl DNSKEY {
     ///    Zone Key flag not set MUST NOT be used to verify RRSIGs that cover
     ///    RRsets.
     /// ```
-    pub fn is_secure_entry_point(&self) -> bool {
+    pub fn secure_entry_point(&self) -> bool {
         self.secure_entry_point
     }
 
@@ -142,7 +142,7 @@ impl DNSKEY {
     ///   The IANA has assigned a bit in the DNSKEY flags field (see Section 7
     ///   of [RFC4034]) for the REVOKE bit (8).
     /// ```
-    pub fn is_revoke(&self) -> bool {
+    pub fn revoke(&self) -> bool {
         self.revoke
     }
 
@@ -155,7 +155,7 @@ impl DNSKEY {
     ///    algorithm and determines the format of the Public Key field.  A list
     ///    of DNSSEC algorithm types can be found in Appendix A.1
     /// ```
-    pub fn get_algorithm(&self) -> &Algorithm {
+    pub fn algorithm(&self) -> &Algorithm {
         &self.algorithm
     }
 
@@ -168,7 +168,7 @@ impl DNSKEY {
     ///    depends on the algorithm of the key being stored and is described in
     ///    separate documents.
     /// ```
-    pub fn get_public_key(&self) -> &[u8] {
+    pub fn public_key(&self) -> &[u8] {
         &self.public_key
     }
 
@@ -250,19 +250,19 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> DecodeResult<DNSKEY>
 
 pub fn emit(encoder: &mut BinEncoder, rdata: &DNSKEY) -> EncodeResult {
     let mut flags: u16 = 0;
-    if rdata.is_zone_key() {
+    if rdata.zone_key() {
         flags |= 0b0000_0001_0000_0000
     }
-    if rdata.is_secure_entry_point() {
+    if rdata.secure_entry_point() {
         flags |= 0b0000_0000_0000_0001
     }
-    if rdata.is_revoke() {
+    if rdata.revoke() {
         flags |= 0b0000_0000_1000_0000
     }
     try!(encoder.emit_u16(flags));
     try!(encoder.emit(3)); // always 3 for now
-    try!(rdata.get_algorithm().emit(encoder));
-    try!(encoder.emit_vec(rdata.get_public_key()));
+    try!(rdata.algorithm().emit(encoder));
+    try!(encoder.emit_vec(rdata.public_key()));
 
     Ok(())
 }

--- a/client/src/rr/rdata/ds.rs
+++ b/client/src/rr/rdata/ds.rs
@@ -94,7 +94,7 @@ impl DS {
     ///    The Key Tag used by the DS RR is identical to the Key Tag used by
     ///    RRSIG RRs.  Appendix B describes how to compute a Key Tag.
     /// ```
-    pub fn get_key_tag(&self) -> u16 {
+    pub fn key_tag(&self) -> u16 {
         self.key_tag
     }
 
@@ -110,7 +110,7 @@ impl DS {
     ///    number used by RRSIG and DNSKEY RRs.  Appendix A.1 lists the
     ///    algorithm number types.
     /// ```
-    pub fn get_algorithm(&self) -> &Algorithm {
+    pub fn algorithm(&self) -> &Algorithm {
         &self.algorithm
     }
 
@@ -123,7 +123,7 @@ impl DS {
     ///    RR.  The Digest Type field identifies the algorithm used to construct
     ///    the digest.  Appendix A.2 lists the possible digest algorithm types.
     /// ```
-    pub fn get_digest_type(&self) -> DigestType {
+    pub fn digest_type(&self) -> DigestType {
         self.digest_type
     }
 
@@ -149,7 +149,7 @@ impl DS {
     ///    DNSKEY RR size.  As of the time of this writing, the only defined
     ///    digest algorithm is SHA-1, which produces a 20 octet digest.
     /// ```
-    pub fn get_digest(&self) -> &[u8] {
+    pub fn digest(&self) -> &[u8] {
         &self.digest
     }
 
@@ -159,9 +159,9 @@ impl DS {
     ///
     /// true if and only if the DNSKEY is covered by the DS record.
     pub fn covers(&self, name: &Name, key: &DNSKEY) -> DnsSecResult<bool> {
-        key.to_digest(name, self.get_digest_type())
+        key.to_digest(name, self.digest_type())
             .map_err(|e| e.into())
-            .map(|hash| if &hash as &[u8] == self.get_digest() {
+            .map(|hash| if &hash as &[u8] == self.digest() {
                 return true;
             } else {
                 return false;
@@ -183,10 +183,10 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> DecodeResult<DS> {
 }
 
 pub fn emit(encoder: &mut BinEncoder, rdata: &DS) -> EncodeResult {
-    try!(encoder.emit_u16(rdata.get_key_tag()));
-    try!(rdata.get_algorithm().emit(encoder)); // always 3 for now
-    try!(encoder.emit(rdata.get_digest_type().into()));
-    try!(encoder.emit_vec(rdata.get_digest()));
+    try!(encoder.emit_u16(rdata.key_tag()));
+    try!(rdata.algorithm().emit(encoder)); // always 3 for now
+    try!(encoder.emit(rdata.digest_type().into()));
+    try!(encoder.emit_vec(rdata.digest()));
 
     Ok(())
 }

--- a/client/src/rr/rdata/mx.rs
+++ b/client/src/rr/rdata/mx.rs
@@ -59,7 +59,7 @@ impl MX {
     ///                 this RR among others at the same owner.  Lower values
     ///                 are preferred.
     /// ```
-    pub fn get_preference(&self) -> u16 {
+    pub fn preference(&self) -> u16 {
         self.preference
     }
 
@@ -69,7 +69,7 @@ impl MX {
     /// EXCHANGE        A <domain-name> which specifies a host willing to act as
     ///                 a mail exchange for the owner name.
     /// ```
-    pub fn get_exchange(&self) -> &Name {
+    pub fn exchange(&self) -> &Name {
         &self.exchange
     }
 }
@@ -96,8 +96,8 @@ pub fn read(decoder: &mut BinDecoder) -> DecodeResult<MX> {
 /// ```
 pub fn emit(encoder: &mut BinEncoder, mx: &MX) -> EncodeResult {
     let is_canonical_names = encoder.is_canonical_names();
-    try!(encoder.emit_u16(mx.get_preference()));
-    try!(mx.get_exchange().emit_with_lowercase(encoder, is_canonical_names));
+    try!(encoder.emit_u16(mx.preference()));
+    try!(mx.exchange().emit_with_lowercase(encoder, is_canonical_names));
     Ok(())
 }
 

--- a/client/src/rr/rdata/nsec.rs
+++ b/client/src/rr/rdata/nsec.rs
@@ -80,7 +80,7 @@ impl NSEC {
     ///    unless at least one authoritative RRset exists at the same owner
     ///    name.
     /// ```
-    pub fn get_next_domain_name(&self) -> &Name {
+    pub fn next_domain_name(&self) -> &Name {
         &self.next_domain_name
     }
 
@@ -95,7 +95,7 @@ impl NSEC {
     ///    A zone MUST NOT include an NSEC RR for any domain name that only
     ///    holds glue records.
     /// ```
-    pub fn get_type_bit_maps(&self) -> &[RecordType] {
+    pub fn type_bit_maps(&self) -> &[RecordType] {
         &self.type_bit_maps
     }
 }
@@ -124,8 +124,8 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> DecodeResult<NSEC> {
 pub fn emit(encoder: &mut BinEncoder, rdata: &NSEC) -> EncodeResult {
     let is_canonical_names = encoder.is_canonical_names();
     encoder.set_canonical_names(true);
-    try!(rdata.get_next_domain_name().emit(encoder));
-    try!(nsec3::encode_bit_maps(encoder, rdata.get_type_bit_maps()));
+    try!(rdata.next_domain_name().emit(encoder));
+    try!(nsec3::encode_bit_maps(encoder, rdata.type_bit_maps()));
     encoder.set_canonical_names(is_canonical_names);
 
     Ok(())

--- a/client/src/rr/rdata/nsec3.rs
+++ b/client/src/rr/rdata/nsec3.rs
@@ -147,7 +147,7 @@ impl NSEC3 {
     ///    The values for this field are defined in the NSEC3 hash algorithm
     ///    registry defined in Section 11.
     /// ```
-    pub fn get_hash_algorithm(&self) -> Nsec3HashAlgorithm {
+    pub fn hash_algorithm(&self) -> Nsec3HashAlgorithm {
         self.hash_algorithm
     }
 
@@ -172,7 +172,7 @@ impl NSEC3 {
     ///    delegations.  It is the least significant bit in the Flags field.
     ///    See Section 6 for details about the use of this flag.
     /// ```
-    pub fn is_opt_out(&self) -> bool {
+    pub fn opt_out(&self) -> bool {
         self.opt_out
     }
 
@@ -188,7 +188,7 @@ impl NSEC3 {
     ///    Section 5 for details of the use of this field, and Section 10.3 for
     ///    limitations on the value.
     /// ```
-    pub fn get_iterations(&self) -> u16 {
+    pub fn iterations(&self) -> u16 {
         self.iterations
     }
 
@@ -201,7 +201,7 @@ impl NSEC3 {
     ///    in order to defend against pre-calculated dictionary attacks.  See
     ///    Section 5 for details on how the salt is used.
     /// ```
-    pub fn get_salt(&self) -> &[u8] {
+    pub fn salt(&self) -> &[u8] {
         &self.salt
     }
 
@@ -220,7 +220,7 @@ impl NSEC3 {
     ///  that, unlike the owner name of the NSEC3 RR, the value of this field
     ///  does not contain the appended zone name.
     /// ```
-    pub fn get_next_hashed_owner_name(&self) -> &[u8] {
+    pub fn next_hashed_owner_name(&self) -> &[u8] {
         &self.next_hashed_owner_name
     }
 
@@ -232,7 +232,7 @@ impl NSEC3 {
     ///  The Type Bit Maps field identifies the RRSet types that exist at the
     ///  original owner name of the NSEC3 RR.
     /// ```
-    pub fn get_type_bit_maps(&self) -> &[RecordType] {
+    pub fn type_bit_maps(&self) -> &[RecordType] {
         &self.type_bit_maps
     }
 }
@@ -374,18 +374,18 @@ enum BitMapState {
 }
 
 pub fn emit(encoder: &mut BinEncoder, rdata: &NSEC3) -> EncodeResult {
-    try!(encoder.emit(rdata.get_hash_algorithm().into()));
+    try!(encoder.emit(rdata.hash_algorithm().into()));
     let mut flags: u8 = 0;
-    if rdata.is_opt_out() {
+    if rdata.opt_out() {
         flags |= 0b0000_0001
     };
     try!(encoder.emit(flags));
-    try!(encoder.emit_u16(rdata.get_iterations()));
-    try!(encoder.emit(rdata.get_salt().len() as u8));
-    try!(encoder.emit_vec(rdata.get_salt()));
-    try!(encoder.emit(rdata.get_next_hashed_owner_name().len() as u8));
-    try!(encoder.emit_vec(rdata.get_next_hashed_owner_name()));
-    try!(encode_bit_maps(encoder, rdata.get_type_bit_maps()));
+    try!(encoder.emit_u16(rdata.iterations()));
+    try!(encoder.emit(rdata.salt().len() as u8));
+    try!(encoder.emit_vec(rdata.salt()));
+    try!(encoder.emit(rdata.next_hashed_owner_name().len() as u8));
+    try!(encoder.emit_vec(rdata.next_hashed_owner_name()));
+    try!(encode_bit_maps(encoder, rdata.type_bit_maps()));
 
     Ok(())
 }

--- a/client/src/rr/rdata/nsec3param.rs
+++ b/client/src/rr/rdata/nsec3param.rs
@@ -109,7 +109,7 @@ impl NSEC3PARAM {
     ///    The acceptable values are the same as the corresponding field in the
     ///    NSEC3 RR.
     /// ```
-    pub fn get_hash_algorithm(&self) -> Nsec3HashAlgorithm {
+    pub fn hash_algorithm(&self) -> Nsec3HashAlgorithm {
         self.hash_algorithm
     }
 
@@ -125,7 +125,7 @@ impl NSEC3PARAM {
     ///    NSEC3PARAM RRs with a Flags field value other than zero MUST be
     ///    ignored.
     /// ```
-    pub fn is_opt_out(&self) -> bool {
+    pub fn opt_out(&self) -> bool {
         self.opt_out
     }
 
@@ -140,7 +140,7 @@ impl NSEC3PARAM {
     ///    Its acceptable values are the same as the corresponding field in the
     ///    NSEC3 RR.
     /// ```
-    pub fn get_iterations(&self) -> u16 {
+    pub fn iterations(&self) -> u16 {
         self.iterations
     }
 
@@ -151,7 +151,7 @@ impl NSEC3PARAM {
     ///
     ///    The Salt field is appended to the original owner name before hashing.
     /// ```
-    pub fn get_salt(&self) -> &[u8] {
+    pub fn salt(&self) -> &[u8] {
         &self.salt
     }
 }
@@ -172,15 +172,15 @@ pub fn read(decoder: &mut BinDecoder) -> DecodeResult<NSEC3PARAM> {
 }
 
 pub fn emit(encoder: &mut BinEncoder, rdata: &NSEC3PARAM) -> EncodeResult {
-    try!(encoder.emit(rdata.get_hash_algorithm().into()));
+    try!(encoder.emit(rdata.hash_algorithm().into()));
     let mut flags: u8 = 0;
-    if rdata.is_opt_out() {
+    if rdata.opt_out() {
         flags |= 0b0000_0001
     };
     try!(encoder.emit(flags));
-    try!(encoder.emit_u16(rdata.get_iterations()));
-    try!(encoder.emit(rdata.get_salt().len() as u8));
-    try!(encoder.emit_vec(&rdata.get_salt()));
+    try!(encoder.emit_u16(rdata.iterations()));
+    try!(encoder.emit(rdata.salt().len() as u8));
+    try!(encoder.emit_vec(&rdata.salt()));
 
     Ok(())
 }

--- a/client/src/rr/rdata/null.rs
+++ b/client/src/rr/rdata/null.rs
@@ -51,7 +51,7 @@ impl NULL {
         NULL { anything: Some(anything) }
     }
 
-    pub fn get_anything(&self) -> Option<&Vec<u8>> {
+    pub fn anything(&self) -> Option<&Vec<u8>> {
         self.anything.as_ref()
     }
 }
@@ -76,7 +76,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> DecodeResult<NULL> {
 }
 
 pub fn emit(encoder: &mut BinEncoder, nil: &NULL) -> EncodeResult {
-    if let Some(ref anything) = nil.get_anything() {
+    if let Some(ref anything) = nil.anything() {
         for b in anything.iter() {
             try!(encoder.emit(*b));
         }

--- a/client/src/rr/rdata/opt.rs
+++ b/client/src/rr/rdata/opt.rs
@@ -178,7 +178,7 @@ impl OPT {
     }
 
     /// The entire map of options
-    pub fn get_options(&self) -> &HashMap<EdnsCode, EdnsOption> {
+    pub fn options(&self) -> &HashMap<EdnsCode, EdnsOption> {
         &self.options
     }
 
@@ -241,7 +241,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> DecodeResult<OPT> {
 }
 
 pub fn emit(encoder: &mut BinEncoder, opt: &OPT) -> EncodeResult {
-    for (ref edns_code, ref edns_option) in opt.get_options().iter() {
+    for (ref edns_code, ref edns_option) in opt.options().iter() {
         try!(encoder.emit_u16(u16::from(**edns_code)));
         try!(encoder.emit_u16(edns_option.len()));
 

--- a/client/src/rr/rdata/sig.rs
+++ b/client/src/rr/rdata/sig.rs
@@ -242,7 +242,7 @@ impl SIG {
     ///
     ///  The "type covered" is the type of the other RRs covered by this SIG.
     /// ```
-    pub fn get_type_covered(&self) -> RecordType {
+    pub fn type_covered(&self) -> RecordType {
         self.type_covered
     }
 
@@ -253,7 +253,7 @@ impl SIG {
     ///
     ///  This octet is as described in section 3.2.
     /// ```
-    pub fn get_algorithm(&self) -> Algorithm {
+    pub fn algorithm(&self) -> Algorithm {
         self.algorithm
     }
 
@@ -289,7 +289,7 @@ impl SIG {
     ///    b.c.d.|  *. | *.d. | *.c.d. |   b.c.d. |    bad   |
     ///  a.b.c.d.|  *. | *.d. | *.c.d. | *.b.c.d. | a.b.c.d. |
     /// ```
-    pub fn get_num_labels(&self) -> u8 {
+    pub fn num_labels(&self) -> u8 {
         self.num_labels
     }
 
@@ -310,7 +310,7 @@ impl SIG {
     ///  that all RRs for a particular type, name, and class, that is, all the
     ///  RRs in any particular RRset, must have the same TTL to start with.
     /// ```
-    pub fn get_original_ttl(&self) -> u32 {
+    pub fn original_ttl(&self) -> u32 {
         self.original_ttl
     }
 
@@ -343,12 +343,12 @@ impl SIG {
     ///  purposes not only when its data is updated but also when new SIG RRs
     ///  are inserted (ie, the zone or any part of it is re-signed).
     /// ```
-    pub fn get_sig_expiration(&self) -> u32 {
+    pub fn sig_expiration(&self) -> u32 {
         self.sig_expiration
     }
 
     /// see `get_sig_expiration`
-    pub fn get_sig_inception(&self) -> u32 {
+    pub fn sig_inception(&self) -> u32 {
         self.sig_inception
     }
 
@@ -368,7 +368,7 @@ impl SIG {
     ///  all other algorithms, including private algorithms, it is calculated
     ///  as a simple checksum of the KEY RR as described in Appendix C.
     /// ```
-    pub fn get_key_tag(&self) -> u16 {
+    pub fn key_tag(&self) -> u16 {
         self.key_tag
     }
 
@@ -386,7 +386,7 @@ impl SIG {
     ///  standard DNS name compression when being transmitted over the
     ///  network.
     /// ```
-    pub fn get_signer_name(&self) -> &Name {
+    pub fn signer_name(&self) -> &Name {
         &self.signer_name
     }
 
@@ -419,7 +419,7 @@ impl SIG {
     ///  SIGs SHOULD NOT be included in a zone for any "meta-type" such as
     ///  ANY, AXFR, etc. (but see section 5.6.2 with regard to IXFR).
     /// ```
-    pub fn get_sig(&self) -> &[u8] {
+    pub fn sig(&self) -> &[u8] {
         &self.sig
     }
 }
@@ -473,15 +473,15 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> DecodeResult<SIG> {
 pub fn emit(encoder: &mut BinEncoder, sig: &SIG) -> EncodeResult {
     let is_canonical_names = encoder.is_canonical_names();
 
-    try!(sig.get_type_covered().emit(encoder));
-    try!(sig.get_algorithm().emit(encoder));
-    try!(encoder.emit(sig.get_num_labels()));
-    try!(encoder.emit_u32(sig.get_original_ttl()));
-    try!(encoder.emit_u32(sig.get_sig_expiration()));
-    try!(encoder.emit_u32(sig.get_sig_inception()));
-    try!(encoder.emit_u16(sig.get_key_tag()));
-    try!(sig.get_signer_name().emit_with_lowercase(encoder, is_canonical_names));
-    try!(encoder.emit_vec(sig.get_sig()));
+    try!(sig.type_covered().emit(encoder));
+    try!(sig.algorithm().emit(encoder));
+    try!(encoder.emit(sig.num_labels()));
+    try!(encoder.emit_u32(sig.original_ttl()));
+    try!(encoder.emit_u32(sig.sig_expiration()));
+    try!(encoder.emit_u32(sig.sig_inception()));
+    try!(encoder.emit_u16(sig.key_tag()));
+    try!(sig.signer_name().emit_with_lowercase(encoder, is_canonical_names));
+    try!(encoder.emit_vec(sig.sig()));
     Ok(())
 }
 

--- a/client/src/rr/rdata/soa.rs
+++ b/client/src/rr/rdata/soa.rs
@@ -125,7 +125,7 @@ impl SOA {
     ///
     /// The `domain-name` of the name server that was the original or primary source of data for
     /// this zone, i.e. the master name server.
-    pub fn get_mname(&self) -> &Name {
+    pub fn mname(&self) -> &Name {
         &self.mname
     }
 
@@ -138,7 +138,7 @@ impl SOA {
     ///
     /// A `domain-name` which specifies the mailbox of the person responsible for this zone, i.e.
     /// the responsible name.
-    pub fn get_rname(&self) -> &Name {
+    pub fn rname(&self) -> &Name {
         &self.rname
     }
 
@@ -153,7 +153,7 @@ impl SOA {
     ///
     /// The unsigned 32 bit version number of the original copy of the zone. Zone transfers
     /// preserve this value. This value wraps and should be compared using sequence space arithmetic.
-    pub fn get_serial(&self) -> u32 {
+    pub fn serial(&self) -> u32 {
         self.serial
     }
 
@@ -165,7 +165,7 @@ impl SOA {
     /// # Return value
     ///
     /// A 32 bit time interval before the zone should be refreshed, in seconds.
-    pub fn get_refresh(&self) -> i32 {
+    pub fn refresh(&self) -> i32 {
         self.refresh
     }
 
@@ -178,7 +178,7 @@ impl SOA {
     ///
     /// A 32 bit time interval that should elapse before a failed refresh should be retried,
     /// in seconds.
-    pub fn get_retry(&self) -> i32 {
+    pub fn retry(&self) -> i32 {
         self.retry
     }
 
@@ -192,7 +192,7 @@ impl SOA {
     ///
     /// A 32 bit time value that specifies the upper limit on the time interval that can elapse
     /// before the zone is no longer authoritative, in seconds
-    pub fn get_expire(&self) -> i32 {
+    pub fn expire(&self) -> i32 {
         self.expire
     }
 
@@ -204,7 +204,7 @@ impl SOA {
     /// # Return value
     ///
     /// The unsigned 32 bit minimum TTL field that should be exported with any RR from this zone.
-    pub fn get_minimum(&self) -> u32 {
+    pub fn minimum(&self) -> u32 {
         self.minimum
     }
 }

--- a/client/src/rr/rdata/srv.rs
+++ b/client/src/rr/rdata/srv.rs
@@ -119,7 +119,7 @@ impl SRV {
     /// order defined by the weight field.  The range is 0-65535.  This
     /// is a 16 bit unsigned integer in network byte order.
     /// ```
-    pub fn get_priority(&self) -> u16 {
+    pub fn priority(&self) -> u16 {
         self.priority
     }
 
@@ -160,7 +160,7 @@ impl SRV {
     /// are no unordered SRV RRs.  This process is repeated for each
     /// Priority.
     /// ```
-    pub fn get_weight(&self) -> u16 {
+    pub fn weight(&self) -> u16 {
         self.weight
     }
 
@@ -171,7 +171,7 @@ impl SRV {
     /// This is often as specified in Assigned Numbers but need not be.
     ///
     /// ```
-    pub fn get_port(&self) -> u16 {
+    pub fn port(&self) -> u16 {
         self.port
     }
 
@@ -187,7 +187,7 @@ impl SRV {
     /// A Target of "." means that the service is decidedly not
     /// available at this domain.
     /// ```
-    pub fn get_target(&self) -> &Name {
+    pub fn target(&self) -> &Name {
         &self.target
     }
 }
@@ -221,10 +221,10 @@ pub fn read(decoder: &mut BinDecoder) -> DecodeResult<SRV> {
 pub fn emit(encoder: &mut BinEncoder, srv: &SRV) -> EncodeResult {
     let is_canonical_names = encoder.is_canonical_names();
 
-    try!(encoder.emit_u16(srv.get_priority()));
-    try!(encoder.emit_u16(srv.get_weight()));
-    try!(encoder.emit_u16(srv.get_port()));
-    try!(srv.get_target().emit_with_lowercase(encoder, is_canonical_names));
+    try!(encoder.emit_u16(srv.priority()));
+    try!(encoder.emit_u16(srv.weight()));
+    try!(encoder.emit_u16(srv.port()));
+    try!(srv.target().emit_with_lowercase(encoder, is_canonical_names));
     Ok(())
 }
 

--- a/client/src/rr/rdata/txt.rs
+++ b/client/src/rr/rdata/txt.rs
@@ -55,7 +55,7 @@ impl TXT {
     /// ```text
     /// TXT-DATA        One or more <character-string>s.
     /// ```
-    pub fn get_txt_data(&self) -> &[String] {
+    pub fn txt_data(&self) -> &[String] {
         &self.txt_data
     }
 }
@@ -71,7 +71,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> DecodeResult<TXT> {
 }
 
 pub fn emit(encoder: &mut BinEncoder, txt: &TXT) -> EncodeResult {
-    for s in txt.get_txt_data() {
+    for s in txt.txt_data() {
         try!(encoder.emit_character_data(s));
     }
 

--- a/client/src/rr/resource.rs
+++ b/client/src/rr/resource.rs
@@ -432,16 +432,16 @@ mod tests {
             .set_rdata(RData::A(Ipv4Addr::new(192, 168, 0, 1)));
 
         let mut greater_name = record.clone();
-        greater_name.name(Name::new().label("zzz").label("example").label("com"));
+        greater_name.set_name(Name::new().label("zzz").label("example").label("com"));
 
         let mut greater_type = record.clone();
-        greater_type.rr_type(RecordType::AAAA);
+        greater_type.set_rr_type(RecordType::AAAA);
 
         let mut greater_class = record.clone();
-        greater_class.dns_class(DNSClass::NONE);
+        greater_class.set_dns_class(DNSClass::NONE);
 
         let mut greater_rdata = record.clone();
-        greater_rdata.rdata(RData::A(Ipv4Addr::new(192, 168, 0, 255)));
+        greater_rdata.set_rdata(RData::A(Ipv4Addr::new(192, 168, 0, 255)));
 
         let compares = vec![(&record, &greater_name),
                             (&record, &greater_type),

--- a/client/src/rr/resource.rs
+++ b/client/src/rr/resource.rs
@@ -129,7 +129,7 @@ impl Record {
     /// ```text
     /// NAME            a domain name to which this resource record pertains.
     /// ```
-    pub fn name(&mut self, name: domain::Name) -> &mut Self {
+    pub fn set_name(&mut self, name: domain::Name) -> &mut Self {
         self.name_labels = name;
         self
     }
@@ -143,7 +143,7 @@ impl Record {
     ///                 field specifies the meaning of the data in the RDATA
     ///                 field.
     /// ```
-    pub fn rr_type(&mut self, rr_type: RecordType) -> &mut Self {
+    pub fn set_rr_type(&mut self, rr_type: RecordType) -> &mut Self {
         self.rr_type = rr_type;
         self
     }
@@ -152,7 +152,7 @@ impl Record {
     /// CLASS           two octets which specify the class of the data in the
     ///                 RDATA field.
     /// ```
-    pub fn dns_class(&mut self, dns_class: DNSClass) -> &mut Self {
+    pub fn set_dns_class(&mut self, dns_class: DNSClass) -> &mut Self {
         self.dns_class = dns_class;
         self
     }
@@ -164,7 +164,7 @@ impl Record {
     ///                 interpreted to mean that the RR can only be used for the
     ///                 transaction in progress, and should not be cached.
     /// ```
-    pub fn ttl(&mut self, ttl: u32) -> &mut Self {
+    pub fn set_ttl(&mut self, ttl: u32) -> &mut Self {
         self.ttl = ttl;
         self
     }
@@ -176,27 +176,27 @@ impl Record {
     ///                 For example, the if the TYPE is A and the CLASS is IN,
     ///                 the RDATA field is a 4 octet ARPA Internet address.
     /// ```
-    pub fn rdata(&mut self, rdata: RData) -> &mut Self {
+    pub fn set_rdata(&mut self, rdata: RData) -> &mut Self {
         self.rdata = rdata;
         self
     }
 
-    pub fn get_name(&self) -> &domain::Name {
+    pub fn name(&self) -> &domain::Name {
         &self.name_labels
     }
-    pub fn get_rr_type(&self) -> RecordType {
+    pub fn rr_type(&self) -> RecordType {
         self.rr_type
     }
-    pub fn get_dns_class(&self) -> DNSClass {
+    pub fn dns_class(&self) -> DNSClass {
         self.dns_class
     }
-    pub fn get_ttl(&self) -> u32 {
+    pub fn ttl(&self) -> u32 {
         self.ttl
     }
-    pub fn get_rdata(&self) -> &RData {
+    pub fn rdata(&self) -> &RData {
         &self.rdata
     }
-    pub fn get_rdata_mut(&mut self) -> &mut RData {
+    pub fn rdata_mut(&mut self) -> &mut RData {
         &mut self.rdata
     }
     pub fn unwrap_rdata(self) -> RData {
@@ -402,10 +402,10 @@ mod tests {
         record.add_name("www".to_string())
             .add_name("example".to_string())
             .add_name("com".to_string())
-            .rr_type(RecordType::A)
-            .dns_class(DNSClass::IN)
-            .ttl(5)
-            .rdata(RData::A(Ipv4Addr::new(192, 168, 0, 1)));
+            .set_rr_type(RecordType::A)
+            .set_dns_class(DNSClass::IN)
+            .set_ttl(5)
+            .set_rdata(RData::A(Ipv4Addr::new(192, 168, 0, 1)));
 
         let mut vec_bytes: Vec<u8> = Vec::with_capacity(512);
         {
@@ -426,10 +426,10 @@ mod tests {
         record.add_name("www".to_string())
             .add_name("example".to_string())
             .add_name("com".to_string())
-            .rr_type(RecordType::A)
-            .dns_class(DNSClass::IN)
-            .ttl(5)
-            .rdata(RData::A(Ipv4Addr::new(192, 168, 0, 1)));
+            .set_rr_type(RecordType::A)
+            .set_dns_class(DNSClass::IN)
+            .set_ttl(5)
+            .set_rdata(RData::A(Ipv4Addr::new(192, 168, 0, 1)));
 
         let mut greater_name = record.clone();
         greater_name.name(Name::new().label("zzz").label("example").label("com"));

--- a/client/src/rr/rr_set.rs
+++ b/client/src/rr/rr_set.rs
@@ -99,14 +99,14 @@ impl RecordSet {
     /// # Return value
     ///
     /// Label of the Resource Record Set
-    pub fn get_name(&self) -> &Name {
+    pub fn name(&self) -> &Name {
         &self.name
     }
 
     /// # Return value
     ///
     /// `RecordType` of the Resource Record Set
-    pub fn get_record_type(&self) -> RecordType {
+    pub fn record_type(&self) -> RecordType {
         self.record_type
     }
 
@@ -121,7 +121,7 @@ impl RecordSet {
     }
 
     /// Returns the `DNSClass` of the RecordSet
-    pub fn get_dns_class(&self) -> DNSClass {
+    pub fn dns_class(&self) -> DNSClass {
         self.dns_class
     }
 
@@ -141,7 +141,7 @@ impl RecordSet {
     ///
     /// TTL, time-to-live, of the Resource Record Set, this is the maximum length of time that an
     /// RecordSet should be cached.
-    pub fn get_ttl(&self) -> u32 {
+    pub fn ttl(&self) -> u32 {
         self.ttl
     }
 
@@ -152,10 +152,10 @@ impl RecordSet {
     /// * `and_rrsigs` - if true, RRSIGs will be returned if they exist
     /// * `supported_algorithms` - the RRSIGs will be filtered by the set of supported_algorithms,
     ///                            and then only the maximal RRSIG algorithm will be returned.
-    pub fn get_records(&self,
-                       and_rrsigs: bool,
-                       supported_algorithms: SupportedAlgorithms)
-                       -> Vec<&Record> {
+    pub fn records(&self,
+                   and_rrsigs: bool,
+                   supported_algorithms: SupportedAlgorithms)
+                   -> Vec<&Record> {
         if and_rrsigs {
             let rrsigs = self.rrsigs
                 .iter()
@@ -186,11 +186,11 @@ impl RecordSet {
     }
 
     /// Returns the serial number at which the record was updated.
-    pub fn get_serial(&self) -> u32 {
+    pub fn serial(&self) -> u32 {
         self.serial
     }
 
-    pub fn get_rrsigs(&self) -> &[Record] {
+    pub fn rrsigs(&self) -> &[Record] {
         &self.rrsigs
     }
 
@@ -426,13 +426,13 @@ mod test {
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
-        assert_eq!(rr_set.get_records(false, Default::default()).len(), 1);
-        assert!(rr_set.get_records(false, Default::default()).contains(&&insert));
+        assert_eq!(rr_set.records(false, Default::default()).len(), 1);
+        assert!(rr_set.records(false, Default::default()).contains(&&insert));
 
         // dups ignored
         assert!(!rr_set.insert(insert.clone(), 0));
-        assert_eq!(rr_set.get_records(false, Default::default()).len(), 1);
-        assert!(rr_set.get_records(false, Default::default()).contains(&&insert));
+        assert_eq!(rr_set.records(false, Default::default()).len(), 1);
+        assert!(rr_set.records(false, Default::default()).contains(&&insert));
 
         // add one
         let insert1 = Record::new()
@@ -443,9 +443,9 @@ mod test {
             .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 25)))
             .clone();
         assert!(rr_set.insert(insert1.clone(), 0));
-        assert_eq!(rr_set.get_records(false, Default::default()).len(), 2);
-        assert!(rr_set.get_records(false, Default::default()).contains(&&insert));
-        assert!(rr_set.get_records(false, Default::default()).contains(&&insert1));
+        assert_eq!(rr_set.records(false, Default::default()).len(), 2);
+        assert!(rr_set.records(false, Default::default()).contains(&&insert));
+        assert!(rr_set.records(false, Default::default()).contains(&&insert1));
     }
 
     #[test]
@@ -495,19 +495,19 @@ mod test {
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
-        assert!(rr_set.get_records(false, Default::default()).contains(&&insert));
+        assert!(rr_set.records(false, Default::default()).contains(&&insert));
         // same serial number
         assert!(!rr_set.insert(same_serial.clone(), 0));
-        assert!(rr_set.get_records(false, Default::default()).contains(&&insert));
-        assert!(!rr_set.get_records(false, Default::default()).contains(&&same_serial));
+        assert!(rr_set.records(false, Default::default()).contains(&&insert));
+        assert!(!rr_set.records(false, Default::default()).contains(&&same_serial));
 
         assert!(rr_set.insert(new_serial.clone(), 0));
         assert!(!rr_set.insert(same_serial.clone(), 0));
         assert!(!rr_set.insert(insert.clone(), 0));
 
-        assert!(rr_set.get_records(false, Default::default()).contains(&&new_serial));
-        assert!(!rr_set.get_records(false, Default::default()).contains(&&insert));
-        assert!(!rr_set.get_records(false, Default::default()).contains(&&same_serial));
+        assert!(rr_set.records(false, Default::default()).contains(&&new_serial));
+        assert!(!rr_set.records(false, Default::default()).contains(&&insert));
+        assert!(!rr_set.records(false, Default::default()).contains(&&same_serial));
     }
 
     #[test]
@@ -535,12 +535,12 @@ mod test {
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
-        assert!(rr_set.get_records(false, Default::default()).contains(&&insert));
+        assert!(rr_set.records(false, Default::default()).contains(&&insert));
 
         // update the record
         assert!(rr_set.insert(new_record.clone(), 0));
-        assert!(!rr_set.get_records(false, Default::default()).contains(&&insert));
-        assert!(rr_set.get_records(false, Default::default()).contains(&&new_record));
+        assert!(!rr_set.records(false, Default::default()).contains(&&insert));
+        assert!(rr_set.records(false, Default::default()).contains(&&new_record));
     }
 
     #[test]
@@ -595,7 +595,7 @@ mod test {
 
         assert!(rr_set.insert(insert.clone(), 0));
         assert!(!rr_set.remove(&insert, 0));
-        assert!(rr_set.get_records(false, Default::default()).contains(&&insert));
+        assert!(rr_set.records(false, Default::default()).contains(&&insert));
     }
 
     #[test]

--- a/client/src/rr/rr_set.rs
+++ b/client/src/rr/rr_set.rs
@@ -160,12 +160,12 @@ impl RecordSet {
             let rrsigs = self.rrsigs
                 .iter()
                 .filter(|record| if let &RData::SIG(ref rrsig) = record.get_rdata() {
-                    supported_algorithms.has(rrsig.get_algorithm())
+                    supported_algorithms.has(rrsig.algorithm())
                 } else {
                     false
                 })
                 .max_by_key(|record| if let &RData::SIG(ref rrsig) = record.get_rdata() {
-                    rrsig.get_algorithm()
+                    rrsig.algorithm()
                 } else {
                     Algorithm::RSASHA1
                 });
@@ -722,7 +722,7 @@ mod test {
         assert!(rrset.get_records(true, SupportedAlgorithms::all())
             .iter()
             .any(|r| if let &RData::SIG(ref sig) = r.get_rdata() {
-                sig.get_algorithm() == Algorithm::ED25519
+                sig.algorithm() == Algorithm::ED25519
             } else {
                 false
             }));
@@ -732,7 +732,7 @@ mod test {
         assert!(rrset.get_records(true, supported_algorithms)
             .iter()
             .any(|r| if let &RData::SIG(ref sig) = r.get_rdata() {
-                sig.get_algorithm() == Algorithm::ECDSAP384SHA384
+                sig.algorithm() == Algorithm::ECDSAP384SHA384
             } else {
                 false
             }));

--- a/client/src/rr/rr_set.rs
+++ b/client/src/rr/rr_set.rs
@@ -719,7 +719,7 @@ mod test {
         rrset.insert_rrsig(rrsig_ecp384);
         rrset.insert_rrsig(rrsig_ed25519);
 
-        assert!(rrset.get_records(true, SupportedAlgorithms::all())
+        assert!(rrset.records(true, SupportedAlgorithms::all())
             .iter()
             .any(|r| if let &RData::SIG(ref sig) = r.rdata() {
                 sig.algorithm() == Algorithm::ED25519
@@ -729,7 +729,7 @@ mod test {
 
         let mut supported_algorithms = SupportedAlgorithms::new();
         supported_algorithms.set(Algorithm::ECDSAP384SHA384);
-        assert!(rrset.get_records(true, supported_algorithms)
+        assert!(rrset.records(true, supported_algorithms)
             .iter()
             .any(|r| if let &RData::SIG(ref sig) = r.rdata() {
                 sig.algorithm() == Algorithm::ECDSAP384SHA384

--- a/client/src/rr/rr_set.rs
+++ b/client/src/rr/rr_set.rs
@@ -271,7 +271,7 @@ impl RecordSet {
                     match soa_record.get_rdata() {
                         &RData::SOA(ref existing_soa) => {
                             if let &RData::SOA(ref new_soa) = record.get_rdata() {
-                                if new_soa.get_serial() <= existing_soa.get_serial() {
+                                if new_soa.serial() <= existing_soa.serial() {
                                     info!("update ignored serial out of data: {:?} <= {:?}",
                                           new_soa,
                                           existing_soa);

--- a/client/src/rr/rr_set.rs
+++ b/client/src/rr/rr_set.rs
@@ -86,10 +86,10 @@ impl RecordSet {
     /// The newly created Resource Record Set
     pub fn from(record: Record) -> Self {
         RecordSet {
-            name: record.get_name().clone(),
-            record_type: record.get_rr_type(),
-            dns_class: record.get_dns_class(),
-            ttl: record.get_ttl(),
+            name: record.name().clone(),
+            record_type: record.rr_type(),
+            dns_class: record.dns_class(),
+            ttl: record.ttl(),
             records: vec![record],
             rrsigs: vec![],
             serial: 0,
@@ -116,7 +116,7 @@ impl RecordSet {
     pub fn set_dns_class(&mut self, dns_class: DNSClass) {
         self.dns_class = dns_class;
         for r in self.records.iter_mut() {
-            r.dns_class(dns_class);
+            r.set_dns_class(dns_class);
         }
     }
 
@@ -131,7 +131,7 @@ impl RecordSet {
     pub fn set_ttl(&mut self, ttl: u32) {
         self.ttl = ttl;
         for r in self.records.iter_mut() {
-            r.ttl(ttl);
+            r.set_ttl(ttl);
         }
     }
 
@@ -159,12 +159,12 @@ impl RecordSet {
         if and_rrsigs {
             let rrsigs = self.rrsigs
                 .iter()
-                .filter(|record| if let &RData::SIG(ref rrsig) = record.get_rdata() {
+                .filter(|record| if let &RData::SIG(ref rrsig) = record.rdata() {
                     supported_algorithms.has(rrsig.algorithm())
                 } else {
                     false
                 })
-                .max_by_key(|record| if let &RData::SIG(ref rrsig) = record.get_rdata() {
+                .max_by_key(|record| if let &RData::SIG(ref rrsig) = record.rdata() {
                     rrsig.algorithm()
                 } else {
                     Algorithm::RSASHA1
@@ -212,10 +212,10 @@ impl RecordSet {
         assert_eq!(self.record_type, rdata.to_record_type());
 
         let mut record = Record::with(self.name.clone(), self.record_type, self.ttl);
-        record.rdata(rdata.clone()); // TODO: remove clone()? this is only needed for the record return
+        record.set_rdata(rdata.clone()); // TODO: remove clone()? this is only needed for the record return
         self.insert(record, 0);
 
-        self.records.iter().find(|r| *r.get_rdata() == rdata).expect("insert failed? 172")
+        self.records.iter().find(|r| *r.rdata() == rdata).expect("insert failed? 172")
     }
 
     /// Inserts a new Resource Record into the Set.
@@ -252,15 +252,15 @@ impl RecordSet {
     ///
     /// FIXME: make a default add without serial number for basic usage
     pub fn insert(&mut self, record: Record, serial: u32) -> bool {
-        assert_eq!(record.get_name(), &self.name);
-        assert_eq!(record.get_rr_type(), self.record_type);
+        assert_eq!(record.name(), &self.name);
+        assert_eq!(record.rr_type(), self.record_type);
 
         // RFC 2136                       DNS Update                     April 1997
         //
         // 1.1.5. The following RR types cannot be appended to an RRset.  If the
         //  following comparison rules are met, then an attempt to add the new RR
         //  will result in the replacement of the previous RR:
-        match record.get_rr_type() {
+        match record.rr_type() {
             // SOA    compare only NAME, CLASS and TYPE -- it is not possible to
             //         have more than one SOA per zone, even if any of the data
             //         fields differ.
@@ -268,9 +268,9 @@ impl RecordSet {
                 assert!(self.records.len() <= 1);
 
                 if let Some(soa_record) = self.records.iter().next() {
-                    match soa_record.get_rdata() {
+                    match soa_record.rdata() {
                         &RData::SOA(ref existing_soa) => {
-                            if let &RData::SOA(ref new_soa) = record.get_rdata() {
+                            if let &RData::SOA(ref new_soa) = record.rdata() {
                                 if new_soa.serial() <= existing_soa.serial() {
                                     info!("update ignored serial out of data: {:?} <= {:?}",
                                           new_soa,
@@ -279,7 +279,7 @@ impl RecordSet {
                                 }
                             } else {
                                 // not panicking here, b/c this is a bad record from the client or something, ingnore
-                                info!("wrong rdata for SOA update: {:?}", record.get_rdata());
+                                info!("wrong rdata for SOA update: {:?}", record.rdata());
                                 return false;
                             }
                         }
@@ -304,7 +304,7 @@ impl RecordSet {
         let to_replace: Vec<usize> = self.records
             .iter()
             .enumerate()
-            .filter(|&(_, rr)| rr.get_rdata() == record.get_rdata())
+            .filter(|&(_, rr)| rr.rdata() == record.rdata())
             .map(|(i, _)| i)
             .collect::<Vec<usize>>();
 
@@ -318,13 +318,13 @@ impl RecordSet {
             // TODO: this shouldn't really need a clone since there should only be one...
             self.records.push(record.clone());
             self.records.swap_remove(i);
-            self.ttl = record.get_ttl();
+            self.ttl = record.ttl();
             self.updated(serial);
             replaced = true;
         }
 
         if !replaced {
-            self.ttl = record.get_ttl();
+            self.ttl = record.ttl();
             self.updated(serial);
             self.records.push(record);
             true
@@ -347,11 +347,11 @@ impl RecordSet {
     ///
     /// True if a record was removed.
     pub fn remove(&mut self, record: &Record, serial: u32) -> bool {
-        assert_eq!(record.get_name(), &self.name);
-        assert!(record.get_rr_type() == self.record_type ||
-                record.get_rr_type() == RecordType::ANY);
+        assert_eq!(record.name(), &self.name);
+        assert!(record.rr_type() == self.record_type ||
+                record.rr_type() == RecordType::ANY);
 
-        match record.get_rr_type() {
+        match record.rr_type() {
             // never delete the last NS record
             RecordType::NS => {
                 if self.records.len() <= 1 {
@@ -371,7 +371,7 @@ impl RecordSet {
         let to_remove: Vec<usize> = self.records
             .iter()
             .enumerate()
-            .filter(|&(_, rr)| rr.get_rdata() == record.get_rdata())
+            .filter(|&(_, rr)| rr.rdata() == record.rdata())
             .map(|(i, _)| i)
             .collect::<Vec<usize>>();
 
@@ -418,11 +418,11 @@ mod test {
         let mut rr_set = RecordSet::new(&name, record_type, 0);
 
         let insert = Record::new()
-            .name(name.clone())
-            .ttl(86400)
-            .rr_type(record_type)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+            .set_name(name.clone())
+            .set_ttl(86400)
+            .set_rr_type(record_type)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -436,11 +436,11 @@ mod test {
 
         // add one
         let insert1 = Record::new()
-            .name(name.clone())
-            .ttl(86400)
-            .rr_type(record_type)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 25)))
+            .set_name(name.clone())
+            .set_ttl(86400)
+            .set_rr_type(record_type)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 25)))
             .clone();
         assert!(rr_set.insert(insert1.clone(), 0));
         assert_eq!(rr_set.get_records(false, Default::default()).len(), 2);
@@ -455,43 +455,43 @@ mod test {
         let mut rr_set = RecordSet::new(&name, record_type, 0);
 
         let insert = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::SOA)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
-                                       Name::parse("noc.dns.icann.org.", None).unwrap(),
-                                       2015082403,
-                                       7200,
-                                       3600,
-                                       1209600,
-                                       3600)))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::SOA)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
+                                           Name::parse("noc.dns.icann.org.", None).unwrap(),
+                                           2015082403,
+                                           7200,
+                                           3600,
+                                           1209600,
+                                           3600)))
             .clone();
         let same_serial = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::SOA)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.net.", None).unwrap(),
-                                       Name::parse("noc.dns.icann.net.", None).unwrap(),
-                                       2015082403,
-                                       7200,
-                                       3600,
-                                       1209600,
-                                       3600)))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::SOA)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.net.", None).unwrap(),
+                                           Name::parse("noc.dns.icann.net.", None).unwrap(),
+                                           2015082403,
+                                           7200,
+                                           3600,
+                                           1209600,
+                                           3600)))
             .clone();
         let new_serial = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::SOA)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.net.", None).unwrap(),
-                                       Name::parse("noc.dns.icann.net.", None).unwrap(),
-                                       2015082404,
-                                       7200,
-                                       3600,
-                                       1209600,
-                                       3600)))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::SOA)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.net.", None).unwrap(),
+                                           Name::parse("noc.dns.icann.net.", None).unwrap(),
+                                           2015082404,
+                                           7200,
+                                           3600,
+                                           1209600,
+                                           3600)))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -520,18 +520,18 @@ mod test {
         let mut rr_set = RecordSet::new(&name, record_type, 0);
 
         let insert = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::CNAME)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::CNAME(cname.clone()))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::CNAME)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::CNAME(cname.clone()))
             .clone();
         let new_record = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::CNAME)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::CNAME(new_cname.clone()))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::CNAME)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::CNAME(new_cname.clone()))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -550,18 +550,18 @@ mod test {
         let mut rr_set = RecordSet::new(&name, record_type, 0);
 
         let insert = Record::new()
-            .name(name.clone())
-            .ttl(86400)
-            .rr_type(record_type)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+            .set_name(name.clone())
+            .set_ttl(86400)
+            .set_rr_type(record_type)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
             .clone();
         let insert1 = Record::new()
-            .name(name.clone())
-            .ttl(86400)
-            .rr_type(record_type)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 25)))
+            .set_name(name.clone())
+            .set_ttl(86400)
+            .set_rr_type(record_type)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 25)))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -580,17 +580,17 @@ mod test {
         let mut rr_set = RecordSet::new(&name, record_type, 0);
 
         let insert = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::SOA)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
-                                       Name::parse("noc.dns.icann.org.", None).unwrap(),
-                                       2015082403,
-                                       7200,
-                                       3600,
-                                       1209600,
-                                       3600)))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::SOA)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
+                                           Name::parse("noc.dns.icann.org.", None).unwrap(),
+                                           2015082403,
+                                           7200,
+                                           3600,
+                                           1209600,
+                                           3600)))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -605,18 +605,18 @@ mod test {
         let mut rr_set = RecordSet::new(&name, record_type, 0);
 
         let ns1 = Record::new()
-            .name(name.clone())
-            .ttl(86400)
-            .rr_type(RecordType::NS)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+            .set_name(name.clone())
+            .set_ttl(86400)
+            .set_rr_type(RecordType::NS)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
             .clone();
         let ns2 = Record::new()
-            .name(name.clone())
-            .ttl(86400)
-            .rr_type(RecordType::NS)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+            .set_name(name.clone())
+            .set_ttl(86400)
+            .set_rr_type(RecordType::NS)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
             .clone();
 
         assert!(rr_set.insert(ns1.clone(), 0));
@@ -677,40 +677,40 @@ mod test {
                                vec![]);
 
         let rrsig_rsa = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::RRSIG)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::SIG(rsasha256))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::RRSIG)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::SIG(rsasha256))
             .clone();
         let rrsig_ecp256 = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::RRSIG)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::SIG(ecp256))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::RRSIG)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::SIG(ecp256))
             .clone();
         let rrsig_ecp384 = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::RRSIG)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::SIG(ecp384))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::RRSIG)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::SIG(ecp384))
             .clone();
         let rrsig_ed25519 = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::RRSIG)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::SIG(ed25519))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::RRSIG)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::SIG(ed25519))
             .clone();
 
         let a = Record::new()
-            .name(name.clone())
-            .ttl(3600)
-            .rr_type(RecordType::A)
-            .dns_class(DNSClass::IN)
-            .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+            .set_name(name.clone())
+            .set_ttl(3600)
+            .set_rr_type(RecordType::A)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
             .clone();
 
         let mut rrset = a.into_record_set();
@@ -721,7 +721,7 @@ mod test {
 
         assert!(rrset.get_records(true, SupportedAlgorithms::all())
             .iter()
-            .any(|r| if let &RData::SIG(ref sig) = r.get_rdata() {
+            .any(|r| if let &RData::SIG(ref sig) = r.rdata() {
                 sig.algorithm() == Algorithm::ED25519
             } else {
                 false
@@ -731,7 +731,7 @@ mod test {
         supported_algorithms.set(Algorithm::ECDSAP384SHA384);
         assert!(rrset.get_records(true, supported_algorithms)
             .iter()
-            .any(|r| if let &RData::SIG(ref sig) = r.get_rdata() {
+            .any(|r| if let &RData::SIG(ref sig) = r.rdata() {
                 sig.algorithm() == Algorithm::ECDSAP384SHA384
             } else {
                 false

--- a/client/src/serialize/txt/master.rs
+++ b/client/src/serialize/txt/master.rs
@@ -251,9 +251,9 @@ impl Parser {
                                     // expire is for the SOA, minimum is default for records
                                     if let RData::SOA(ref soa) = rdata {
                                         // TODO, this looks wrong, get_expire() should be get_minimum(), right?
-                                        record.ttl(soa.get_expire() as u32); // the spec seems a little inaccurate with u32 and i32
+                                        record.ttl(soa.expire() as u32); // the spec seems a little inaccurate with u32 and i32
                                         if ttl.is_none() {
-                                            ttl = Some(soa.get_minimum());
+                                            ttl = Some(soa.minimum());
                                         } // TODO: should this only set it if it's not set?
                                     } else {
                                         assert!(false,

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -223,7 +223,7 @@ impl Authority {
     /// Returns the minimum ttl (as used in the SOA record)
     pub fn get_minimum_ttl(&self) -> u32 {
         self.get_soa().map_or(0, |soa| if let &RData::SOA(ref rdata) = soa.get_rdata() {
-            rdata.get_minimum()
+            rdata.minimum()
         } else {
             0
         })
@@ -239,7 +239,7 @@ impl Authority {
         };
 
         if let &RData::SOA(ref soa_rdata) = soa.get_rdata() {
-            soa_rdata.get_serial()
+            soa_rdata.serial()
         } else {
             panic!("This was not an SOA record"); // valid panic, never should happen
         }
@@ -255,7 +255,7 @@ impl Authority {
 
         let serial = if let &mut RData::SOA(ref mut soa_rdata) = soa.get_rdata_mut() {
             soa_rdata.increment_serial();
-            soa_rdata.get_serial()
+            soa_rdata.serial()
         } else {
             panic!("This was not an SOA record"); // valid panic, never should happen
         };

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -487,7 +487,7 @@ impl Authority {
                 None
             })
             .any(|sig| {
-                let name = sig.get_signer_name();
+                let name = sig.signer_name();
                 let keys = self.lookup(name, RecordType::KEY, false, SupportedAlgorithms::new());
                 debug!("found keys {:?}", keys);
                 keys.iter()
@@ -510,11 +510,11 @@ impl Authority {
                         let pkey = pkey.unwrap();
                         let signer: Signer = Signer::new_verifier(*key.algorithm(),
                                                                   pkey,
-                                                                  sig.get_signer_name().clone(),
+                                                                  sig.signer_name().clone(),
                                                                   false,
                                                                   true);
 
-                        signer.verify_message(update_message, sig.get_sig())
+                        signer.verify_message(update_message, sig.sig())
                             .map(|_| {
                                 info!("verified sig: {:?} with key: {:?}", sig, key);
                                 true

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -116,7 +116,7 @@ impl Authority {
             // AXFR is special, it is used to mark the dump of a full zone.
             //  when recovering, if an AXFR is encountered, we should remove all the records in the
             //  authority.
-            if record.get_rr_type() == RecordType::AXFR {
+            if record.rr_type() == RecordType::AXFR {
                 self.records.clear();
             } else {
                 match self.update_records(&[record], false) {
@@ -147,7 +147,7 @@ impl Authority {
             info!("persisting zone to journal at SOA.serial: {}", serial);
 
             // TODO: THIS NEEDS TO BE IN A TRANSACTION!!!
-            try!(journal.insert_record(serial, Record::new().rr_type(RecordType::AXFR)));
+            try!(journal.insert_record(serial, Record::new().set_rr_type(RecordType::AXFR)));
 
             for rr_set in self.records.values() {
                 // TODO: should we preserve rr_sets or not?
@@ -222,7 +222,7 @@ impl Authority {
 
     /// Returns the minimum ttl (as used in the SOA record)
     pub fn get_minimum_ttl(&self) -> u32 {
-        self.get_soa().map_or(0, |soa| if let &RData::SOA(ref rdata) = soa.get_rdata() {
+        self.get_soa().map_or(0, |soa| if let &RData::SOA(ref rdata) = soa.rdata() {
             rdata.minimum()
         } else {
             0
@@ -238,7 +238,7 @@ impl Authority {
             return 0;
         };
 
-        if let &RData::SOA(ref soa_rdata) = soa.get_rdata() {
+        if let &RData::SOA(ref soa_rdata) = soa.rdata() {
             soa_rdata.serial()
         } else {
             panic!("This was not an SOA record"); // valid panic, never should happen
@@ -253,7 +253,7 @@ impl Authority {
             return 0;
         };
 
-        let serial = if let &mut RData::SOA(ref mut soa_rdata) = soa.get_rdata_mut() {
+        let serial = if let &mut RData::SOA(ref mut soa_rdata) = soa.rdata_mut() {
             soa_rdata.increment_serial();
             soa_rdata.serial()
         } else {
@@ -358,23 +358,23 @@ impl Authority {
         //           if (zone_rrset<rrset.name, rrset.type> != rrset)
         //                return (NXRRSET)
         for require in pre_requisites {
-            if require.get_ttl() != 0 {
+            if require.ttl() != 0 {
                 warn!("ttl must be 0 for: {:?}", require);
                 return Err(ResponseCode::FormErr);
             }
 
-            if !self.origin.zone_of(require.get_name()) {
-                warn!("{} is not a zone_of {}", require.get_name(), self.origin);
+            if !self.origin.zone_of(require.name()) {
+                warn!("{} is not a zone_of {}", require.name(), self.origin);
                 return Err(ResponseCode::NotZone);
             }
 
-            match require.get_dns_class() {
+            match require.dns_class() {
         DNSClass::ANY =>
-          if let &RData::NULL( .. ) = require.get_rdata() {
-            match require.get_rr_type() {
+          if let &RData::NULL( .. ) = require.rdata() {
+            match require.rr_type() {
               // ANY      ANY      empty    Name is in use
               RecordType::ANY => {
-                if self.lookup(require.get_name(), RecordType::ANY, false, SupportedAlgorithms::new()).is_empty() {
+                if self.lookup(require.name(), RecordType::ANY, false, SupportedAlgorithms::new()).is_empty() {
                   return Err(ResponseCode::NXDomain);
                 } else {
                   continue;
@@ -382,7 +382,7 @@ impl Authority {
               },
               // ANY      rrset    empty    RRset exists (value independent)
               rrset @ _ => {
-                if self.lookup(require.get_name(), rrset, false, SupportedAlgorithms::new()).is_empty() {
+                if self.lookup(require.name(), rrset, false, SupportedAlgorithms::new()).is_empty() {
                   return Err(ResponseCode::NXRRSet);
                 } else {
                   continue;
@@ -394,11 +394,11 @@ impl Authority {
           }
         ,
         DNSClass::NONE =>
-          if let &RData::NULL( .. ) = require.get_rdata() {
-            match require.get_rr_type() {
+          if let &RData::NULL( .. ) = require.rdata() {
+            match require.rr_type() {
               // NONE     ANY      empty    Name is not in use
               RecordType::ANY => {
-                if !self.lookup(require.get_name(), RecordType::ANY, false, SupportedAlgorithms::new()).is_empty() {
+                if !self.lookup(require.name(), RecordType::ANY, false, SupportedAlgorithms::new()).is_empty() {
                   return Err(ResponseCode::YXDomain);
                 } else {
                   continue;
@@ -406,7 +406,7 @@ impl Authority {
               },
               // NONE     rrset    empty    RRset does not exist
               rrset @ _ => {
-                if !self.lookup(require.get_name(), rrset, false, SupportedAlgorithms::new()).is_empty() {
+                if !self.lookup(require.name(), rrset, false, SupportedAlgorithms::new()).is_empty() {
                   return Err(ResponseCode::YXRRSet);
                 } else {
                   continue;
@@ -419,7 +419,7 @@ impl Authority {
         ,
         class @ _ if class == self.class =>
           // zone     rrset    rr       RRset exists (value dependent)
-          if self.lookup(require.get_name(), require.get_rr_type(), false, SupportedAlgorithms::new())
+          if self.lookup(require.name(), require.rr_type(), false, SupportedAlgorithms::new())
                  .iter()
                  .filter(|rr| *rr == &require)
                  .next()
@@ -481,7 +481,7 @@ impl Authority {
         debug!("authorizing with: {:?}", sig0s);
         if !sig0s.is_empty() &&
            sig0s.iter()
-            .filter_map(|sig0| if let &RData::SIG(ref sig) = sig0.get_rdata() {
+            .filter_map(|sig0| if let &RData::SIG(ref sig) = sig0.rdata() {
                 Some(sig)
             } else {
                 None
@@ -491,7 +491,7 @@ impl Authority {
                 let keys = self.lookup(name, RecordType::KEY, false, SupportedAlgorithms::new());
                 debug!("found keys {:?}", keys);
                 keys.iter()
-                    .filter_map(|rr_set| if let &RData::KEY(ref key) = rr_set.get_rdata() {
+                    .filter_map(|rr_set| if let &RData::KEY(ref key) = rr_set.rdata() {
                         Some(key)
                     } else {
                         None
@@ -581,13 +581,13 @@ impl Authority {
         //           else
         //                return (FORMERR)
         for rr in records {
-            if !self.get_origin().zone_of(rr.get_name()) {
+            if !self.get_origin().zone_of(rr.name()) {
                 return Err(ResponseCode::NotZone);
             }
 
-            let class: DNSClass = rr.get_dns_class();
+            let class: DNSClass = rr.dns_class();
             if class == self.class {
-                match rr.get_rr_type() {
+                match rr.rr_type() {
                     RecordType::ANY | RecordType::AXFR | RecordType::IXFR => {
                         return Err(ResponseCode::FormErr)
                     }
@@ -596,15 +596,15 @@ impl Authority {
             } else {
                 match class {
                     DNSClass::ANY => {
-                        if rr.get_ttl() != 0 {
+                        if rr.ttl() != 0 {
                             return Err(ResponseCode::FormErr);
                         }
-                        if let &RData::NULL(..) = rr.get_rdata() {
+                        if let &RData::NULL(..) = rr.rdata() {
                             ()
                         } else {
                             return Err(ResponseCode::FormErr);
                         }
-                        match rr.get_rr_type() {
+                        match rr.rr_type() {
                             RecordType::AXFR | RecordType::IXFR => {
                                 return Err(ResponseCode::FormErr)
                             }
@@ -612,10 +612,10 @@ impl Authority {
                         }
                     }
                     DNSClass::NONE => {
-                        if rr.get_ttl() != 0 {
+                        if rr.ttl() != 0 {
                             return Err(ResponseCode::FormErr);
                         }
-                        match rr.get_rr_type() {
+                        match rr.rr_type() {
                             RecordType::ANY | RecordType::AXFR | RecordType::IXFR => {
                                 return Err(ResponseCode::FormErr)
                             }
@@ -707,9 +707,9 @@ impl Authority {
         //                zone_rr<rr.name, rr.type, rr.data> = Nil
         //      return (NOERROR)
         for rr in records {
-            let rr_key = RrKey::new(rr.get_name(), rr.get_rr_type());
+            let rr_key = RrKey::new(rr.name(), rr.rr_type());
 
-            match rr.get_dns_class() {
+            match rr.dns_class() {
                 class @ _ if class == self.class => {
                     // RFC 2136 - 3.4.2.2. Any Update RR whose CLASS is the same as ZCLASS is added to
                     //  the zone.  In case of duplicate RDATAs (which for SOA RRs is always
@@ -728,9 +728,9 @@ impl Authority {
                 }
                 DNSClass::ANY => {
                     // This is a delete of entire RRSETs, either many or one. In either case, the spec is clear:
-                    match rr.get_rr_type() {
+                    match rr.rr_type() {
                         t @ RecordType::SOA |
-                        t @ RecordType::NS if rr.get_name() == &self.origin => {
+                        t @ RecordType::NS if rr.name() == &self.origin => {
                             // SOA and NS records are not to be deleted if they are the origin records
                             info!("skipping delete of {:?} see RFC 2136 - 3.4.2.3", t);
                             continue;
@@ -743,7 +743,7 @@ impl Authority {
 
                             // ANY      ANY      empty    Delete all RRsets from a name
                             info!("deleting all records at name (not SOA or NS at origin): {:?}",
-                                  rr.get_name());
+                                  rr.name());
                             let to_delete = self.records
                                 .keys()
                                 .filter(|k| {
@@ -751,7 +751,7 @@ impl Authority {
                                        k.record_type == RecordType::NS) &&
                                       k.name != self.origin)
                                 })
-                                .filter(|k| &k.name == rr.get_name())
+                                .filter(|k| &k.name == rr.name())
                                 .cloned()
                                 .collect::<Vec<RrKey>>();
                             for delete in to_delete {
@@ -766,7 +766,7 @@ impl Authority {
                             //   SOA or NS RRs will be deleted.
 
                             // ANY      rrset    empty    Delete an RRset
-                            if let &RData::NULL(..) = rr.get_rdata() {
+                            if let &RData::NULL(..) = rr.rdata() {
                                 let deleted = self.records.remove(&rr_key);
                                 info!("deleted rrset: {:?}", deleted);
                                 updated = updated || deleted.is_some();
@@ -823,12 +823,12 @@ impl Authority {
     ///
     /// Ok() on success or Err() with the `ResponseCode` associated with the error.
     pub fn upsert(&mut self, record: Record, serial: u32) -> bool {
-        assert_eq!(self.class, record.get_dns_class());
+        assert_eq!(self.class, record.dns_class());
 
-        let rr_key = RrKey::new(record.get_name(), record.get_rr_type());
+        let rr_key = RrKey::new(record.name(), record.rr_type());
         let records: &mut RecordSet = self.records
             .entry(rr_key)
-            .or_insert(RecordSet::new(record.get_name(), record.get_rr_type(), serial));
+            .or_insert(RecordSet::new(record.name(), record.rr_type(), serial));
 
         records.insert(record, serial)
     }
@@ -1072,7 +1072,7 @@ impl Authority {
                         // names aren't equal, create the NSEC record
                         let mut record = Record::with(name.clone(), RecordType::NSEC, ttl);
                         let rdata = NSEC::new(key.name.clone(), vec);
-                        record.rdata(RData::NSEC(rdata));
+                        record.set_rdata(RData::NSEC(rdata));
                         records.push(record);
 
                         // new record...
@@ -1086,7 +1086,7 @@ impl Authority {
                 // names aren't equal, create the NSEC record
                 let mut record = Record::with(name.clone(), RecordType::NSEC, ttl);
                 let rdata = NSEC::new(self.get_origin().clone(), vec);
-                record.rdata(RData::NSEC(rdata));
+                record.set_rdata(RData::NSEC(rdata));
                 records.push(record);
             }
         }
@@ -1158,7 +1158,7 @@ impl Authority {
                 let signature = signature.unwrap();
 
                 let mut rrsig = rrsig_temp.clone();
-                rrsig.rdata(RData::SIG(SIG::new(// type_covered: RecordType,
+                rrsig.set_rdata(RData::SIG(SIG::new(// type_covered: RecordType,
                                                 rr_set.get_record_type(),
                                                 // algorithm: Algorithm,
                                                 signer.algorithm(),

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -497,8 +497,8 @@ impl Authority {
                         None
                     })
                     .any(|key| {
-                        let pkey = KeyPair::from_public_bytes(key.get_public_key(),
-                                                              *key.get_algorithm());
+                        let pkey = KeyPair::from_public_bytes(key.public_key(),
+                                                              *key.algorithm());
                         if let Err(error) = pkey {
                             warn!("public key {:?} of {} could not be used: {}",
                                   key,
@@ -508,7 +508,7 @@ impl Authority {
                         }
 
                         let pkey = pkey.unwrap();
-                        let signer: Signer = Signer::new_verifier(*key.get_algorithm(),
+                        let signer: Signer = Signer::new_verifier(*key.algorithm(),
                                                                   pkey,
                                                                   sig.get_signer_name().clone(),
                                                                   false,

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -915,7 +915,7 @@ impl Authority {
                   is_secure: bool,
                   supported_algorithms: SupportedAlgorithms)
                   -> Vec<&Record> {
-        let record_type: RecordType = query.get_query_type();
+        let record_type: RecordType = query.query_type();
 
         // if this is an AXFR zone transfer, verify that this is either the slave or master
         //  for AXFR the first and last record must be the SOA
@@ -929,7 +929,7 @@ impl Authority {
 
         // it would be better to stream this back, rather than packaging everything up in an array
         //  though for UDP it would still need to be bundled
-        let mut query_result: Vec<_> = self.lookup(query.get_name(),
+        let mut query_result: Vec<_> = self.lookup(query.name(),
                                                    record_type,
                                                    is_secure,
                                                    supported_algorithms);

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -89,7 +89,7 @@ impl Authority {
     pub fn add_secure_key(&mut self, signer: Signer) -> DnsSecResult<()> {
         // also add the key to the zone
         let zone_ttl = self.get_minimum_ttl();
-        let dnskey = try!(signer.get_key().to_dnskey(signer.get_algorithm()));
+        let dnskey = try!(signer.key().to_dnskey(signer.algorithm()));
         let dnskey = Record::from_rdata(self.origin.clone(),
                                         zone_ttl,
                                         RecordType::DNSKEY,
@@ -1122,19 +1122,19 @@ impl Authority {
             let rrsig_temp = Record::with(rr_set.get_name().clone(), RecordType::RRSIG, zone_ttl);
 
             for signer in self.secure_keys.iter() {
-                let expiration = inception + signer.get_sig_duration();
+                let expiration = inception + signer.sig_duration();
 
                 let hash =
                     signer.hash_rrset(rr_set.get_name(),
                                       self.class,
                                       rr_set.get_name().num_labels(),
                                       rr_set.get_record_type(),
-                                      signer.get_algorithm(),
+                                      signer.algorithm(),
                                       rr_set.get_ttl(),
                                       expiration.timestamp() as u32,
                                       inception.timestamp() as u32,
                                       try!(signer.calculate_key_tag()),
-                                      signer.get_signer_name(),
+                                      signer.signer_name(),
                                       // TODO: this is a nasty clone... the issue is that the vec
                                       //  from get_records is of Vec<&R>, but we really want &[R]
                                       &rr_set.get_records(false, SupportedAlgorithms::new())
@@ -1161,7 +1161,7 @@ impl Authority {
                 rrsig.rdata(RData::SIG(SIG::new(// type_covered: RecordType,
                                                 rr_set.get_record_type(),
                                                 // algorithm: Algorithm,
-                                                signer.get_algorithm(),
+                                                signer.algorithm(),
                                                 // num_labels: u8,
                                                 rr_set.get_name().num_labels(),
                                                 // original_ttl: u32,
@@ -1173,7 +1173,7 @@ impl Authority {
                                                 // key_tag: u16,
                                                 try!(signer.calculate_key_tag()),
                                                 // signer_name: Name,
-                                                signer.get_signer_name().clone(),
+                                                signer.signer_name().clone(),
                                                 // sig: Vec<u8>
                                                 signature)));
 

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -477,7 +477,7 @@ impl Authority {
         }
 
         // verify sig0, currently the only authorization that is accepted.
-        let sig0s: &[Record] = update_message.get_sig0();
+        let sig0s: &[Record] = update_message.sig0();
         debug!("authorizing with: {:?}", sig0s);
         if !sig0s.is_empty() &&
            sig0s.iter()
@@ -528,7 +528,7 @@ impl Authority {
             return Ok(());
         } else {
             warn!("no sig0 matched registered records: id {}",
-                  update_message.get_id());
+                  update_message.id());
         }
 
         // getting here, we will always default to rejecting the request
@@ -893,10 +893,10 @@ impl Authority {
     pub fn update(&mut self, update: &Message) -> UpdateResult<bool> {
         // the spec says to authorize after prereqs, seems better to auth first.
         try!(self.authorize(update));
-        try!(self.verify_prerequisites(update.get_pre_requisites()));
-        try!(self.pre_scan(update.get_updates()));
+        try!(self.verify_prerequisites(update.prerequisites()));
+        try!(self.pre_scan(update.updates()));
 
-        self.update_records(update.get_updates(), true)
+        self.update_records(update.updates(), true)
     }
 
     /// Using the specified query, perform a lookup against this zone.

--- a/server/src/authority/catalog.rs
+++ b/server/src/authority/catalog.rs
@@ -210,12 +210,12 @@ impl Catalog {
         //  therefore the Zone Section is allowed to contain exactly one record.
         //  The ZNAME is the zone name, the ZTYPE must be SOA, and the ZCLASS is
         //  the zone's class.
-        if zones.len() != 1 || zones[0].get_query_type() != RecordType::SOA {
+        if zones.len() != 1 || zones[0].query_type() != RecordType::SOA {
             response.set_response_code(ResponseCode::FormErr);
             return response;
         }
 
-        if let Some(authority) = self.find_auth_recurse(zones[0].get_name()) {
+        if let Some(authority) = self.find_auth_recurse(zones[0].name()) {
             let mut authority = authority.write().unwrap(); // poison errors should panic...
             match authority.get_zone_type() {
                 ZoneType::Slave => {
@@ -262,7 +262,7 @@ impl Catalog {
         // TODO: the spec is very unclear on what to do with multiple queries
         //  we will search for each, in the future, maybe make this threaded to respond even faster.
         for query in request.queries() {
-            if let Some(ref_authority) = self.find_auth_recurse(query.get_name()) {
+            if let Some(ref_authority) = self.find_auth_recurse(query.name()) {
                 let authority = &ref_authority.read().unwrap(); // poison errors should panic
                 debug!("found authority: {:?}", authority.get_origin());
                 let (is_dnssec, supported_algorithms) = request.edns()
@@ -294,7 +294,7 @@ impl Catalog {
                     if is_dnssec {
                         // get NSEC records
                         let nsecs =
-                            authority.get_nsec_records(query.get_name(),
+                            authority.get_nsec_records(query.name(),
                                                        is_dnssec,
                                                        supported_algorithms);
                         response.add_name_servers(nsecs.into_iter().cloned());

--- a/server/src/authority/catalog.rs
+++ b/server/src/authority/catalog.rs
@@ -40,17 +40,17 @@ impl RequestHandler for Catalog {
     /// * `request` - the requested action to perform.
     fn handle_request(&self, request: &Message) -> Message {
         info!("request id: {} type: {:?} op_code: {:?}",
-              request.get_id(),
-              request.get_message_type(),
-              request.get_op_code());
+              request.id(),
+              request.message_type(),
+              request.op_code());
         debug!("request: {:?}", request);
 
         let mut resp_edns_opt: Option<Edns> = None;
 
         // check if it's edns
-        if let Some(req_edns) = request.get_edns() {
+        if let Some(req_edns) = request.edns() {
             let mut response = Message::new();
-            response.id(request.get_id());
+            response.set_id(request.id());
 
             let mut resp_edns: Edns = Edns::new();
 
@@ -69,7 +69,7 @@ impl RequestHandler for Catalog {
                 warn!("request edns version greater than {}: {}",
                       our_version,
                       req_edns.get_version());
-                response.response_code(ResponseCode::BADVERS);
+                response.set_response_code(ResponseCode::BADVERS);
                 response.set_edns(resp_edns);
                 return response;
             }
@@ -81,11 +81,11 @@ impl RequestHandler for Catalog {
             resp_edns_opt = Some(resp_edns);
         }
 
-        let mut response: Message = match request.get_message_type() {
+        let mut response: Message = match request.message_type() {
             // TODO think about threading query lookups for multiple lookups, this could be a huge improvement
             //  especially for recursive lookups
             MessageType::Query => {
-                match request.get_op_code() {
+                match request.op_code() {
                     OpCode::Query => {
                         let response = self.lookup(&request);
                         debug!("query response: {:?}", response);
@@ -100,16 +100,16 @@ impl RequestHandler for Catalog {
                     }
                     c @ _ => {
                         error!("unimplemented op_code: {:?}", c);
-                        Message::error_msg(request.get_id(),
-                                           request.get_op_code(),
+                        Message::error_msg(request.id(),
+                                           request.op_code(),
                                            ResponseCode::NotImp)
                     }
                 }
             }
             MessageType::Response => {
-                warn!("got a response as a request from id: {}", request.get_id());
-                Message::error_msg(request.get_id(),
-                                   request.get_op_code(),
+                warn!("got a response as a request from id: {}", request.id());
+                Message::error_msg(request.id(),
+                                   request.op_code(),
                                    ResponseCode::NotImp)
             }
         };
@@ -198,11 +198,11 @@ impl Catalog {
     /// * `request` - an update message
     pub fn update(&self, update: &Message) -> Message {
         let mut response: Message = Message::new();
-        response.id(update.get_id());
-        response.op_code(OpCode::Update);
-        response.message_type(MessageType::Response);
+        response.set_id(update.id());
+        response.set_op_code(OpCode::Update);
+        response.set_message_type(MessageType::Response);
 
-        let zones: &[Query] = update.get_zones();
+        let zones: &[Query] = update.zones();
 
         // 2.3 - Zone Section
         //
@@ -211,7 +211,7 @@ impl Catalog {
         //  The ZNAME is the zone name, the ZTYPE must be SOA, and the ZCLASS is
         //  the zone's class.
         if zones.len() != 1 || zones[0].get_query_type() != RecordType::SOA {
-            response.response_code(ResponseCode::FormErr);
+            response.set_response_code(ResponseCode::FormErr);
             return response;
         }
 
@@ -220,7 +220,7 @@ impl Catalog {
             match authority.get_zone_type() {
                 ZoneType::Slave => {
                     error!("slave forwarding for update not yet implemented");
-                    response.response_code(ResponseCode::NotImp);
+                    response.set_response_code(ResponseCode::NotImp);
                     return response;
                 }
                 ZoneType::Master => {
@@ -228,21 +228,21 @@ impl Catalog {
                     match update_result {
                         // successful update
                         Ok(..) => {
-                            response.response_code(ResponseCode::NoError);
+                            response.set_response_code(ResponseCode::NoError);
                         }
                         Err(response_code) => {
-                            response.response_code(response_code);
+                            response.set_response_code(response_code);
                         }
                     }
                     return response;
                 }
                 _ => {
-                    response.response_code(ResponseCode::NotAuth);
+                    response.set_response_code(ResponseCode::NotAuth);
                     return response;
                 }
             }
         } else {
-            response.response_code(ResponseCode::NXDomain);
+            response.set_response_code(ResponseCode::NXDomain);
             response
         }
     }
@@ -254,18 +254,18 @@ impl Catalog {
     /// * `request` - the query message.
     pub fn lookup(&self, request: &Message) -> Message {
         let mut response: Message = Message::new();
-        response.id(request.get_id());
-        response.op_code(OpCode::Query);
-        response.message_type(MessageType::Response);
-        response.add_queries(request.get_queries().into_iter().cloned());
+        response.set_id(request.id());
+        response.set_op_code(OpCode::Query);
+        response.set_message_type(MessageType::Response);
+        response.add_queries(request.queries().into_iter().cloned());
 
         // TODO: the spec is very unclear on what to do with multiple queries
         //  we will search for each, in the future, maybe make this threaded to respond even faster.
-        for query in request.get_queries() {
+        for query in request.queries() {
             if let Some(ref_authority) = self.find_auth_recurse(query.get_name()) {
                 let authority = &ref_authority.read().unwrap(); // poison errors should panic
                 debug!("found authority: {:?}", authority.get_origin());
-                let (is_dnssec, supported_algorithms) = request.get_edns()
+                let (is_dnssec, supported_algorithms) = request.edns()
                     .map_or((false, SupportedAlgorithms::new()), |edns| {
                         let supported_algorithms = if let Some(&EdnsOption::DAU(algs)) =
                             edns.get_option(&EdnsCode::DAU) {
@@ -279,8 +279,8 @@ impl Catalog {
 
                 let records = authority.search(query, is_dnssec, supported_algorithms);
                 if !records.is_empty() {
-                    response.response_code(ResponseCode::NoError);
-                    response.authoritative(true);
+                    response.set_response_code(ResponseCode::NoError);
+                    response.set_authoritative(true);
                     response.add_answers(records.into_iter().cloned());
 
                     // get the NS records
@@ -301,7 +301,7 @@ impl Catalog {
                     }
 
                     // in the not found case it's standard to return the SOA in the authority section
-                    response.response_code(ResponseCode::NXDomain);
+                    response.set_response_code(ResponseCode::NXDomain);
 
                     let soa = authority.get_soa_secure(is_dnssec, supported_algorithms);
                     if soa.is_empty() {
@@ -312,7 +312,7 @@ impl Catalog {
                 }
             } else {
                 // we found nothing.
-                response.response_code(ResponseCode::NXDomain);
+                response.set_response_code(ResponseCode::NXDomain);
             }
         }
 

--- a/server/src/authority/catalog.rs
+++ b/server/src/authority/catalog.rs
@@ -58,17 +58,17 @@ impl RequestHandler for Catalog {
             // TODO: what version are we?
             let our_version = 0;
             resp_edns.set_dnssec_ok(true);
-            resp_edns.set_max_payload(if req_edns.get_max_payload() < 512 {
+            resp_edns.set_max_payload(if req_edns.max_payload() < 512 {
                 512
             } else {
-                req_edns.get_max_payload()
+                req_edns.max_payload()
             });
             resp_edns.set_version(our_version);
 
-            if req_edns.get_version() > our_version {
+            if req_edns.version() > our_version {
                 warn!("request edns version greater than {}: {}",
                       our_version,
-                      req_edns.get_version());
+                      req_edns.version());
                 response.set_response_code(ResponseCode::BADVERS);
                 response.set_edns(resp_edns);
                 return response;
@@ -268,13 +268,13 @@ impl Catalog {
                 let (is_dnssec, supported_algorithms) = request.edns()
                     .map_or((false, SupportedAlgorithms::new()), |edns| {
                         let supported_algorithms = if let Some(&EdnsOption::DAU(algs)) =
-                            edns.get_option(&EdnsCode::DAU) {
+                            edns.option(&EdnsCode::DAU) {
                             algs
                         } else {
                             Default::default()
                         };
 
-                        (edns.is_dnssec_ok(), supported_algorithms)
+                        (edns.dnssec_ok(), supported_algorithms)
                     });
 
                 let records = authority.search(query, is_dnssec, supported_algorithms);

--- a/server/src/server/request_stream.rs
+++ b/server/src/server/request_stream.rs
@@ -60,7 +60,7 @@ impl<S> Stream for RequestStream<S>
                     let mut decoder = BinDecoder::new(&buffer);
                     match Message::read(&mut decoder) {
                         Ok(message) => {
-                            debug!("received message: {}", message.get_id());
+                            debug!("received message: {}", message.id());
                             let request = Request {
                                 message: message,
                                 src: addr,
@@ -93,7 +93,7 @@ pub struct ResponseHandle {
 impl ResponseHandle {
     /// Serializes and sends a message to to the wrapped handle
     pub fn send(&mut self, response: Message) -> io::Result<()> {
-        debug!("sending message: {}", response.get_id());
+        debug!("sending message: {}", response.id());
         let mut buffer = Vec::with_capacity(512);
         let encode_result = {
             let mut encoder: BinEncoder = BinEncoder::new(&mut buffer);

--- a/server/tests/authority_tests.rs
+++ b/server/tests/authority_tests.rs
@@ -134,7 +134,7 @@ fn test_authorize() {
     let authority: Authority = create_example();
 
     let mut message = Message::new();
-    message.id(10).message_type(MessageType::Query).op_code(OpCode::Update);
+    message.set_id(10).set_message_type(MessageType::Query).set_op_code(OpCode::Update);
 
     assert_eq!(authority.authorize(&message), Err(ResponseCode::Refused));
 

--- a/server/tests/authority_tests.rs
+++ b/server/tests/authority_tests.rs
@@ -683,7 +683,7 @@ fn test_zone_signing() {
         assert!(results.iter().any(|r| {
             r.get_rr_type() == RecordType::RRSIG && r.get_name() == record.get_name() &&
             if let &RData::SIG(ref rrsig) = r.get_rdata() {
-                rrsig.get_type_covered() == record.get_rr_type()
+                rrsig.type_covered() == record.get_rr_type()
             } else {
                 false
             }

--- a/server/tests/authority_tests.rs
+++ b/server/tests/authority_tests.rs
@@ -63,7 +63,7 @@ fn test_authority() {
     let authority: Authority = create_example();
 
     assert!(authority.get_soa().is_some());
-    assert_eq!(authority.get_soa().unwrap().get_dns_class(), DNSClass::IN);
+    assert_eq!(authority.get_soa().unwrap().dns_class(), DNSClass::IN);
 
     assert!(!authority.lookup(authority.get_origin(),
                 RecordType::NS,
@@ -76,19 +76,19 @@ fn test_authority() {
 
     assert_eq!(**lookup.first().unwrap(),
                Record::new()
-                   .name(authority.get_origin().clone())
-                   .ttl(86400)
-                   .rr_type(RecordType::NS)
-                   .dns_class(DNSClass::IN)
-                   .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                   .set_name(authority.get_origin().clone())
+                   .set_ttl(86400)
+                   .set_rr_type(RecordType::NS)
+                   .set_dns_class(DNSClass::IN)
+                   .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                    .clone());
     assert_eq!(**lookup.last().unwrap(),
                Record::new()
-                   .name(authority.get_origin().clone())
-                   .ttl(86400)
-                   .rr_type(RecordType::NS)
-                   .dns_class(DNSClass::IN)
-                   .rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                   .set_name(authority.get_origin().clone())
+                   .set_ttl(86400)
+                   .set_rr_type(RecordType::NS)
+                   .set_dns_class(DNSClass::IN)
+                   .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
                    .clone());
 
     assert!(!authority.lookup(authority.get_origin(),
@@ -105,11 +105,11 @@ fn test_authority() {
 
     assert_eq!(**lookup.first().unwrap(),
                Record::new()
-                   .name(authority.get_origin().clone())
-                   .ttl(60)
-                   .rr_type(RecordType::TXT)
-                   .dns_class(DNSClass::IN)
-                   .rdata(RData::TXT(TXT::new(vec!["$Id: example.com 4415 2015-08-24 \
+                   .set_name(authority.get_origin().clone())
+                   .set_ttl(60)
+                   .set_rr_type(RecordType::TXT)
+                   .set_dns_class(DNSClass::IN)
+                   .set_rdata(RData::TXT(TXT::new(vec!["$Id: example.com 4415 2015-08-24 \
                                                     20:12:23Z davids $"
                                                        .to_string()])))
                    .clone());
@@ -121,11 +121,11 @@ fn test_authority() {
                    .first()
                    .unwrap(),
                Record::new()
-                   .name(authority.get_origin().clone())
-                   .ttl(86400)
-                   .rr_type(RecordType::A)
-                   .dns_class(DNSClass::IN)
-                   .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                   .set_name(authority.get_origin().clone())
+                   .set_ttl(86400)
+                   .set_rr_type(RecordType::A)
+                   .set_dns_class(DNSClass::IN)
+                   .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
                    .clone());
 }
 
@@ -153,137 +153,137 @@ fn test_prerequisites() {
 
     // first check the initial negatives, ttl = 0, and the zone is the same
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(not_in_zone.clone())
-                                                    .ttl(86400)
-                                                    .rr_type(RecordType::A)
-                                                    .dns_class(DNSClass::IN)
-                                                    .rdata(RData::NULL(NULL::new()))
+                                                    .set_name(not_in_zone.clone())
+                                                    .set_ttl(86400)
+                                                    .set_rr_type(RecordType::A)
+                                                    .set_dns_class(DNSClass::IN)
+                                                    .set_rdata(RData::NULL(NULL::new()))
                                                     .clone()]),
                Err(ResponseCode::FormErr));
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(not_zone.clone())
-                                                    .ttl(0)
-                                                    .rr_type(RecordType::A)
-                                                    .dns_class(DNSClass::IN)
-                                                    .rdata(RData::NULL(NULL::new()))
+                                                    .set_name(not_zone.clone())
+                                                    .set_ttl(0)
+                                                    .set_rr_type(RecordType::A)
+                                                    .set_dns_class(DNSClass::IN)
+                                                    .set_rdata(RData::NULL(NULL::new()))
                                                     .clone()]),
                Err(ResponseCode::NotZone));
 
     // *   ANY      ANY      empty    Name is in use
     assert!(authority.verify_prerequisites(&[Record::new()
-                                    .name(authority.get_origin().clone())
-                                    .ttl(0)
-                                    .dns_class(DNSClass::ANY)
-                                    .rr_type(RecordType::ANY)
-                                    .rdata(RData::NULL(NULL::new()))
+                                    .set_name(authority.get_origin().clone())
+                                    .set_ttl(0)
+                                    .set_dns_class(DNSClass::ANY)
+                                    .set_rr_type(RecordType::ANY)
+                                    .set_rdata(RData::NULL(NULL::new()))
                                     .clone()])
         .is_ok());
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(not_in_zone.clone())
-                                                    .ttl(0)
-                                                    .dns_class(DNSClass::ANY)
-                                                    .rr_type(RecordType::ANY)
-                                                    .rdata(RData::NULL(NULL::new()))
+                                                    .set_name(not_in_zone.clone())
+                                                    .set_ttl(0)
+                                                    .set_dns_class(DNSClass::ANY)
+                                                    .set_rr_type(RecordType::ANY)
+                                                    .set_rdata(RData::NULL(NULL::new()))
                                                     .clone()]),
                Err(ResponseCode::NXDomain));
 
     // *   ANY      rrset    empty    RRset exists (value independent)
     assert!(authority.verify_prerequisites(&[Record::new()
-                                    .name(authority.get_origin().clone())
-                                    .ttl(0)
-                                    .dns_class(DNSClass::ANY)
-                                    .rr_type(RecordType::A)
-                                    .rdata(RData::NULL(NULL::new()))
+                                    .set_name(authority.get_origin().clone())
+                                    .set_ttl(0)
+                                    .set_dns_class(DNSClass::ANY)
+                                    .set_rr_type(RecordType::A)
+                                    .set_rdata(RData::NULL(NULL::new()))
                                     .clone()])
         .is_ok());
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(not_in_zone.clone())
-                                                    .ttl(0)
-                                                    .dns_class(DNSClass::ANY)
-                                                    .rr_type(RecordType::A)
-                                                    .rdata(RData::NULL(NULL::new()))
+                                                    .set_name(not_in_zone.clone())
+                                                    .set_ttl(0)
+                                                    .set_dns_class(DNSClass::ANY)
+                                                    .set_rr_type(RecordType::A)
+                                                    .set_rdata(RData::NULL(NULL::new()))
                                                     .clone()]),
                Err(ResponseCode::NXRRSet));
 
     // *   NONE     ANY      empty    Name is not in use
     assert!(authority.verify_prerequisites(&[Record::new()
-                                    .name(not_in_zone.clone())
-                                    .ttl(0)
-                                    .dns_class(DNSClass::NONE)
-                                    .rr_type(RecordType::ANY)
-                                    .rdata(RData::NULL(NULL::new()))
+                                    .set_name(not_in_zone.clone())
+                                    .set_ttl(0)
+                                    .set_dns_class(DNSClass::NONE)
+                                    .set_rr_type(RecordType::ANY)
+                                    .set_rdata(RData::NULL(NULL::new()))
                                     .clone()])
         .is_ok());
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(authority.get_origin().clone())
-                                                    .ttl(0)
-                                                    .dns_class(DNSClass::NONE)
-                                                    .rr_type(RecordType::ANY)
-                                                    .rdata(RData::NULL(NULL::new()))
+                                                    .set_name(authority.get_origin().clone())
+                                                    .set_ttl(0)
+                                                    .set_dns_class(DNSClass::NONE)
+                                                    .set_rr_type(RecordType::ANY)
+                                                    .set_rdata(RData::NULL(NULL::new()))
                                                     .clone()]),
                Err(ResponseCode::YXDomain));
 
     // *   NONE     rrset    empty    RRset does not exist
     assert!(authority.verify_prerequisites(&[Record::new()
-                                    .name(not_in_zone.clone())
-                                    .ttl(0)
-                                    .dns_class(DNSClass::NONE)
-                                    .rr_type(RecordType::A)
-                                    .rdata(RData::NULL(NULL::new()))
+                                    .set_name(not_in_zone.clone())
+                                    .set_ttl(0)
+                                    .set_dns_class(DNSClass::NONE)
+                                    .set_rr_type(RecordType::A)
+                                    .set_rdata(RData::NULL(NULL::new()))
                                     .clone()])
         .is_ok());
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(authority.get_origin().clone())
-                                                    .ttl(0)
-                                                    .dns_class(DNSClass::NONE)
-                                                    .rr_type(RecordType::A)
-                                                    .rdata(RData::NULL(NULL::new()))
+                                                    .set_name(authority.get_origin().clone())
+                                                    .set_ttl(0)
+                                                    .set_dns_class(DNSClass::NONE)
+                                                    .set_rr_type(RecordType::A)
+                                                    .set_rdata(RData::NULL(NULL::new()))
                                                     .clone()]),
                Err(ResponseCode::YXRRSet));
 
     // *   zone     rrset    rr       RRset exists (value dependent)
     assert!(authority.verify_prerequisites(&[Record::new()
-                                    .name(authority.get_origin().clone())
-                                    .ttl(0)
-                                    .dns_class(DNSClass::IN)
-                                    .rr_type(RecordType::A)
-                                    .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                                    .set_name(authority.get_origin().clone())
+                                    .set_ttl(0)
+                                    .set_dns_class(DNSClass::IN)
+                                    .set_rr_type(RecordType::A)
+                                    .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
                                     .clone()])
         .is_ok());
     // wrong class
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(authority.get_origin().clone())
-                                                    .ttl(0)
-                                                    .dns_class(DNSClass::CH)
-                                                    .rr_type(RecordType::A)
-                                                    .rdata(RData::A(Ipv4Addr::new(93,
-                                                                                  184,
-                                                                                  216,
-                                                                                  34)))
+                                                    .set_name(authority.get_origin().clone())
+                                                    .set_ttl(0)
+                                                    .set_dns_class(DNSClass::CH)
+                                                    .set_rr_type(RecordType::A)
+                                                    .set_rdata(RData::A(Ipv4Addr::new(93,
+                                                                                      184,
+                                                                                      216,
+                                                                                      34)))
                                                     .clone()]),
                Err(ResponseCode::FormErr));
     // wrong Name
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(not_in_zone.clone())
-                                                    .ttl(0)
-                                                    .dns_class(DNSClass::IN)
-                                                    .rr_type(RecordType::A)
-                                                    .rdata(RData::A(Ipv4Addr::new(93,
-                                                                                  184,
-                                                                                  216,
-                                                                                  24)))
+                                                    .set_name(not_in_zone.clone())
+                                                    .set_ttl(0)
+                                                    .set_dns_class(DNSClass::IN)
+                                                    .set_rr_type(RecordType::A)
+                                                    .set_rdata(RData::A(Ipv4Addr::new(93,
+                                                                                      184,
+                                                                                      216,
+                                                                                      24)))
                                                     .clone()]),
                Err(ResponseCode::NXRRSet));
     // wrong IP
     assert_eq!(authority.verify_prerequisites(&[Record::new()
-                                                    .name(authority.get_origin().clone())
-                                                    .ttl(0)
-                                                    .dns_class(DNSClass::IN)
-                                                    .rr_type(RecordType::A)
-                                                    .rdata(RData::A(Ipv4Addr::new(93,
-                                                                                  184,
-                                                                                  216,
-                                                                                  24)))
+                                                    .set_name(authority.get_origin().clone())
+                                                    .set_ttl(0)
+                                                    .set_dns_class(DNSClass::IN)
+                                                    .set_rr_type(RecordType::A)
+                                                    .set_rdata(RData::A(Ipv4Addr::new(93,
+                                                                                      184,
+                                                                                      216,
+                                                                                      24)))
                                                     .clone()]),
                Err(ResponseCode::NXRRSet));
 }
@@ -296,159 +296,159 @@ fn test_pre_scan() {
     let authority: Authority = create_example();
 
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(not_zone.clone())
-                                        .ttl(86400)
-                                        .rr_type(RecordType::A)
-                                        .dns_class(DNSClass::IN)
-                                        .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                                        .set_name(not_zone.clone())
+                                        .set_ttl(86400)
+                                        .set_rr_type(RecordType::A)
+                                        .set_dns_class(DNSClass::IN)
+                                        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
                                         .clone()]),
                Err(ResponseCode::NotZone));
 
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(86400)
-                                        .rr_type(RecordType::ANY)
-                                        .dns_class(DNSClass::IN)
-                                        .rdata(RData::NULL(NULL::new()))
+                                        .set_name(up_name.clone())
+                                        .set_ttl(86400)
+                                        .set_rr_type(RecordType::ANY)
+                                        .set_dns_class(DNSClass::IN)
+                                        .set_rdata(RData::NULL(NULL::new()))
                                         .clone()]),
                Err(ResponseCode::FormErr));
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(86400)
-                                        .rr_type(RecordType::AXFR)
-                                        .dns_class(DNSClass::IN)
-                                        .rdata(RData::NULL(NULL::new()))
+                                        .set_name(up_name.clone())
+                                        .set_ttl(86400)
+                                        .set_rr_type(RecordType::AXFR)
+                                        .set_dns_class(DNSClass::IN)
+                                        .set_rdata(RData::NULL(NULL::new()))
                                         .clone()]),
                Err(ResponseCode::FormErr));
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(86400)
-                                        .rr_type(RecordType::IXFR)
-                                        .dns_class(DNSClass::IN)
-                                        .rdata(RData::NULL(NULL::new()))
+                                        .set_name(up_name.clone())
+                                        .set_ttl(86400)
+                                        .set_rr_type(RecordType::IXFR)
+                                        .set_dns_class(DNSClass::IN)
+                                        .set_rdata(RData::NULL(NULL::new()))
                                         .clone()]),
                Err(ResponseCode::FormErr));
     assert!(authority.pre_scan(&[Record::new()
-                        .name(up_name.clone())
-                        .ttl(86400)
-                        .rr_type(RecordType::A)
-                        .dns_class(DNSClass::IN)
-                        .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                        .set_name(up_name.clone())
+                        .set_ttl(86400)
+                        .set_rr_type(RecordType::A)
+                        .set_dns_class(DNSClass::IN)
+                        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
                         .clone()])
         .is_ok());
     assert!(authority.pre_scan(&[Record::new()
-                        .name(up_name.clone())
-                        .ttl(86400)
-                        .rr_type(RecordType::A)
-                        .dns_class(DNSClass::IN)
-                        .rdata(RData::NULL(NULL::new()))
-                        .clone()])
-        .is_ok());
-
-    assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(86400)
-                                        .rr_type(RecordType::A)
-                                        .dns_class(DNSClass::ANY)
-                                        .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
-                                        .clone()]),
-               Err(ResponseCode::FormErr));
-    assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(0)
-                                        .rr_type(RecordType::A)
-                                        .dns_class(DNSClass::ANY)
-                                        .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
-                                        .clone()]),
-               Err(ResponseCode::FormErr));
-    assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(0)
-                                        .rr_type(RecordType::AXFR)
-                                        .dns_class(DNSClass::ANY)
-                                        .rdata(RData::NULL(NULL::new()))
-                                        .clone()]),
-               Err(ResponseCode::FormErr));
-    assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(0)
-                                        .rr_type(RecordType::IXFR)
-                                        .dns_class(DNSClass::ANY)
-                                        .rdata(RData::NULL(NULL::new()))
-                                        .clone()]),
-               Err(ResponseCode::FormErr));
-    assert!(authority.pre_scan(&[Record::new()
-                        .name(up_name.clone())
-                        .ttl(0)
-                        .rr_type(RecordType::ANY)
-                        .dns_class(DNSClass::ANY)
-                        .rdata(RData::NULL(NULL::new()))
-                        .clone()])
-        .is_ok());
-    assert!(authority.pre_scan(&[Record::new()
-                        .name(up_name.clone())
-                        .ttl(0)
-                        .rr_type(RecordType::A)
-                        .dns_class(DNSClass::ANY)
-                        .rdata(RData::NULL(NULL::new()))
+                        .set_name(up_name.clone())
+                        .set_ttl(86400)
+                        .set_rr_type(RecordType::A)
+                        .set_dns_class(DNSClass::IN)
+                        .set_rdata(RData::NULL(NULL::new()))
                         .clone()])
         .is_ok());
 
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(86400)
-                                        .rr_type(RecordType::A)
-                                        .dns_class(DNSClass::NONE)
-                                        .rdata(RData::NULL(NULL::new()))
+                                        .set_name(up_name.clone())
+                                        .set_ttl(86400)
+                                        .set_rr_type(RecordType::A)
+                                        .set_dns_class(DNSClass::ANY)
+                                        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
                                         .clone()]),
                Err(ResponseCode::FormErr));
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(0)
-                                        .rr_type(RecordType::ANY)
-                                        .dns_class(DNSClass::NONE)
-                                        .rdata(RData::NULL(NULL::new()))
+                                        .set_name(up_name.clone())
+                                        .set_ttl(0)
+                                        .set_rr_type(RecordType::A)
+                                        .set_dns_class(DNSClass::ANY)
+                                        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
                                         .clone()]),
                Err(ResponseCode::FormErr));
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(0)
-                                        .rr_type(RecordType::AXFR)
-                                        .dns_class(DNSClass::NONE)
-                                        .rdata(RData::NULL(NULL::new()))
+                                        .set_name(up_name.clone())
+                                        .set_ttl(0)
+                                        .set_rr_type(RecordType::AXFR)
+                                        .set_dns_class(DNSClass::ANY)
+                                        .set_rdata(RData::NULL(NULL::new()))
                                         .clone()]),
                Err(ResponseCode::FormErr));
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(0)
-                                        .rr_type(RecordType::IXFR)
-                                        .dns_class(DNSClass::NONE)
-                                        .rdata(RData::NULL(NULL::new()))
+                                        .set_name(up_name.clone())
+                                        .set_ttl(0)
+                                        .set_rr_type(RecordType::IXFR)
+                                        .set_dns_class(DNSClass::ANY)
+                                        .set_rdata(RData::NULL(NULL::new()))
                                         .clone()]),
                Err(ResponseCode::FormErr));
     assert!(authority.pre_scan(&[Record::new()
-                        .name(up_name.clone())
-                        .ttl(0)
-                        .rr_type(RecordType::A)
-                        .dns_class(DNSClass::NONE)
-                        .rdata(RData::NULL(NULL::new()))
+                        .set_name(up_name.clone())
+                        .set_ttl(0)
+                        .set_rr_type(RecordType::ANY)
+                        .set_dns_class(DNSClass::ANY)
+                        .set_rdata(RData::NULL(NULL::new()))
                         .clone()])
         .is_ok());
     assert!(authority.pre_scan(&[Record::new()
-                        .name(up_name.clone())
-                        .ttl(0)
-                        .rr_type(RecordType::A)
-                        .dns_class(DNSClass::NONE)
-                        .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                        .set_name(up_name.clone())
+                        .set_ttl(0)
+                        .set_rr_type(RecordType::A)
+                        .set_dns_class(DNSClass::ANY)
+                        .set_rdata(RData::NULL(NULL::new()))
                         .clone()])
         .is_ok());
 
     assert_eq!(authority.pre_scan(&[Record::new()
-                                        .name(up_name.clone())
-                                        .ttl(86400)
-                                        .rr_type(RecordType::A)
-                                        .dns_class(DNSClass::CH)
-                                        .rdata(RData::NULL(NULL::new()))
+                                        .set_name(up_name.clone())
+                                        .set_ttl(86400)
+                                        .set_rr_type(RecordType::A)
+                                        .set_dns_class(DNSClass::NONE)
+                                        .set_rdata(RData::NULL(NULL::new()))
+                                        .clone()]),
+               Err(ResponseCode::FormErr));
+    assert_eq!(authority.pre_scan(&[Record::new()
+                                        .set_name(up_name.clone())
+                                        .set_ttl(0)
+                                        .set_rr_type(RecordType::ANY)
+                                        .set_dns_class(DNSClass::NONE)
+                                        .set_rdata(RData::NULL(NULL::new()))
+                                        .clone()]),
+               Err(ResponseCode::FormErr));
+    assert_eq!(authority.pre_scan(&[Record::new()
+                                        .set_name(up_name.clone())
+                                        .set_ttl(0)
+                                        .set_rr_type(RecordType::AXFR)
+                                        .set_dns_class(DNSClass::NONE)
+                                        .set_rdata(RData::NULL(NULL::new()))
+                                        .clone()]),
+               Err(ResponseCode::FormErr));
+    assert_eq!(authority.pre_scan(&[Record::new()
+                                        .set_name(up_name.clone())
+                                        .set_ttl(0)
+                                        .set_rr_type(RecordType::IXFR)
+                                        .set_dns_class(DNSClass::NONE)
+                                        .set_rdata(RData::NULL(NULL::new()))
+                                        .clone()]),
+               Err(ResponseCode::FormErr));
+    assert!(authority.pre_scan(&[Record::new()
+                        .set_name(up_name.clone())
+                        .set_ttl(0)
+                        .set_rr_type(RecordType::A)
+                        .set_dns_class(DNSClass::NONE)
+                        .set_rdata(RData::NULL(NULL::new()))
+                        .clone()])
+        .is_ok());
+    assert!(authority.pre_scan(&[Record::new()
+                        .set_name(up_name.clone())
+                        .set_ttl(0)
+                        .set_rr_type(RecordType::A)
+                        .set_dns_class(DNSClass::NONE)
+                        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                        .clone()])
+        .is_ok());
+
+    assert_eq!(authority.pre_scan(&[Record::new()
+                                        .set_name(up_name.clone())
+                                        .set_ttl(86400)
+                                        .set_rr_type(RecordType::A)
+                                        .set_dns_class(DNSClass::CH)
+                                        .set_rdata(RData::NULL(NULL::new()))
                                         .clone()]),
                Err(ResponseCode::FormErr));
 }
@@ -463,32 +463,32 @@ fn test_update() {
     authority.set_allow_update(true);
 
     let mut original_vec: Vec<Record> = vec![Record::new()
-                 .name(www_name.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::TXT)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()])))
+                 .set_name(www_name.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::TXT)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()])))
                  .clone(),
              Record::new()
-                 .name(www_name.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::A)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                 .set_name(www_name.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::A)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
                  .clone(),
              Record::new()
-                 .name(www_name.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::AAAA)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::AAAA(Ipv6Addr::new(0x2606,
-                                                  0x2800,
-                                                  0x220,
-                                                  0x1,
-                                                  0x248,
-                                                  0x1893,
-                                                  0x25c8,
-                                                  0x1946)))
+                 .set_name(www_name.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::AAAA)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::AAAA(Ipv6Addr::new(0x2606,
+                                                      0x2800,
+                                                      0x220,
+                                                      0x1,
+                                                      0x248,
+                                                      0x1893,
+                                                      0x25c8,
+                                                      0x1946)))
                  .clone()];
 
     original_vec.sort();
@@ -514,11 +514,11 @@ fn test_update() {
     //
     //  zone     rrset    rr       Add to an RRset
     let add_record = &[Record::new()
-                           .name(new_name.clone())
-                           .ttl(86400)
-                           .rr_type(RecordType::A)
-                           .dns_class(DNSClass::IN)
-                           .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                           .set_name(new_name.clone())
+                           .set_ttl(86400)
+                           .set_rr_type(RecordType::A)
+                           .set_dns_class(DNSClass::IN)
+                           .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
                            .clone()];
     assert!(authority.update_records(add_record, true).expect("update failed"));
     assert_eq!(authority.lookup(&new_name,
@@ -529,11 +529,11 @@ fn test_update() {
     assert_eq!(serial + 1, authority.get_serial());
 
     let add_www_record = &[Record::new()
-                               .name(www_name.clone())
-                               .ttl(86400)
-                               .rr_type(RecordType::A)
-                               .dns_class(DNSClass::IN)
-                               .rdata(RData::A(Ipv4Addr::new(10, 0, 0, 1)))
+                               .set_name(www_name.clone())
+                               .set_ttl(86400)
+                               .set_rr_type(RecordType::A)
+                               .set_dns_class(DNSClass::IN)
+                               .set_rdata(RData::A(Ipv4Addr::new(10, 0, 0, 1)))
                                .clone()];
     assert!(authority.update_records(add_www_record, true).expect("update failed"));
     assert_eq!(serial + 2, authority.get_serial());
@@ -554,11 +554,11 @@ fn test_update() {
     //
     //  NONE     rrset    rr       Delete an RR from an RRset
     let del_record = &[Record::new()
-                           .name(new_name.clone())
-                           .ttl(86400)
-                           .rr_type(RecordType::A)
-                           .dns_class(DNSClass::NONE)
-                           .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                           .set_name(new_name.clone())
+                           .set_ttl(86400)
+                           .set_rr_type(RecordType::A)
+                           .set_dns_class(DNSClass::NONE)
+                           .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
                            .clone()];
     assert!(authority.update_records(del_record, true).expect("update failed"));
     assert_eq!(serial + 3, authority.get_serial());
@@ -577,11 +577,11 @@ fn test_update() {
 
     // remove one from www
     let del_record = &[Record::new()
-                           .name(www_name.clone())
-                           .ttl(86400)
-                           .rr_type(RecordType::A)
-                           .dns_class(DNSClass::NONE)
-                           .rdata(RData::A(Ipv4Addr::new(10, 0, 0, 1)))
+                           .set_name(www_name.clone())
+                           .set_ttl(86400)
+                           .set_rr_type(RecordType::A)
+                           .set_dns_class(DNSClass::NONE)
+                           .set_rdata(RData::A(Ipv4Addr::new(10, 0, 0, 1)))
                            .clone()];
     assert!(authority.update_records(del_record, true).expect("update failed"));
     assert_eq!(serial + 4, authority.get_serial());
@@ -598,35 +598,35 @@ fn test_update() {
     //
     //  ANY      rrset    empty    Delete an RRset
     let del_record = &[Record::new()
-                           .name(www_name.clone())
-                           .ttl(86400)
-                           .rr_type(RecordType::A)
-                           .dns_class(DNSClass::ANY)
-                           .rdata(RData::NULL(NULL::new()))
+                           .set_name(www_name.clone())
+                           .set_ttl(86400)
+                           .set_rr_type(RecordType::A)
+                           .set_dns_class(DNSClass::ANY)
+                           .set_rdata(RData::NULL(NULL::new()))
                            .clone()];
     assert!(authority.update_records(del_record, true).expect("update failed"));
     assert_eq!(serial + 5, authority.get_serial());
     let mut removed_a_vec: Vec<_> = vec![Record::new()
-                                             .name(www_name.clone())
-                                             .ttl(86400)
-                                             .rr_type(RecordType::TXT)
-                                             .dns_class(DNSClass::IN)
-                                             .rdata(RData::TXT(TXT::new(vec!["v=spf1 -all"
+                                             .set_name(www_name.clone())
+                                             .set_ttl(86400)
+                                             .set_rr_type(RecordType::TXT)
+                                             .set_dns_class(DNSClass::IN)
+                                             .set_rdata(RData::TXT(TXT::new(vec!["v=spf1 -all"
                                                                                  .to_string()])))
                                              .clone(),
                                          Record::new()
-                                             .name(www_name.clone())
-                                             .ttl(86400)
-                                             .rr_type(RecordType::AAAA)
-                                             .dns_class(DNSClass::IN)
-                                             .rdata(RData::AAAA(Ipv6Addr::new(0x2606,
-                                                                              0x2800,
-                                                                              0x220,
-                                                                              0x1,
-                                                                              0x248,
-                                                                              0x1893,
-                                                                              0x25c8,
-                                                                              0x1946)))
+                                             .set_name(www_name.clone())
+                                             .set_ttl(86400)
+                                             .set_rr_type(RecordType::AAAA)
+                                             .set_dns_class(DNSClass::IN)
+                                             .set_rdata(RData::AAAA(Ipv6Addr::new(0x2606,
+                                                                                  0x2800,
+                                                                                  0x220,
+                                                                                  0x1,
+                                                                                  0x248,
+                                                                                  0x1893,
+                                                                                  0x25c8,
+                                                                                  0x1946)))
                                              .clone()];
     removed_a_vec.sort();
 
@@ -644,11 +644,11 @@ fn test_update() {
     //  ANY      ANY      empty    Delete all RRsets from a name
     println!("deleting all records");
     let del_record = &[Record::new()
-                           .name(www_name.clone())
-                           .ttl(86400)
-                           .rr_type(RecordType::ANY)
-                           .dns_class(DNSClass::ANY)
-                           .rdata(RData::NULL(NULL::new()))
+                           .set_name(www_name.clone())
+                           .set_ttl(86400)
+                           .set_rr_type(RecordType::ANY)
+                           .set_dns_class(DNSClass::ANY)
+                           .set_rdata(RData::NULL(NULL::new()))
                            .clone()];
     assert!(authority.update_records(del_record, true).expect("update failed"));
     assert!(authority.lookup(&www_name,
@@ -719,11 +719,11 @@ fn test_journal() {
     let new_name = Name::new().label("new").label("example").label("com");
     let delete_name = Name::new().label("www").label("example").label("com");
     let new_record =
-        Record::new().name(new_name.clone()).rdata(RData::A(Ipv4Addr::new(10, 11, 12, 13))).clone();
+        Record::new().set_name(new_name.clone()).set_rdata(RData::A(Ipv4Addr::new(10, 11, 12, 13))).clone();
     let delete_record = Record::new()
-        .name(delete_name.clone())
-        .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
-        .dns_class(DNSClass::NONE)
+        .set_name(delete_name.clone())
+        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+        .set_dns_class(DNSClass::NONE)
         .clone();
     authority.update_records(&[new_record.clone(), delete_record], true).unwrap();
 

--- a/server/tests/authority_tests.rs
+++ b/server/tests/authority_tests.rs
@@ -29,9 +29,9 @@ fn test_search() {
 
     let result = example.search(&query, false, SupportedAlgorithms::new());
     if !result.is_empty() {
-        assert_eq!(result.first().unwrap().get_rr_type(), RecordType::A);
-        assert_eq!(result.first().unwrap().get_dns_class(), DNSClass::IN);
-        assert_eq!(result.first().unwrap().get_rdata(),
+        assert_eq!(result.first().unwrap().rr_type(), RecordType::A);
+        assert_eq!(result.first().unwrap().dns_class(), DNSClass::IN);
+        assert_eq!(result.first().unwrap().rdata(),
                    &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
     } else {
         panic!("expected a result"); // valid panic, in test
@@ -49,9 +49,9 @@ fn test_search_www() {
 
     let result = example.search(&query, false, SupportedAlgorithms::new());
     if !result.is_empty() {
-        assert_eq!(result.first().unwrap().get_rr_type(), RecordType::A);
-        assert_eq!(result.first().unwrap().get_dns_class(), DNSClass::IN);
-        assert_eq!(result.first().unwrap().get_rdata(),
+        assert_eq!(result.first().unwrap().rr_type(), RecordType::A);
+        assert_eq!(result.first().unwrap().dns_class(), DNSClass::IN);
+        assert_eq!(result.first().unwrap().rdata(),
                    &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
     } else {
         panic!("expected a result"); // valid panic, in test
@@ -668,22 +668,22 @@ fn test_zone_signing() {
                                    true,
                                    SupportedAlgorithms::all());
 
-    assert!(results.iter().any(|r| r.get_rr_type() == RecordType::DNSKEY),
+    assert!(results.iter().any(|r| r.rr_type() == RecordType::DNSKEY),
             "must contain a DNSKEY");
 
     for record in results.iter() {
-        if record.get_rr_type() == RecordType::RRSIG {
+        if record.rr_type() == RecordType::RRSIG {
             continue;
         }
-        if record.get_rr_type() == RecordType::DNSKEY {
+        if record.rr_type() == RecordType::DNSKEY {
             continue;
         }
 
         // validate all records have associated RRSIGs after signing
         assert!(results.iter().any(|r| {
-            r.get_rr_type() == RecordType::RRSIG && r.get_name() == record.get_name() &&
-            if let &RData::SIG(ref rrsig) = r.get_rdata() {
-                rrsig.type_covered() == record.get_rr_type()
+            r.rr_type() == RecordType::RRSIG && r.name() == record.name() &&
+            if let &RData::SIG(ref rrsig) = r.rdata() {
+                rrsig.type_covered() == record.rr_type()
             } else {
                 false
             }
@@ -701,7 +701,7 @@ fn test_get_nsec() {
     let results = authority.get_nsec_records(&name, true, SupportedAlgorithms::all());
 
     for record in results.iter() {
-        assert!(record.get_name() < &name);
+        assert!(record.name() < &name);
     }
 }
 
@@ -786,8 +786,8 @@ fn test_recovery() {
         let other_rr_set =
             authority.get_records().get(rr_key).expect(&format!("key doesn't exist: {:?}", rr_key));
         rr_set.iter().zip(other_rr_set.iter()).all(|(record, other_record)| {
-            record.get_ttl() == other_record.get_ttl() &&
-            record.get_rdata() == other_record.get_rdata()
+            record.ttl() == other_record.ttl() &&
+            record.rdata() == other_record.rdata()
         })
     }));
 
@@ -796,8 +796,8 @@ fn test_recovery() {
             .get(rr_key)
             .expect(&format!("key doesn't exist: {:?}", rr_key));
         rr_set.iter().zip(other_rr_set.iter()).all(|(record, other_record)| {
-            record.get_ttl() == other_record.get_ttl() &&
-            record.get_rdata() == other_record.get_rdata()
+            record.ttl() == other_record.ttl() &&
+            record.rdata() == other_record.rdata()
         })
     }));
 }

--- a/server/tests/authority_tests.rs
+++ b/server/tests/authority_tests.rs
@@ -25,7 +25,7 @@ fn test_search() {
     let origin = example.get_origin().clone();
 
     let mut query: Query = Query::new();
-    query.name(origin.clone());
+    query.set_name(origin.clone());
 
     let result = example.search(&query, false, SupportedAlgorithms::new());
     if !result.is_empty() {
@@ -45,7 +45,7 @@ fn test_search_www() {
     let www_name = Name::parse("www.example.com.", None).unwrap();
 
     let mut query: Query = Query::new();
-    query.name(www_name.clone());
+    query.set_name(www_name.clone());
 
     let result = example.search(&query, false, SupportedAlgorithms::new());
     if !result.is_empty() {

--- a/server/tests/catalog_tests.rs
+++ b/server/tests/catalog_tests.rs
@@ -24,85 +24,85 @@ pub fn create_test() -> Authority {
                                                 false,
                                                 false);
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(3600)
-                       .rr_type(RecordType::SOA)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None)
+                       .set_name(origin.clone())
+                       .set_ttl(3600)
+                       .set_rr_type(RecordType::SOA)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None)
                                                       .unwrap(),
-                                                  Name::parse("noc.dns.icann.org.", None)
+                                                      Name::parse("noc.dns.icann.org.", None)
                                                       .unwrap(),
-                                                  2015082403,
-                                                  7200,
-                                                  3600,
-                                                  1209600,
-                                                  3600)))
+                                                      2015082403,
+                                                      7200,
+                                                      3600,
+                                                      1209600,
+                                                      3600)))
                        .clone(),
                    0);
 
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::NS)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                       .set_name(origin.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::NS)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                        .clone(),
                    0);
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::NS)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                       .set_name(origin.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::NS)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
                        .clone(),
                    0);
 
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::A)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
+                       .set_name(origin.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::A)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
                        .clone(),
                    0);
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::AAAA)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::AAAA(Ipv6Addr::new(0x2606,
-                                                        0x2800,
-                                                        0x220,
-                                                        0x1,
-                                                        0x248,
-                                                        0x1893,
-                                                        0x25c8,
-                                                        0x1946)))
+                       .set_name(origin.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::AAAA)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::AAAA(Ipv6Addr::new(0x2606,
+                                                            0x2800,
+                                                            0x220,
+                                                            0x1,
+                                                            0x248,
+                                                            0x1893,
+                                                            0x25c8,
+                                                            0x1946)))
                        .clone(),
                    0);
 
     let www_name: Name = Name::parse("www.test.com.", None).unwrap();
     records.upsert(Record::new()
-                       .name(www_name.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::A)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
+                       .set_name(www_name.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::A)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
                        .clone(),
                    0);
     records.upsert(Record::new()
-                       .name(www_name.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::AAAA)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::AAAA(Ipv6Addr::new(0x2606,
-                                                        0x2800,
-                                                        0x220,
-                                                        0x1,
-                                                        0x248,
-                                                        0x1893,
-                                                        0x25c8,
-                                                        0x1946)))
+                       .set_name(www_name.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::AAAA)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::AAAA(Ipv6Addr::new(0x2606,
+                                                            0x2800,
+                                                            0x220,
+                                                            0x1,
+                                                            0x248,
+                                                            0x1893,
+                                                            0x25c8,
+                                                            0x1946)))
                        .clone(),
                    0);
 
@@ -208,17 +208,17 @@ fn test_axfr() {
     let test = create_test();
     let origin = test.get_origin().clone();
     let soa = Record::new()
-        .name(origin.clone())
-        .ttl(3600)
-        .rr_type(RecordType::SOA)
-        .dns_class(DNSClass::IN)
-        .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
-                                   Name::parse("noc.dns.icann.org.", None).unwrap(),
-                                   2015082403,
-                                   7200,
-                                   3600,
-                                   1209600,
-                                   3600)))
+        .set_name(origin.clone())
+        .set_ttl(3600)
+        .set_rr_type(RecordType::SOA)
+        .set_dns_class(DNSClass::IN)
+        .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
+                                       Name::parse("noc.dns.icann.org.", None).unwrap(),
+                                       2015082403,
+                                       7200,
+                                       3600,
+                                       1209600,
+                                       3600)))
         .clone();
 
     let mut catalog: Catalog = Catalog::new();
@@ -242,86 +242,86 @@ fn test_axfr() {
     let www_name: Name = Name::parse("www.test.com.", None).unwrap();
     let mut expected_set =
         vec![Record::new()
-                 .name(origin.clone())
-                 .ttl(3600)
-                 .rr_type(RecordType::SOA)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
-                                            Name::parse("noc.dns.icann.org.", None).unwrap(),
-                                            2015082403,
-                                            7200,
-                                            3600,
-                                            1209600,
-                                            3600)))
+                 .set_name(origin.clone())
+                 .set_ttl(3600)
+                 .set_rr_type(RecordType::SOA)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
+                                                Name::parse("noc.dns.icann.org.", None).unwrap(),
+                                                2015082403,
+                                                7200,
+                                                3600,
+                                                1209600,
+                                                3600)))
                  .clone(),
              Record::new()
-                 .name(origin.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::NS)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                 .set_name(origin.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::NS)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                  .clone(),
              Record::new()
-                 .name(origin.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::NS)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                 .set_name(origin.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::NS)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
                  .clone(),
              Record::new()
-                 .name(origin.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::A)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
+                 .set_name(origin.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::A)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
                  .clone(),
              Record::new()
-                 .name(origin.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::AAAA)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::AAAA(Ipv6Addr::new(0x2606,
-                                                  0x2800,
-                                                  0x220,
-                                                  0x1,
-                                                  0x248,
-                                                  0x1893,
-                                                  0x25c8,
-                                                  0x1946)))
+                 .set_name(origin.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::AAAA)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::AAAA(Ipv6Addr::new(0x2606,
+                                                      0x2800,
+                                                      0x220,
+                                                      0x1,
+                                                      0x248,
+                                                      0x1893,
+                                                      0x25c8,
+                                                      0x1946)))
                  .clone(),
              Record::new()
-                 .name(www_name.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::A)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
+                 .set_name(www_name.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::A)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
                  .clone(),
              Record::new()
-                 .name(www_name.clone())
-                 .ttl(86400)
-                 .rr_type(RecordType::AAAA)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::AAAA(Ipv6Addr::new(0x2606,
-                                                  0x2800,
-                                                  0x220,
-                                                  0x1,
-                                                  0x248,
-                                                  0x1893,
-                                                  0x25c8,
-                                                  0x1946)))
+                 .set_name(www_name.clone())
+                 .set_ttl(86400)
+                 .set_rr_type(RecordType::AAAA)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::AAAA(Ipv6Addr::new(0x2606,
+                                                      0x2800,
+                                                      0x220,
+                                                      0x1,
+                                                      0x248,
+                                                      0x1893,
+                                                      0x25c8,
+                                                      0x1946)))
                  .clone(),
              Record::new()
-                 .name(origin.clone())
-                 .ttl(3600)
-                 .rr_type(RecordType::SOA)
-                 .dns_class(DNSClass::IN)
-                 .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
-                                            Name::parse("noc.dns.icann.org.", None).unwrap(),
-                                            2015082403,
-                                            7200,
-                                            3600,
-                                            1209600,
-                                            3600)))
+                 .set_name(origin.clone())
+                 .set_ttl(3600)
+                 .set_rr_type(RecordType::SOA)
+                 .set_dns_class(DNSClass::IN)
+                 .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
+                                                Name::parse("noc.dns.icann.org.", None).unwrap(),
+                                                2015082403,
+                                                7200,
+                                                3600,
+                                                1209600,
+                                                3600)))
                  .clone()];
 
     expected_set.sort();

--- a/server/tests/catalog_tests.rs
+++ b/server/tests/catalog_tests.rs
@@ -123,7 +123,7 @@ fn test_catalog_lookup() {
     let mut question: Message = Message::new();
 
     let mut query: Query = Query::new();
-    query.name(origin.clone());
+    query.set_name(origin.clone());
 
     question.add_query(query);
 
@@ -152,7 +152,7 @@ fn test_catalog_lookup() {
 
     // other zone
     let mut query: Query = Query::new();
-    query.name(test_origin.clone());
+    query.set_name(test_origin.clone());
 
     question.add_query(query);
 
@@ -180,7 +180,7 @@ fn test_catalog_nx_soa() {
     let mut question: Message = Message::new();
 
     let mut query: Query = Query::new();
-    query.name(Name::parse("nx.example.com.", None).unwrap());
+    query.set_name(Name::parse("nx.example.com.", None).unwrap());
 
     question.add_query(query);
 
@@ -225,8 +225,8 @@ fn test_axfr() {
     catalog.upsert(origin.clone(), test);
 
     let mut query: Query = Query::new();
-    query.name(origin.clone());
-    query.query_type(RecordType::AXFR);
+    query.set_name(origin.clone());
+    query.set_query_type(RecordType::AXFR);
 
     let mut question: Message = Message::new();
     question.add_query(query);

--- a/server/tests/catalog_tests.rs
+++ b/server/tests/catalog_tests.rs
@@ -135,19 +135,19 @@ fn test_catalog_lookup() {
     let answers: &[Record] = result.answers();
 
     assert!(!answers.is_empty());
-    assert_eq!(answers.first().unwrap().get_rr_type(), RecordType::A);
-    assert_eq!(answers.first().unwrap().get_rdata(),
+    assert_eq!(answers.first().unwrap().rr_type(), RecordType::A);
+    assert_eq!(answers.first().unwrap().rdata(),
                &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
 
     let mut ns: Vec<Record> = result.name_servers().to_vec();
     ns.sort();
 
     assert_eq!(ns.len(), 2);
-    assert_eq!(ns.first().unwrap().get_rr_type(), RecordType::NS);
-    assert_eq!(ns.first().unwrap().get_rdata(),
+    assert_eq!(ns.first().unwrap().rr_type(), RecordType::NS);
+    assert_eq!(ns.first().unwrap().rdata(),
                &RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()));
-    assert_eq!(ns.last().unwrap().get_rr_type(), RecordType::NS);
-    assert_eq!(ns.last().unwrap().get_rdata(),
+    assert_eq!(ns.last().unwrap().rr_type(), RecordType::NS);
+    assert_eq!(ns.last().unwrap().rdata(),
                &RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()));
 
     // other zone
@@ -164,8 +164,8 @@ fn test_catalog_lookup() {
     let answers: &[Record] = result.answers();
 
     assert!(!answers.is_empty());
-    assert_eq!(answers.first().unwrap().get_rr_type(), RecordType::A);
-    assert_eq!(answers.first().unwrap().get_rdata(),
+    assert_eq!(answers.first().unwrap().rr_type(), RecordType::A);
+    assert_eq!(answers.first().unwrap().rdata(),
                &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
 }
 
@@ -192,8 +192,8 @@ fn test_catalog_nx_soa() {
     let ns: &[Record] = result.name_servers();
 
     assert_eq!(ns.len(), 1);
-    assert_eq!(ns.first().unwrap().get_rr_type(), RecordType::SOA);
-    assert_eq!(ns.first().unwrap().get_rdata(),
+    assert_eq!(ns.first().unwrap().rr_type(), RecordType::SOA);
+    assert_eq!(ns.first().unwrap().rdata(),
                &RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None).unwrap(),
                                     Name::parse("noc.dns.icann.org.", None).unwrap(),
                                     2015082403,

--- a/server/tests/catalog_tests.rs
+++ b/server/tests/catalog_tests.rs
@@ -129,17 +129,17 @@ fn test_catalog_lookup() {
 
     let result: Message = catalog.lookup(&question);
 
-    assert_eq!(result.get_response_code(), ResponseCode::NoError);
-    assert_eq!(result.get_message_type(), MessageType::Response);
+    assert_eq!(result.response_code(), ResponseCode::NoError);
+    assert_eq!(result.message_type(), MessageType::Response);
 
-    let answers: &[Record] = result.get_answers();
+    let answers: &[Record] = result.answers();
 
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().get_rr_type(), RecordType::A);
     assert_eq!(answers.first().unwrap().get_rdata(),
                &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
 
-    let mut ns: Vec<Record> = result.get_name_servers().to_vec();
+    let mut ns: Vec<Record> = result.name_servers().to_vec();
     ns.sort();
 
     assert_eq!(ns.len(), 2);
@@ -158,10 +158,10 @@ fn test_catalog_lookup() {
 
     let result: Message = catalog.lookup(&question);
 
-    assert_eq!(result.get_response_code(), ResponseCode::NoError);
-    assert_eq!(result.get_message_type(), MessageType::Response);
+    assert_eq!(result.response_code(), ResponseCode::NoError);
+    assert_eq!(result.message_type(), MessageType::Response);
 
-    let answers: &[Record] = result.get_answers();
+    let answers: &[Record] = result.answers();
 
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().get_rr_type(), RecordType::A);
@@ -186,10 +186,10 @@ fn test_catalog_nx_soa() {
 
     let result: Message = catalog.lookup(&question);
 
-    assert_eq!(result.get_response_code(), ResponseCode::NXDomain);
-    assert_eq!(result.get_message_type(), MessageType::Response);
+    assert_eq!(result.response_code(), ResponseCode::NXDomain);
+    assert_eq!(result.message_type(), MessageType::Response);
 
-    let ns: &[Record] = result.get_name_servers();
+    let ns: &[Record] = result.name_servers();
 
     assert_eq!(ns.len(), 1);
     assert_eq!(ns.first().unwrap().get_rr_type(), RecordType::SOA);
@@ -232,7 +232,7 @@ fn test_axfr() {
     question.add_query(query);
 
     let result: Message = catalog.lookup(&question);
-    let mut answers: Vec<Record> = result.get_answers().to_vec();
+    let mut answers: Vec<Record> = result.answers().to_vec();
 
     assert_eq!(answers.first().unwrap(), &soa);
     assert_eq!(answers.last().unwrap(), &soa);

--- a/server/tests/client_future_tests.rs
+++ b/server/tests/client_future_tests.rs
@@ -198,8 +198,8 @@ fn create_sig0_ready_client(io_loop: &Core) -> (BasicClientHandle, domain::Name)
     auth_key.rdata(RData::KEY(DNSKEY::new(false,
                                           false,
                                           false,
-                                          signer.get_algorithm(),
-                                          signer.get_key()
+                                          signer.algorithm(),
+                                          signer.key()
                                               .to_public_bytes()
                                               .expect("to_vec failed"))));
     authority.upsert(auth_key, 0);

--- a/server/tests/client_future_tests.rs
+++ b/server/tests/client_future_tests.rs
@@ -516,9 +516,9 @@ fn test_compare_and_swap_multi() {
         .expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
-    let mut new = RecordSet::with_ttl(current.get_name().clone(),
-                                      current.get_record_type(),
-                                      current.get_ttl());
+    let mut new = RecordSet::with_ttl(current.name().clone(),
+                                      current.record_type(),
+                                      current.ttl());
     let new1 = new.new_record(RData::A(Ipv4Addr::new(100, 10, 101, 10))).clone();
     let new2 = new.new_record(RData::A(Ipv4Addr::new(100, 10, 101, 11))).clone();
     let new = new;
@@ -527,9 +527,9 @@ fn test_compare_and_swap_multi() {
         .expect("compare_and_swap failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
-    let result = io_loop.run(client.query(new.get_name().clone(),
-                          new.get_dns_class(),
-                          new.get_record_type()))
+    let result = io_loop.run(client.query(new.name().clone(),
+                                          new.dns_class(),
+                                          new.record_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 2);
@@ -547,9 +547,9 @@ fn test_compare_and_swap_multi() {
         .expect("compare_and_swap failed");
     assert_eq!(result.get_response_code(), ResponseCode::NXRRSet);
 
-    let result = io_loop.run(client.query(new.get_name().clone(),
-                          new.get_dns_class(),
-                          new.get_record_type()))
+    let result = io_loop.run(client.query(new.name().clone(),
+                                          new.dns_class(),
+                                          new.record_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 2);

--- a/server/tests/client_future_tests.rs
+++ b/server/tests/client_future_tests.rs
@@ -195,11 +195,11 @@ fn create_sig0_ready_client(io_loop: &Core) -> (BasicClientHandle, domain::Name)
                                                                    "com".to_string()]),
                                     RecordType::KEY,
                                     Duration::minutes(5).num_seconds() as u32);
-    auth_key.rdata(RData::KEY(DNSKEY::new(false,
-                                          false,
-                                          false,
-                                          signer.algorithm(),
-                                          signer.key()
+    auth_key.set_rdata(RData::KEY(DNSKEY::new(false,
+                                              false,
+                                              false,
+                                              signer.algorithm(),
+                                              signer.key()
                                               .to_public_bytes()
                                               .expect("to_vec failed"))));
     authority.upsert(auth_key, 0);
@@ -225,15 +225,15 @@ fn test_create() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
     let record = record;
 
 
     let result = io_loop.run(client.create(record.clone(), origin.clone())).expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
-    let result = io_loop.run(client.query(record.get_name().clone(),
-                          record.get_dns_class(),
-                          record.get_rr_type()))
+    let result = io_loop.run(client.query(record.name().clone(),
+                                          record.dns_class(),
+                                          record.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 1);
@@ -263,7 +263,7 @@ fn test_create_multi() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
     let record = record;
 
     let mut record2 = record.clone();
@@ -276,9 +276,9 @@ fn test_create_multi() {
 
     let result = io_loop.run(client.create(rrset.clone(), origin.clone())).expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
-    let result = io_loop.run(client.query(record.get_name().clone(),
-                          record.get_dns_class(),
-                          record.get_rr_type()))
+    let result = io_loop.run(client.query(record.name().clone(),
+                                          record.dns_class(),
+                                          record.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 2);
@@ -310,7 +310,7 @@ fn test_append() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
     let record = record;
 
     // first check the must_exist option
@@ -324,9 +324,9 @@ fn test_append() {
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = io_loop.run(client.query(record.get_name().clone(),
-                          record.get_dns_class(),
-                          record.get_rr_type()))
+    let result = io_loop.run(client.query(record.name().clone(),
+                                          record.dns_class(),
+                                          record.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 1);
@@ -341,9 +341,9 @@ fn test_append() {
         .expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
-    let result = io_loop.run(client.query(record.get_name().clone(),
-                          record.get_dns_class(),
-                          record.get_rr_type()))
+    let result = io_loop.run(client.query(record.name().clone(),
+                                          record.dns_class(),
+                                          record.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 2);
@@ -356,9 +356,9 @@ fn test_append() {
         .expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
-    let result = io_loop.run(client.query(record.get_name().clone(),
-                          record.get_dns_class(),
-                          record.get_rr_type()))
+    let result = io_loop.run(client.query(record.name().clone(),
+                                          record.dns_class(),
+                                          record.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 2);
@@ -375,7 +375,7 @@ fn test_append_multi() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     // first check the must_exist option
     let result = io_loop.run(client.append(record.clone(), origin.clone(), true))
@@ -388,9 +388,9 @@ fn test_append_multi() {
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = io_loop.run(client.query(record.get_name().clone(),
-                          record.get_dns_class(),
-                          record.get_rr_type()))
+    let result = io_loop.run(client.query(record.name().clone(),
+                                          record.dns_class(),
+                                          record.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 1);
@@ -409,9 +409,9 @@ fn test_append_multi() {
     let result = io_loop.run(client.append(rrset, origin.clone(), true)).expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
-    let result = io_loop.run(client.query(record.get_name().clone(),
-                          record.get_dns_class(),
-                          record.get_rr_type()))
+    let result = io_loop.run(client.query(record.name().clone(),
+                                          record.dns_class(),
+                                          record.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 3);
@@ -426,9 +426,9 @@ fn test_append_multi() {
         .expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
-    let result = io_loop.run(client.query(record.get_name().clone(),
-                          record.get_dns_class(),
-                          record.get_rr_type()))
+    let result = io_loop.run(client.query(record.name().clone(),
+                                          record.dns_class(),
+                                          record.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 3);
@@ -449,7 +449,7 @@ fn test_compare_and_swap() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
     let record = record;
 
     let result = io_loop.run(client.create(record.clone(), origin.clone())).expect("create failed");
@@ -568,7 +568,7 @@ fn test_delete_by_rdata() {
                                                                   "com".to_string()]),
                                    RecordType::A,
                                    Duration::minutes(5).num_seconds() as u32);
-    record1.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record1.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     // first check the must_exist option
     let result = io_loop.run(client.delete_by_rdata(record1.clone(), origin.clone()))
@@ -591,9 +591,9 @@ fn test_delete_by_rdata() {
         .expect("delete failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
-    let result = io_loop.run(client.query(record1.get_name().clone(),
-                          record1.get_dns_class(),
-                          record1.get_rr_type()))
+    let result = io_loop.run(client.query(record1.name().clone(),
+                                          record1.dns_class(),
+                                          record1.rr_type()))
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 1);
@@ -670,7 +670,7 @@ fn test_delete_rrset() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     // first check the must_exist option
     let result = io_loop.run(client.delete_rrset(record.clone(), origin.clone()))
@@ -711,11 +711,11 @@ fn test_delete_all() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     // first check the must_exist option
     let result =
-        io_loop.run(client.delete_all(record.get_name().clone(), origin.clone(), DNSClass::IN))
+        io_loop.run(client.delete_all(record.name().clone(), origin.clone(), DNSClass::IN))
             .expect("delete failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 

--- a/server/tests/client_tests.rs
+++ b/server/tests/client_tests.rs
@@ -367,8 +367,8 @@ fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient, domain::Name) 
     auth_key.rdata(RData::KEY(DNSKEY::new(false,
                                           false,
                                           false,
-                                          signer.get_algorithm(),
-                                          signer.get_key()
+                                          signer.algorithm(),
+                                          signer.key()
                                               .to_public_bytes()
                                               .expect("to_vec failed"))));
     authority.upsert(auth_key, 0);

--- a/server/tests/client_tests.rs
+++ b/server/tests/client_tests.rs
@@ -364,11 +364,11 @@ fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient, domain::Name) 
                                                                    "com".to_string()]),
                                     RecordType::KEY,
                                     Duration::minutes(5).num_seconds() as u32);
-    auth_key.rdata(RData::KEY(DNSKEY::new(false,
-                                          false,
-                                          false,
-                                          signer.algorithm(),
-                                          signer.key()
+    auth_key.set_rdata(RData::KEY(DNSKEY::new(false,
+                                              false,
+                                              false,
+                                              signer.algorithm(),
+                                              signer.key()
                                               .to_public_bytes()
                                               .expect("to_vec failed"))));
     authority.upsert(auth_key, 0);
@@ -390,14 +390,14 @@ fn test_create() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
 
     let result = client.create(record.clone(), origin.clone()).expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
-    let result = client.query(record.get_name(),
-               record.get_dns_class(),
-               record.get_rr_type())
+    let result = client.query(record.name(),
+                              record.dns_class(),
+                              record.rr_type())
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 1);
@@ -428,7 +428,7 @@ fn test_append() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     // first check the must_exist option
     let result = client.append(record.clone(), origin.clone(), true).expect("append failed");
@@ -439,9 +439,9 @@ fn test_append() {
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = client.query(record.get_name(),
-               record.get_dns_class(),
-               record.get_rr_type())
+    let result = client.query(record.name(),
+                              record.dns_class(),
+                              record.rr_type())
         .expect("query failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
     assert_eq!(result.get_answers().len(), 1);
@@ -495,7 +495,7 @@ fn test_compare_and_swap() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     let result = client.create(record.clone(), origin.clone()).expect("create failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
@@ -548,7 +548,7 @@ fn test_delete_by_rdata() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     // first check the must_exist option
     let result = client.delete_by_rdata(record.clone(), origin.clone()).expect("delete failed");
@@ -591,7 +591,7 @@ fn test_delete_rrset() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     // first check the must_exist option
     let result = client.delete_rrset(record.clone(), origin.clone()).expect("delete failed");
@@ -629,10 +629,10 @@ fn test_delete_all() {
                                                                  "com".to_string()]),
                                   RecordType::A,
                                   Duration::minutes(5).num_seconds() as u32);
-    record.rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 
     // first check the must_exist option
-    let result = client.delete_all(record.get_name().clone(), origin.clone(), DNSClass::IN)
+    let result = client.delete_all(record.name().clone(), origin.clone(), DNSClass::IN)
         .expect("delete failed");
     assert_eq!(result.get_response_code(), ResponseCode::NoError);
 

--- a/server/tests/common/authority.rs
+++ b/server/tests/common/authority.rs
@@ -18,36 +18,36 @@ pub fn create_example() -> Authority {
                                                 false);
     // example.com.		3600	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082403 7200 3600 1209600 3600
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(3600)
-                       .rr_type(RecordType::SOA)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None)
+                       .set_name(origin.clone())
+                       .set_ttl(3600)
+                       .set_rr_type(RecordType::SOA)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::SOA(SOA::new(Name::parse("sns.dns.icann.org.", None)
                                                       .unwrap(),
-                                                  Name::parse("noc.dns.icann.org.", None)
+                                                      Name::parse("noc.dns.icann.org.", None)
                                                       .unwrap(),
-                                                  2015082403,
-                                                  7200,
-                                                  3600,
-                                                  1209600,
-                                                  3600)))
+                                                      2015082403,
+                                                      7200,
+                                                      3600,
+                                                      1209600,
+                                                      3600)))
                        .clone(),
                    0);
 
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::NS)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                       .set_name(origin.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::NS)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
                        .clone(),
                    0);
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::NS)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                       .set_name(origin.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::NS)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
                        .clone(),
                    0);
 
@@ -55,11 +55,11 @@ pub fn create_example() -> Authority {
     //records.upsert(origin.clone(), Record::new().name(origin.clone()).ttl(60).rr_type(RecordType::TXT).dns_class(DNSClass::IN).rdata(RData::TXT{ txt_data: vec!["v=spf1 -all".to_string()] }).clone());
     // example.com.		60	IN	TXT	"$Id: example.com 4415 2015-08-24 20:12:23Z davids $"
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(60)
-                       .rr_type(RecordType::TXT)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::TXT(TXT::new(vec!["$Id: example.com 4415 2015-08-24 \
+                       .set_name(origin.clone())
+                       .set_ttl(60)
+                       .set_rr_type(RecordType::TXT)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::TXT(TXT::new(vec!["$Id: example.com 4415 2015-08-24 \
                                                         20:12:23Z davids $"
                                                            .to_string()])))
                        .clone(),
@@ -67,28 +67,28 @@ pub fn create_example() -> Authority {
 
     // example.com.		86400	IN	A	93.184.216.34
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::A)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                       .set_name(origin.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::A)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
                        .clone(),
                    0);
 
     // example.com.		86400	IN	AAAA	2606:2800:220:1:248:1893:25c8:1946
     records.upsert(Record::new()
-                       .name(origin.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::AAAA)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::AAAA(Ipv6Addr::new(0x2606,
-                                                        0x2800,
-                                                        0x220,
-                                                        0x1,
-                                                        0x248,
-                                                        0x1893,
-                                                        0x25c8,
-                                                        0x1946)))
+                       .set_name(origin.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::AAAA)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::AAAA(Ipv6Addr::new(0x2606,
+                                                            0x2800,
+                                                            0x220,
+                                                            0x1,
+                                                            0x248,
+                                                            0x1893,
+                                                            0x25c8,
+                                                            0x1946)))
                        .clone(),
                    0);
 
@@ -111,38 +111,38 @@ pub fn create_example() -> Authority {
 
     // www.example.com.	86400	IN	TXT	"v=spf1 -all"
     records.upsert(Record::new()
-                       .name(www_name.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::TXT)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()])))
+                       .set_name(www_name.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::TXT)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()])))
                        .clone(),
                    0);
 
     // www.example.com.	86400	IN	A	93.184.216.34
     records.upsert(Record::new()
-                       .name(www_name.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::A)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                       .set_name(www_name.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::A)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
                        .clone(),
                    0);
 
     // www.example.com.	86400	IN	AAAA	2606:2800:220:1:248:1893:25c8:1946
     records.upsert(Record::new()
-                       .name(www_name.clone())
-                       .ttl(86400)
-                       .rr_type(RecordType::AAAA)
-                       .dns_class(DNSClass::IN)
-                       .rdata(RData::AAAA(Ipv6Addr::new(0x2606,
-                                                        0x2800,
-                                                        0x220,
-                                                        0x1,
-                                                        0x248,
-                                                        0x1893,
-                                                        0x25c8,
-                                                        0x1946)))
+                       .set_name(www_name.clone())
+                       .set_ttl(86400)
+                       .set_rr_type(RecordType::AAAA)
+                       .set_dns_class(DNSClass::IN)
+                       .set_rdata(RData::AAAA(Ipv6Addr::new(0x2606,
+                                                            0x2800,
+                                                            0x220,
+                                                            0x1,
+                                                            0x248,
+                                                            0x1893,
+                                                            0x25c8,
+                                                            0x1946)))
                        .clone(),
                    0);
 

--- a/server/tests/persistence_tests.rs
+++ b/server/tests/persistence_tests.rs
@@ -32,9 +32,9 @@ fn create_test_journal() -> (Record, Journal) {
     let www = Name::with_labels(vec!["www".to_string(), "example".to_string(), "com".to_string()]);
 
     let mut record = Record::new();
-    record.name(www);
-    record.rr_type(RecordType::A);
-    record.rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap()));
+    record.set_name(www);
+    record.set_rr_type(RecordType::A);
+    record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap()));
 
     // test that this message can be inserted
     let conn = Connection::open_in_memory().expect("could not create in memory DB");
@@ -45,7 +45,7 @@ fn create_test_journal() -> (Record, Journal) {
     journal.insert_record(0, &record).unwrap();
 
     // insert another...
-    record.rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap()));
+    record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap()));
     journal.insert_record(0, &record).unwrap();
 
     (record, journal)
@@ -58,13 +58,13 @@ fn test_insert_and_select_record() {
     // select the record
     let (row_id, journal_record) =
         journal.select_record(0).expect("persistence error").expect("none");
-    record.rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap()));
+    record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap()));
     assert_eq!(journal_record, record);
 
     // test another
     let (row_id, journal_record) =
         journal.select_record(row_id + 1).expect("persistence error").expect("none");
-    record.rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap()));
+    record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap()));
     assert_eq!(journal_record, record);
 
     // check that we get nothing for id over row_id
@@ -78,9 +78,9 @@ fn test_iterator() {
 
     let mut iter = journal.iter();
 
-    assert_eq!(record.rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap())),
+    assert_eq!(record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap())),
                &iter.next().unwrap());
-    assert_eq!(record.rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap())),
+    assert_eq!(record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap())),
                &iter.next().unwrap());
     assert_eq!(None, iter.next());
 }

--- a/server/tests/secure_client_handle_tests.rs
+++ b/server/tests/secure_client_handle_tests.rs
@@ -51,15 +51,15 @@ fn test_secure_query_example<H>(mut client: SecureClientHandle<H>, mut io_loop: 
         .expect("query failed");
 
     println!("response records: {:?}", response);
-    assert!(response.get_edns().expect("edns not here").is_dnssec_ok());
+    assert!(response.edns().expect("edns not here").dnssec_ok());
 
-    assert!(!response.get_answers().is_empty());
-    let record = &response.get_answers()[0];
-    assert_eq!(record.get_name(), &name);
-    assert_eq!(record.get_rr_type(), RecordType::A);
-    assert_eq!(record.get_dns_class(), DNSClass::IN);
+    assert!(!response.answers().is_empty());
+    let record = &response.answers()[0];
+    assert_eq!(record.name(), &name);
+    assert_eq!(record.rr_type(), RecordType::A);
+    assert_eq!(record.dns_class(), DNSClass::IN);
 
-    if let &RData::A(ref address) = record.get_rdata() {
+    if let &RData::A(ref address) = record.rdata() {
         assert_eq!(address, &Ipv4Addr::new(93, 184, 216, 34))
     } else {
         assert!(false);
@@ -92,7 +92,7 @@ fn test_nsec_query_example<H>(mut client: SecureClientHandle<H>, mut io_loop: Co
 
     let response = io_loop.run(client.query(name.clone(), DNSClass::IN, RecordType::A))
         .expect("query failed");
-    assert_eq!(response.get_response_code(), ResponseCode::NXDomain);
+    assert_eq!(response.response_code(), ResponseCode::NXDomain);
 }
 
 // TODO: NSEC response code wrong in Trust-DNS? Issue #53
@@ -123,8 +123,8 @@ fn test_nsec_query_type<H>(mut client: SecureClientHandle<H>, mut io_loop: Core)
     let response = io_loop.run(client.query(name.clone(), DNSClass::IN, RecordType::NS))
         .expect("query failed");
 
-    assert_eq!(response.get_response_code(), ResponseCode::NoError);
-    assert!(response.get_answers().is_empty());
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert!(response.answers().is_empty());
 }
 
 #[test]
@@ -153,10 +153,10 @@ fn dnssec_rollernet_td_test<H>(mut client: SecureClientHandle<H>, mut io_loop: C
     let response = io_loop.run(client.query(name.clone(), DNSClass::IN, RecordType::DS))
         .expect("query failed");
 
-    assert_eq!(response.get_response_code(), ResponseCode::NoError);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
     // rollernet doesn't have any DS records...
     //  would have failed validation
-    assert!(response.get_answers().is_empty());
+    assert!(response.answers().is_empty());
 }
 
 fn dnssec_rollernet_td_mixed_case_test<H>(mut client: SecureClientHandle<H>, mut io_loop: Core)
@@ -167,10 +167,10 @@ fn dnssec_rollernet_td_mixed_case_test<H>(mut client: SecureClientHandle<H>, mut
     let response = io_loop.run(client.query(name.clone(), DNSClass::IN, RecordType::DS))
         .expect("query failed");
 
-    assert_eq!(response.get_response_code(), ResponseCode::NoError);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
     // rollernet doesn't have any DS records...
     //  would have failed validation
-    assert!(response.get_answers().is_empty());
+    assert!(response.answers().is_empty());
 }
 
 fn with_nonet<F>(test: F)
@@ -198,7 +198,7 @@ fn with_nonet<F>(test: F)
 
     let trust_anchor = {
         let signers = authority.get_secure_keys();
-        let public_key = signers.first().expect("expected a key in the authority").get_key();
+        let public_key = signers.first().expect("expected a key in the authority").key();
 
         let mut trust_anchor = TrustAnchor::new();
         trust_anchor.insert_trust_anchor(public_key.to_public_bytes().expect("to_vec failed"));

--- a/server/tests/server_future_tests.rs
+++ b/server/tests/server_future_tests.rs
@@ -192,30 +192,30 @@ fn client_thread_www<C: ClientConnection>(conn: C)
 
     let response = client.query(&name, DNSClass::IN, RecordType::A).expect("error querying");
 
-    assert!(response.get_response_code() == ResponseCode::NoError,
+    assert!(response.response_code() == ResponseCode::NoError,
             "got an error: {:?}",
-            response.get_response_code());
+            response.response_code());
 
-    let record = &response.get_answers()[0];
-    assert_eq!(record.get_name(), &name);
-    assert_eq!(record.get_rr_type(), RecordType::A);
-    assert_eq!(record.get_dns_class(), DNSClass::IN);
+    let record = &response.answers()[0];
+    assert_eq!(record.name(), &name);
+    assert_eq!(record.rr_type(), RecordType::A);
+    assert_eq!(record.dns_class(), DNSClass::IN);
 
-    if let &RData::A(ref address) = record.get_rdata() {
+    if let &RData::A(ref address) = record.rdata() {
         assert_eq!(address, &Ipv4Addr::new(93, 184, 216, 34))
     } else {
         assert!(false);
     }
 
-    let mut ns: Vec<_> = response.get_name_servers().to_vec();
+    let mut ns: Vec<_> = response.name_servers().to_vec();
     ns.sort();
 
     assert_eq!(ns.len(), 2);
-    assert_eq!(ns.first().unwrap().get_rr_type(), RecordType::NS);
-    assert_eq!(ns.first().unwrap().get_rdata(),
+    assert_eq!(ns.first().unwrap().rr_type(), RecordType::NS);
+    assert_eq!(ns.first().unwrap().rdata(),
                &RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()));
-    assert_eq!(ns.last().unwrap().get_rr_type(), RecordType::NS);
-    assert_eq!(ns.last().unwrap().get_rdata(),
+    assert_eq!(ns.last().unwrap().rr_type(), RecordType::NS);
+    assert_eq!(ns.last().unwrap().rdata(),
                &RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()));
 }
 

--- a/server/tests/txt_tests.rs
+++ b/server/tests/txt_tests.rs
@@ -102,11 +102,11 @@ venera  A       10.1.0.52
 
     for (record, ref name) in compare {
         assert_eq!(&Name::with_labels(vec!["isi".into(), "edu".into()]),
-                   record.get_name());
-        assert_eq!(60, record.get_ttl()); // TODO: should this be minimum or expire?
-        assert_eq!(DNSClass::IN, record.get_dns_class());
-        assert_eq!(RecordType::NS, record.get_rr_type());
-        if let RData::NS(ref nsdname) = *record.get_rdata() {
+                   record.name());
+        assert_eq!(60, record.ttl()); // TODO: should this be minimum or expire?
+        assert_eq!(DNSClass::IN, record.dns_class());
+        assert_eq!(RecordType::NS, record.rr_type());
+        if let RData::NS(ref nsdname) = *record.rdata() {
             assert_eq!(name, nsdname);
         } else {
             panic!("Not an NS record!!!") // valid panic, test code
@@ -127,11 +127,11 @@ venera  A       10.1.0.52
 
 
     for (record, (num, ref name)) in compare {
-        assert_eq!(&Name::new().label("isi").label("edu"), record.get_name());
-        assert_eq!(60, record.get_ttl()); // TODO: should this be minimum or expire?
-        assert_eq!(DNSClass::IN, record.get_dns_class());
-        assert_eq!(RecordType::MX, record.get_rr_type());
-        if let RData::MX(ref rdata) = *record.get_rdata() {
+        assert_eq!(&Name::new().label("isi").label("edu"), record.name());
+        assert_eq!(60, record.ttl()); // TODO: should this be minimum or expire?
+        assert_eq!(DNSClass::IN, record.dns_class());
+        assert_eq!(RecordType::MX, record.rr_type());
+        if let RData::MX(ref rdata) = *record.rdata() {
             assert_eq!(num, rdata.preference());
             assert_eq!(name, rdata.exchange());
         } else {
@@ -222,7 +222,7 @@ venera  A       10.1.0.52
 
 
     for (record, ref vector) in compare {
-        if let RData::TXT(ref rdata) = *record.get_rdata() {
+        if let RData::TXT(ref rdata) = *record.rdata() {
             assert_eq!(vector as &[String], rdata.txt_data());
         } else {
             panic!("Not a TXT record!!!") // valid panic, test code

--- a/server/tests/txt_tests.rs
+++ b/server/tests/txt_tests.rs
@@ -73,14 +73,14 @@ venera  A       10.1.0.52
     if let RData::SOA(ref soa) = *soa_record.get_rdata() {
         // this should all be lowercased
         assert_eq!(&Name::new().label("venera").label("isi").label("edu"),
-                   soa.get_mname());
+                   soa.mname());
         assert_eq!(&Name::new().label("action.domains").label("isi").label("edu"),
-                   soa.get_rname());
-        assert_eq!(20, soa.get_serial());
-        assert_eq!(7200, soa.get_refresh());
-        assert_eq!(600, soa.get_retry());
-        assert_eq!(3600000, soa.get_expire());
-        assert_eq!(60, soa.get_minimum());
+                   soa.rname());
+        assert_eq!(20, soa.serial());
+        assert_eq!(7200, soa.refresh());
+        assert_eq!(600, soa.retry());
+        assert_eq!(3600000, soa.expire());
+        assert_eq!(60, soa.minimum());
     } else {
         panic!("Not an SOA record!!!") // valid panic, test code
     }

--- a/server/tests/txt_tests.rs
+++ b/server/tests/txt_tests.rs
@@ -65,12 +65,12 @@ venera  A       10.1.0.52
 
     // SOA
     let soa_record = authority.get_soa().unwrap();
-    assert_eq!(RecordType::SOA, soa_record.get_rr_type());
+    assert_eq!(RecordType::SOA, soa_record.rr_type());
     assert_eq!(&Name::new().label("isi").label("edu"),
-               soa_record.get_name()); // i.e. the origin or domain
-    assert_eq!(3600000, soa_record.get_ttl());
-    assert_eq!(DNSClass::IN, soa_record.get_dns_class());
-    if let RData::SOA(ref soa) = *soa_record.get_rdata() {
+               soa_record.name()); // i.e. the origin or domain
+    assert_eq!(3600000, soa_record.ttl());
+    assert_eq!(DNSClass::IN, soa_record.dns_class());
+    if let RData::SOA(ref soa) = *soa_record.rdata() {
         // this should all be lowercased
         assert_eq!(&Name::new().label("venera").label("isi").label("edu"),
                    soa.mname());
@@ -148,11 +148,11 @@ venera  A       10.1.0.52
         .cloned()
         .unwrap();
     assert_eq!(&Name::new().label("a").label("isi").label("edu"),
-               a_record.get_name());
-    assert_eq!(60, a_record.get_ttl()); // TODO: should this be minimum or expire?
-    assert_eq!(DNSClass::IN, a_record.get_dns_class());
-    assert_eq!(RecordType::A, a_record.get_rr_type());
-    if let RData::A(ref address) = *a_record.get_rdata() {
+               a_record.name());
+    assert_eq!(60, a_record.ttl()); // TODO: should this be minimum or expire?
+    assert_eq!(DNSClass::IN, a_record.dns_class());
+    assert_eq!(RecordType::A, a_record.rr_type());
+    if let RData::A(ref address) = *a_record.rdata() {
         assert_eq!(&Ipv4Addr::new(26u8, 3u8, 0u8, 103u8), address);
     } else {
         panic!("Not an A record!!!") // valid panic, test code
@@ -168,8 +168,8 @@ venera  A       10.1.0.52
             .cloned()
             .unwrap();
     assert_eq!(&Name::new().label("aaaa").label("isi").label("edu"),
-               aaaa_record.get_name());
-    if let RData::AAAA(ref address) = *aaaa_record.get_rdata() {
+               aaaa_record.name());
+    if let RData::AAAA(ref address) = *aaaa_record.rdata() {
         assert_eq!(&Ipv6Addr::from_str("4321:0:1:2:3:4:567:89ab").unwrap(),
                    address);
     } else {
@@ -186,9 +186,9 @@ venera  A       10.1.0.52
             .cloned()
             .unwrap();
     assert_eq!(&Name::new().label("short").label("isi").label("edu"),
-               short_record.get_name());
-    assert_eq!(70, short_record.get_ttl());
-    if let RData::A(ref address) = *short_record.get_rdata() {
+               short_record.name());
+    assert_eq!(70, short_record.ttl());
+    if let RData::A(ref address) = *short_record.rdata() {
         assert_eq!(&Ipv4Addr::new(26u8, 3u8, 0u8, 104u8), address);
     } else {
         panic!("Not an A record!!!") // valid panic, test code
@@ -243,7 +243,7 @@ venera  A       10.1.0.52
         .first()
         .cloned()
         .unwrap();
-    if let RData::PTR(ref ptrdname) = *ptr_record.get_rdata() {
+    if let RData::PTR(ref ptrdname) = *ptr_record.rdata() {
         assert_eq!(&Name::new().label("a").label("isi").label("edu"), ptrdname);
     } else {
         panic!("Not a PTR record!!!") // valid panic, test code
@@ -262,7 +262,7 @@ venera  A       10.1.0.52
         .first()
         .cloned()
         .unwrap();
-    if let RData::SRV(ref rdata) = *srv_record.get_rdata() {
+    if let RData::SRV(ref rdata) = *srv_record.rdata() {
         assert_eq!(rdata.priority(), 1);
         assert_eq!(rdata.weight(), 2);
         assert_eq!(rdata.port(), 3);

--- a/server/tests/txt_tests.rs
+++ b/server/tests/txt_tests.rs
@@ -132,8 +132,8 @@ venera  A       10.1.0.52
         assert_eq!(DNSClass::IN, record.get_dns_class());
         assert_eq!(RecordType::MX, record.get_rr_type());
         if let RData::MX(ref rdata) = *record.get_rdata() {
-            assert_eq!(num, rdata.get_preference());
-            assert_eq!(name, rdata.get_exchange());
+            assert_eq!(num, rdata.preference());
+            assert_eq!(name, rdata.exchange());
         } else {
             panic!("Not an NS record!!!") // valid panic, test code
         }

--- a/server/tests/txt_tests.rs
+++ b/server/tests/txt_tests.rs
@@ -223,7 +223,7 @@ venera  A       10.1.0.52
 
     for (record, ref vector) in compare {
         if let RData::TXT(ref rdata) = *record.get_rdata() {
-            assert_eq!(vector as &[String], rdata.get_txt_data());
+            assert_eq!(vector as &[String], rdata.txt_data());
         } else {
             panic!("Not a TXT record!!!") // valid panic, test code
         }
@@ -263,10 +263,10 @@ venera  A       10.1.0.52
         .cloned()
         .unwrap();
     if let RData::SRV(ref rdata) = *srv_record.get_rdata() {
-        assert_eq!(rdata.get_priority(), 1);
-        assert_eq!(rdata.get_weight(), 2);
-        assert_eq!(rdata.get_port(), 3);
-        assert_eq!(rdata.get_target(),
+        assert_eq!(rdata.priority(), 1);
+        assert_eq!(rdata.weight(), 2);
+        assert_eq!(rdata.port(), 3);
+        assert_eq!(rdata.target(),
                    &Name::new().label("short").label("isi").label("edu"));
     } else {
         panic!("Not an SRV record!!!") // valid panic, test code

--- a/server/tests/z_named_tests.rs
+++ b/server/tests/z_named_tests.rs
@@ -151,9 +151,9 @@ fn query(io_loop: &mut Core, client: &mut BasicClientHandle) -> bool {
     let response = response.unwrap();
 
 
-    let record = &response.get_answers()[0];
+    let record = &response.answers()[0];
 
-    if let &RData::A(ref address) = record.get_rdata() {
+    if let &RData::A(ref address) = record.rdata() {
         address == &Ipv4Addr::new(127, 0, 0, 1)
     } else {
         false


### PR DESCRIPTION
Rename public getters/setters in the client code to conform to [RFC#344](https://github.com/aturon/rfcs/blob/conventions-galore/active/0000-conventions-galore.md#gettersetter-apis). In summary:

* `fn foo(&mut self, ...)` renamed to `fn set_foo(&mut self, ...)`;
* `fn get_foo(&self)` renamed to `fn foo(&self)`;
* `fn is_foo(&self)` renamed to `fn foo(&self)` where appropriate, i.e., where the underlying property is named `foo`.