### PR TITLE
Fix SIG(0) calculation

### DIFF
--- a/client/src/op/message.rs
+++ b/client/src/op/message.rs
@@ -655,25 +655,7 @@ impl Message {
                                 signer.signer_name().clone(),
                                 Vec::new());
         let signature: Vec<u8> = try!(signer.sign_message(self, &pre_sig0));
-        sig0.set_rdata(
-            RData::SIG(SIG::new(
-                // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
-                RecordType::NULL,
-                signer.algorithm(),
-                num_labels,
-                // see above, original_ttl is meaningless, The TTL fields SHOULD be zero
-                0,
-                // recommended time is +5 minutes from now, to prevent timing attacks, 2 is probably good
-                expiration_time,
-                // current time, this should be UTC
-                // unsigned numbers of seconds since the start of 1 January 1970, GMT
-                inception_time,
-                key_tag,
-                // can probably get rid of this clone if the owndership is correct
-                signer.signer_name().clone(),
-                signature,
-            )
-        ));
+        sig0.set_rdata(RData::SIG(pre_sig0.set_sig(signature)));
 
         debug!("sig0: {:?}", sig0);
 

--- a/client/src/op/message.rs
+++ b/client/src/op/message.rs
@@ -618,7 +618,6 @@ impl Message {
     #[cfg(feature = "openssl")]
     pub fn sign(&mut self, signer: &Signer, inception_time: u32) -> DnsSecResult<()> {
         debug!("signing message: {:?}", self);
-        let signature: Vec<u8> = try!(signer.sign_message(self));
         let key_tag: u16 = try!(signer.calculate_key_tag());
 
         // this is based on RFCs 2535, 2931 and 3007
@@ -640,6 +639,22 @@ impl Message {
         let expiration_time: u32 = inception_time + (5 * 60); // +5 minutes in seconds
 
         sig0.set_rr_type(RecordType::SIG);
+        let pre_sig0 = SIG::new(// type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
+                                RecordType::NULL,
+                                signer.algorithm(),
+                                num_labels,
+                                // see above, original_ttl is meaningless, The TTL fields SHOULD be zero
+                                0,
+                                // recommended time is +5 minutes from now, to prevent timing attacks, 2 is probably good
+                                expiration_time,
+                                // current time, this should be UTC
+                                // unsigned numbers of seconds since the start of 1 January 1970, GMT
+                                inception_time,
+                                key_tag,
+                                // can probably get rid of this clone if the owndership is correct
+                                signer.signer_name().clone(),
+                                Vec::new());
+        let signature: Vec<u8> = try!(signer.sign_message(self, &pre_sig0));
         sig0.set_rdata(
             RData::SIG(SIG::new(
                 // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -427,7 +427,7 @@ impl Signer {
             message.emit(&mut encoder).unwrap(); // coding error if this panics (i think?)
         }
 
-        DigestType::from(self.algorithm).hash(&buf)
+        Ok(buf)
     }
 
     /// Signs the given message, returning the signature bytes.

--- a/client/src/rr/rdata/key.rs
+++ b/client/src/rr/rdata/key.rs
@@ -380,6 +380,16 @@ fn test_key_usage() {
 ///    apply if the update is within the name and class scope as per
 ///    sections 3.1.1 and 3.1.2.
 /// ```
+///
+/// [RFC 3007](https://tools.ietf.org/html/rfc3007#section-1.5), Secure Dynamic Update, November 2000
+///
+/// ```text
+///    [RFC2535, section 3.1.2] defines the signatory field of a key as the
+///    final 4 bits of the flags field, but does not define its value.  This
+///    proposal leaves this field undefined.  Updating [RFC2535], this field
+///    SHOULD be set to 0 in KEY records, and MUST be ignored.
+///
+/// ```
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct UpdateScope {
     /// this key is authorized to attach,
@@ -403,7 +413,7 @@ impl Default for UpdateScope {
             zone: false,
             strong: false,
             unique: false,
-            general: true,
+            general: false,
         }
     }
 }

--- a/client/src/rr/rdata/sig.rs
+++ b/client/src/rr/rdata/sig.rs
@@ -235,6 +235,29 @@ impl SIG {
         }
     }
 
+    /// Add actual signature value to existing SIG record data.
+    ///
+    /// # Arguments
+    ///
+    /// * `signature` - signature to be stored in this record.
+    ///
+    /// # Return value
+    ///
+    /// The new SIG record data.
+    pub fn set_sig(self, signature: Vec<u8>) -> Self {
+        SIG {
+            type_covered: self.type_covered,
+            algorithm: self.algorithm,
+            num_labels: self.num_labels,
+            original_ttl: self.original_ttl,
+            sig_expiration: self.sig_expiration,
+            sig_inception: self.sig_inception,
+            key_tag: self.key_tag,
+            signer_name: self.signer_name,
+            sig: signature,
+        }
+    }
+
     /// [RFC 2535, Domain Name System Security Extensions, March 1999](https://tools.ietf.org/html/rfc2535#section-4.1.1)
     ///
     /// ```text

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -520,7 +520,7 @@ impl Authority {
                                                               true);
 
                     signer
-                        .verify_message(update_message, sig.sig())
+                        .verify_message(update_message, sig.sig(), sig)
                         .map(|_| {
                                  info!("verified sig: {:?} with key: {:?}", sig, key);
                                  true


### PR DESCRIPTION
This fixes https://github.com/bluejekyll/trust-dns/issues/120, and a bug where the message was hashed twice before signing it.

With these changes, bind9 accepts a SIG(0) signed update request sent with trust_dns.

As mentioned in https://github.com/jannic/trust-dns/commit/f1c05cfcdb0506836adf68988be2af859288fc1f I only tested this with RSA signatures, not sure if ED25519 are missing the hashing step, now.