### PR TITLE
Fix possible panic in Name::zone_of

### DIFF
--- a/client/src/rr/domain.rs
+++ b/client/src/rr/domain.rs
@@ -176,6 +176,16 @@ impl Name {
     pub fn zone_of(&self, name: &Self) -> bool {
         let self_len = self.labels.len();
         let name_len = name.labels.len();
+        if self_len == 0 {
+            return true;
+        }
+        if name_len == 0 {
+            // self_len != 0
+            return false;
+        }
+        if self_len > name_len {
+            return false;
+        }
         let self_lower = self.to_lowercase();
         let name_lower = name.to_lowercase();
 

--- a/client/src/rr/domain.rs
+++ b/client/src/rr/domain.rs
@@ -785,10 +785,13 @@ mod tests {
         let zone = Name::new().label("example").label("com");
         let www = Name::new().label("www").label("example").label("com");
         let none = Name::new().label("none").label("com");
+        let root = Name::root();
 
         assert!(zone.zone_of(&zone));
         assert!(zone.zone_of(&www));
-        assert!(!zone.zone_of(&none))
+        assert!(!zone.zone_of(&none));
+        assert!(root.zone_of(&zone));
+        assert!(!zone.zone_of(&root));
     }
 
     #[test]


### PR DESCRIPTION
Calling Name::zone_of would panic (`attempt to subtract with overflow`) if either `self` or `name` is root. Fixing that.

Also we can return early when `self_len > name_len`.