### PR TITLE
Make ServerFuture generic over T: RequestHandler

### DIFF
--- a/client/src/op/mod.rs
+++ b/client/src/op/mod.rs
@@ -22,7 +22,6 @@ pub mod header;
 pub mod message;
 pub mod op_code;
 pub mod query;
-pub mod request_handler;
 pub mod response_code;
 
 pub use self::edns::Edns;
@@ -31,5 +30,4 @@ pub use self::header::MessageType;
 pub use self::message::{Message, UpdateMessage};
 pub use self::op_code::OpCode;
 pub use self::query::Query;
-pub use self::request_handler::RequestHandler;
 pub use self::response_code::ResponseCode;

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -19,9 +19,11 @@
 mod request_stream;
 mod server_future;
 mod timeout_stream;
+mod request_handler;
 
 pub use self::request_stream::Request;
 pub use self::request_stream::RequestStream;
 pub use self::request_stream::ResponseHandle;
 pub use self::server_future::ServerFuture;
 pub use self::timeout_stream::TimeoutStream;
+pub use self::request_handler::RequestHandler;

--- a/server/src/server/request_handler.rs
+++ b/server/src/server/request_handler.rs
@@ -7,11 +7,10 @@
 
 //! Request Handler for incoming requests
 
-use op::Message;
+use server::Request;
+use trust_dns::op::Message;
 
 /// Trait for handling incoming requests, and providing a message response.
-///
-/// *note* this probably belongs in the server crate and may move there in the future.
 pub trait RequestHandler {
     /// Determine's what needs to happen given the type of request, i.e. Query or Update.
     ///
@@ -22,5 +21,5 @@ pub trait RequestHandler {
     /// # Returns
     ///
     /// The derived response to the the request
-    fn handle_request(&self, request: &Message) -> Message;
+    fn handle_request(&self, request: &Request) -> Message;
 }

--- a/server/src/server/server_future.rs
+++ b/server/src/server/server_future.rs
@@ -17,12 +17,11 @@ use tokio_core;
 use tokio_core::reactor::Core;
 use tokio_openssl::SslAcceptorExt;
 
-use trust_dns::op::RequestHandler;
 use trust_dns::udp::UdpStream;
 use trust_dns::tcp::TcpStream;
 use trust_dns::tls::TlsStream;
 
-use server::{Request, RequestStream, ResponseHandle, TimeoutStream};
+use server::{Request, RequestHandler, RequestStream, ResponseHandle, TimeoutStream};
 use authority::Catalog;
 
 // TODO, would be nice to have a Slab for buffers here...
@@ -218,7 +217,7 @@ impl ServerFuture {
                       mut response_handle: ResponseHandle,
                       catalog: Arc<Catalog>)
                       -> io::Result<()> {
-        let response = catalog.handle_request(&request.message);
+        let response = catalog.handle_request(&request);
         response_handle.send(response)
     }
 }

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -16,6 +16,7 @@ use trust_dns::op::*;
 use trust_dns::serialize::binary::*;
 
 use trust_dns_server::authority::Catalog;
+use trust_dns_server::server::{Request, RequestHandler};
 
 pub mod authority;
 pub mod server_harness;
@@ -56,7 +57,8 @@ impl Stream for TestClientStream {
                 let mut decoder = BinDecoder::new(&bytes);
 
                 let message = Message::read(&mut decoder).expect("could not decode message");
-                let response = self.catalog.handle_request(&message);
+                let request = Request { message: message, src: "127.0.0.1:1234".parse().expect("cannot parse host and port") };
+                let response = self.catalog.handle_request(&request);
 
                 let mut buf = Vec::with_capacity(512);
                 {


### PR DESCRIPTION
This allows you to easily implement a DNS server with your own handler.

Also pass in the whole request to the handler function, as sometimes you might be interested in some other details of the request, like the originating IP address.
