### PR TITLE
limit generic functions of Client to Sized types

### DIFF
--- a/client/src/client/client.rs
+++ b/client/src/client/client.rs
@@ -80,7 +80,7 @@ pub trait Client<C: ClientHandle> {
                  query_type: RecordType,
                  rrset: Option<R>)
                  -> ClientResult<Message>
-        where R: IntoRecordSet
+        where R: IntoRecordSet, Self: Sized
     {
         self.get_io_loop()
             .run(self.get_client_handle()
@@ -121,7 +121,7 @@ pub trait Client<C: ClientHandle> {
     ///
     /// The update must go to a zone authority (i.e. the server used in the ClientConnection)
     fn create<R>(&self, rrset: R, zone_origin: domain::Name) -> ClientResult<Message>
-        where R: IntoRecordSet
+        where R: IntoRecordSet, Self: Sized
     {
         self.get_io_loop()
             .run(self.get_client_handle().create(rrset, zone_origin))
@@ -166,7 +166,7 @@ pub trait Client<C: ClientHandle> {
                  zone_origin: domain::Name,
                  must_exist: bool)
                  -> ClientResult<Message>
-        where R: IntoRecordSet
+        where R: IntoRecordSet, Self: Sized
     {
         self.get_io_loop()
             .run(self.get_client_handle()
@@ -220,7 +220,8 @@ pub trait Client<C: ClientHandle> {
                                 zone_origin: domain::Name)
                                 -> ClientResult<Message>
         where CR: IntoRecordSet,
-              NR: IntoRecordSet
+              NR: IntoRecordSet,
+              Self: Sized
     {
         self.get_io_loop()
             .run(self.get_client_handle()
@@ -263,7 +264,7 @@ pub trait Client<C: ClientHandle> {
     /// The update must go to a zone authority (i.e. the server used in the ClientConnection). If
     /// the rrset does not exist and must_exist is false, then the RRSet will be deleted.
     fn delete_by_rdata<R>(&self, record: R, zone_origin: domain::Name) -> ClientResult<Message>
-        where R: IntoRecordSet
+        where R: IntoRecordSet, Self: Sized
     {
         self.get_io_loop()
             .run(self.get_client_handle()


### PR DESCRIPTION
This allowes for function definitions like:
```
fn example<T>(client: &mut Client<T>) {
}
```

Without that change, such a definition fails with:

```
error[E0038]: the trait `trust_dns::client::Client` cannot be made into an object
   --> src/main.rs:220:1
    |
220 |   fn example<T>(client: &mut Client<T>) {
    |  _^ starting here...
221 | | }
    | |_^ ...ending here: the trait `trust_dns::client::Client` cannot be made into an object
    |
    = note: method `notify` has generic type parameters
    = note: method `create` has generic type parameters
    = note: method `append` has generic type parameters
    = note: method `compare_and_swap` has generic type parameters
    = note: method `delete_by_rdata` has generic type parameters
```

I'm not sure if this is really a useful use case. While playing with trust-dns I stumbled on the mentioned error message while trying to pass a client object to a function. In the end, I didn't use that function signature at all.

So feel free to merge the PR if you think it's useful, but I won't be disappointed if you just drop it.