### PR TITLE
Fix sig0 key tag

### DIFF
--- a/client/src/rr/dnssec/keypair.rs
+++ b/client/src/rr/dnssec/keypair.rs
@@ -234,6 +234,7 @@ impl KeyPair {
     }
 
     /// Convert this keypair into a KEY record type for usage with SIG0
+    /// with key type entity (`KeyUsage::Entity`).
     ///
     /// # Arguments
     ///
@@ -242,12 +243,27 @@ impl KeyPair {
     /// # Return
     ///
     /// the KEY record data
-    #[allow(deprecated)]
     pub fn to_sig0key(&self, algorithm: Algorithm) -> DnsSecResult<KEY> {
+        self.to_sig0key_with_usage(algorithm, Default::default())
+    }
+
+    /// Convert this keypair into a KEY record type for usage with SIG0
+    /// with a given key (usage) type.
+    ///
+    /// # Arguments
+    ///
+    /// * `algorithm` - algorithm of the KEY
+    /// * `usage`     - the key type
+    ///
+    /// # Return
+    ///
+    /// the KEY record data
+    pub fn to_sig0key_with_usage(&self, algorithm: Algorithm,
+                                 usage: KeyUsage) -> DnsSecResult<KEY> {
         self.to_public_bytes()
             .map(|bytes| {
                      KEY::new(Default::default(),
-                              KeyUsage::Zone,
+                              usage,
                               Default::default(),
                               Default::default(),
                               algorithm,

--- a/client/src/rr/dnssec/keypair.rs
+++ b/client/src/rr/dnssec/keypair.rs
@@ -31,6 +31,7 @@ use rr::dnssec::public_key::Ed25519;
 #[cfg(feature = "openssl")]
 use rr::dnssec::public_key::dnssec_ecdsa_signature_to_der;
 use rr::rdata::{DNSKEY, DS, KEY};
+use rr::rdata::key::KeyUsage;
 
 /// A public and private key pair, the private portion is not required.
 ///
@@ -241,11 +242,12 @@ impl KeyPair {
     /// # Return
     ///
     /// the KEY record data
+    #[allow(deprecated)]
     pub fn to_sig0key(&self, algorithm: Algorithm) -> DnsSecResult<KEY> {
         self.to_public_bytes()
             .map(|bytes| {
                      KEY::new(Default::default(),
-                              Default::default(),
+                              KeyUsage::Zone,
                               Default::default(),
                               Default::default(),
                               algorithm,

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -523,6 +523,7 @@ mod tests {
 
     use rr::{DNSClass, Name, Record, RecordType};
     use rr::rdata::SIG;
+    use rr::rdata::key::KeyUsage;
     use rr::dnssec::Verifier;
     use op::{Message, Query, UpdateMessage};
 
@@ -580,10 +581,12 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_sign_and_verify_rrset() {
         let rsa = Rsa::generate(512).unwrap();
         let key = KeyPair::from_rsa(rsa).unwrap();
-        let sig0key = key.to_sig0key(Algorithm::RSASHA256).unwrap();
+        let sig0key = key.to_sig0key_with_usage(Algorithm::RSASHA256,
+            KeyUsage::Zone).unwrap();
         let signer = Signer::sig0(sig0key, key, Name::root());
 
         let origin: Name = Name::parse("example.com.", None).unwrap();
@@ -659,6 +662,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_calculate_key_tag() {
         let test_vectors = vec!(
             (vec!(33, 3, 21, 11, 3, 1, 1, 1), 9739),
@@ -672,7 +676,8 @@ mod tests {
             println!("pkey:\n{}", String::from_utf8(rsa_pem).unwrap());
 
             let key = KeyPair::from_rsa(rsa).unwrap();
-            let sig0key = key.to_sig0key(Algorithm::RSASHA256).unwrap();
+            let sig0key = key.to_sig0key_with_usage(Algorithm::RSASHA256,
+                KeyUsage::Zone).unwrap();
             let signer = Signer::sig0(sig0key, key, Name::root());
             let key_tag = signer.calculate_key_tag().unwrap();
 
@@ -681,6 +686,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_calculate_key_tag_pem() {
         let x = "-----BEGIN RSA PRIVATE KEY-----
 MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
@@ -692,7 +698,8 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
         println!("pkey:\n{}", String::from_utf8(rsa_pem).unwrap());
 
         let key = KeyPair::from_rsa(rsa).unwrap();
-        let sig0key = key.to_sig0key(Algorithm::RSASHA256).unwrap();
+        let sig0key = key.to_sig0key_with_usage(Algorithm::RSASHA256,
+            KeyUsage::Zone).unwrap();
         let signer = Signer::sig0(sig0key, key, Name::root());
         let key_tag = signer.calculate_key_tag().unwrap();
 


### PR DESCRIPTION
Please consider adjusting generation of sig0 keys for key tags matching those of Bind. These adjustments fix #147.

I'm not quite sure on why KeyUsage is deprecated, yet used by Bind9. Maybe adjusting a key generated by dnssec-keygen (from Bind) to use a different KeyUsage would work as well. However, I thought I'd rather try to adjust trust-dns than bind.

Note that the RSA parameters are unaffected, but the key tag depends on the configured key's usage. This information is not included in the PEM format of the RSA key, for example.