### PR TITLE
Fix Ed25519 endianness.

### DIFF
--- a/client/src/rr/dnssec/keypair.rs
+++ b/client/src/rr/dnssec/keypair.rs
@@ -210,10 +210,8 @@ impl KeyPair {
                 //  An Ed25519 public key consists of a 32-octet value, which is encoded
                 //  into the Public Key field of a DNSKEY resource record as a simple bit
                 //  string.  The generation of a public key is defined in Section 5.1.5
-                //  in [I-D.irtf-cfrg-eddsa].
-                //
-                // **NOTE: not specified in the RFC is the byte order, assuming it is
-                //  BigEndian/NetworkByteOrder.
+                //  in [RFC 8032]. Breaking tradition, the keys are encoded in little-
+                //  endian byte order.
                 if public_key.len() != 32 {
                     return Err(DnsSecErrorKind::Msg(format!("expected 32 byte public_key: {}",
                                                             public_key.len()))

--- a/client/src/rr/dnssec/keypair.rs
+++ b/client/src/rr/dnssec/keypair.rs
@@ -218,11 +218,6 @@ impl KeyPair {
                                        .into());
                 }
 
-                // these are LittleEndian encoded bytes... we need to special case
-                //  serialzation/deserialization for endianess. why, Intel, why...
-                let mut public_key = public_key.to_vec();
-                public_key.reverse();
-
                 let mut ed_key_pair = Ed25519KeyPairBytes {
                     private_key: [0_u8; 32],
                     public_key: [0_u8; 32],
@@ -295,11 +290,7 @@ impl KeyPair {
             }
             #[cfg(feature = "ring")]
             KeyPair::ED25519(ref ed_key) => {
-                // this is "little endian" encoded bytes... we need to special case
-                //  serialzation/deserialization for endianess. why, Intel, why...
-                let mut pub_key = ed_key.public_key.to_vec();
-                pub_key.reverse();
-                Ok(pub_key)
+                Ok(ed_key.public_key.to_vec())
             }
             // #[cfg(not(all(feature = "openssl", feature = "ring")))]
             // _ => Err(DnsSecErrorKind::Message("openssl nor ring feature(s) not enabled").into()),


### PR DESCRIPTION
I found the Ed25519-in-DNSSEC spec hard to read but AFAICT it doens't specify an encoding different than the RFC 8032 encoding, so there should be no byte swapping.