### PR TITLE
Borrow `Handle`s, don't consume them

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ environment:
     OPENSSL_DIR: C:\OpenSSL
     RUST_BACKTRACE: 1
 
+init:
+  - ps: Disable-NetFirewallRule -DisplayName 'Core Networking - Group Policy (LSASS-Out)'
+
 install:
   # Install OpenSSL
   - ps: Start-FileDownload "http://slproweb.com/download/Win${env:BITS}OpenSSL-${env:OPENSSL_VERSION}.exe"

--- a/client/src/client/client.rs
+++ b/client/src/client/client.rs
@@ -368,7 +368,7 @@ impl SyncClient {
 where <CC as ClientConnection>::MessageStream: Stream<Item=Vec<u8>, Error=io::Error> + 'static{
         let (io_loop, stream, stream_handle) = client_connection.unwrap();
 
-        let client = ClientFuture::new(stream, stream_handle, io_loop.handle(), None);
+        let client = ClientFuture::new(stream, stream_handle, &io_loop.handle(), None);
 
         SyncClient {
             client_handle: RefCell::new(client),
@@ -388,7 +388,7 @@ where <CC as ClientConnection>::MessageStream: Stream<Item=Vec<u8>, Error=io::Er
 where <CC as ClientConnection>::MessageStream: Stream<Item=Vec<u8>, Error=io::Error> + 'static{
         let (io_loop, stream, stream_handle) = client_connection.unwrap();
 
-        let client = ClientFuture::new(stream, stream_handle, io_loop.handle(), Some(signer));
+        let client = ClientFuture::new(stream, stream_handle, &io_loop.handle(), Some(signer));
 
         SyncClient {
             client_handle: RefCell::new(client),
@@ -519,7 +519,7 @@ where CC: ClientConnection,
     let client = ClientFuture::new(
       stream,
       stream_handle,
-      io_loop.handle(),
+      &io_loop.handle(),
       self.signer);
 
     let client = SecureClientHandle::with_trust_anchor(client, self.trust_anchor.unwrap_or(Default::default()));

--- a/client/src/client/client_future.rs
+++ b/client/src/client/client_future.rs
@@ -76,7 +76,7 @@ impl<S: Stream<Item = Vec<u8>, Error = io::Error> + 'static> ClientFuture<S> {
     /// * `signer` - An optional signer for requests, needed for Updates with Sig0, otherwise not needed
     pub fn new(stream: Box<Future<Item = S, Error = io::Error>>,
                stream_handle: Box<ClientStreamHandle>,
-               loop_handle: Handle,
+               loop_handle: &Handle,
                signer: Option<Signer>)
                -> BasicClientHandle {
         Self::with_timeout(stream,
@@ -100,7 +100,7 @@ impl<S: Stream<Item = Vec<u8>, Error = io::Error> + 'static> ClientFuture<S> {
     /// * `signer` - An optional signer for requests, needed for Updates with Sig0, otherwise not needed
     pub fn with_timeout(stream: Box<Future<Item = S, Error = io::Error>>,
                         stream_handle: Box<ClientStreamHandle>,
-                        loop_handle: Handle,
+                        loop_handle: &Handle,
                         timeout_duration: Duration,
                         signer: Option<Signer>)
                         -> BasicClientHandle {

--- a/client/src/tcp/tcp_client_connection.rs
+++ b/client/src/tcp/tcp_client_connection.rs
@@ -61,7 +61,7 @@ impl TcpClientConnection {
     pub fn with_timeout(name_server: SocketAddr, timeout: Duration) -> ClientResult<Self> {
         let io_loop = try!(Core::new());
         let (tcp_client_stream, handle) =
-            TcpClientStream::<TcpStream>::with_timeout(name_server, io_loop.handle(), timeout);
+            TcpClientStream::<TcpStream>::with_timeout(name_server, &io_loop.handle(), timeout);
 
         Ok(TcpClientConnection {
                io_loop: io_loop,

--- a/client/src/tcp/tcp_client_stream.rs
+++ b/client/src/tcp/tcp_client_stream.rs
@@ -36,7 +36,7 @@ impl TcpClientStream<TokioTcpStream> {
     /// * `name_server` - the IP and Port of the DNS server to connect to
     /// * `loop_handle` - reference to the takio_core::Core for future based IO
     pub fn new(name_server: SocketAddr,
-               loop_handle: Handle)
+               loop_handle: &Handle)
                -> (Box<Future<Item = TcpClientStream<TokioTcpStream>, Error = io::Error>>,
                    Box<ClientStreamHandle>) {
         Self::with_timeout(name_server, loop_handle, Duration::from_secs(5))
@@ -50,7 +50,7 @@ impl TcpClientStream<TokioTcpStream> {
     /// * `loop_handle` - reference to the takio_core::Core for future based IO
     /// * `timeout` - connection timeout
     pub fn with_timeout(name_server: SocketAddr,
-                        loop_handle: Handle,
+                        loop_handle: &Handle,
                         timeout: Duration)
                         -> (Box<Future<Item = TcpClientStream<TokioTcpStream>, Error = io::Error>>,
                             Box<ClientStreamHandle>) {
@@ -203,7 +203,7 @@ fn tcp_client_stream_test(server_addr: IpAddr) {
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5), &io_loop.handle());
-    let (stream, mut sender) = TcpClientStream::new(server_addr, io_loop.handle());
+    let (stream, mut sender) = TcpClientStream::new(server_addr, &io_loop.handle());
 
     let mut stream = io_loop
         .run(stream)

--- a/client/src/tcp/tcp_stream.rs
+++ b/client/src/tcp/tcp_stream.rs
@@ -92,7 +92,7 @@ impl TcpStream<TokioTcpStream> {
     /// * `loop_handle` - reference to the takio_core::Core for future based IO
     pub fn new
         (name_server: SocketAddr,
-         loop_handle: Handle)
+         loop_handle: &Handle)
          -> (Box<Future<Item = TcpStream<TokioTcpStream>, Error = io::Error>>, BufStreamHandle) {
         Self::with_timeout(name_server, loop_handle, Duration::from_secs(5))
     }
@@ -106,7 +106,7 @@ impl TcpStream<TokioTcpStream> {
     /// * `timeout` - connection timeout
     pub fn with_timeout
         (name_server: SocketAddr,
-         loop_handle: Handle,
+         loop_handle: &Handle,
          timeout: Duration)
          -> (Box<Future<Item = TcpStream<TokioTcpStream>, Error = io::Error>>, BufStreamHandle) {
         let (message_sender, outbound_messages) = unbounded();
@@ -496,7 +496,7 @@ fn tcp_client_stream_test(server_addr: IpAddr) {
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5), &io_loop.handle());
-    let (stream, sender) = TcpStream::new(server_addr, io_loop.handle());
+    let (stream, sender) = TcpStream::new(server_addr, &io_loop.handle());
 
     let mut stream = io_loop
         .run(stream)

--- a/client/src/tls/tests.rs
+++ b/client/src/tls/tests.rs
@@ -193,7 +193,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
         config_mtls(&root_pkey, &root_name, &root_cert, &mut builder);
     }
 
-    let (stream, sender) = builder.build(server_addr, subject_name.to_string(), io_loop.handle());
+    let (stream, sender) = builder.build(server_addr, subject_name.to_string(), &io_loop.handle());
 
     // TODO: there is a race failure here... a race with the server thread most likely...
     let mut stream = io_loop

--- a/client/src/tls/tls_client_connection.rs
+++ b/client/src/tls/tls_client_connection.rs
@@ -85,7 +85,7 @@ impl TlsClientConnectionBuilder {
                  subject_name: String)
                  -> ClientResult<TlsClientConnection> {
         let io_loop = try!(Core::new());
-        let (tls_client_stream, handle) = self.0.build(name_server, subject_name, io_loop.handle());
+        let (tls_client_stream, handle) = self.0.build(name_server, subject_name, &io_loop.handle());
 
         Ok(TlsClientConnection {
                io_loop: io_loop,

--- a/client/src/tls/tls_client_stream.rs
+++ b/client/src/tls/tls_client_stream.rs
@@ -59,7 +59,7 @@ impl TlsClientStreamBuilder {
         (self,
          name_server: SocketAddr,
          subject_name: String,
-         loop_handle: Handle)
+         loop_handle: &Handle)
          -> (Box<Future<Item = TlsClientStream, Error = io::Error>>, Box<ClientStreamHandle>) {
         let (stream_future, sender) = self.0.build(name_server, subject_name, loop_handle);
 

--- a/client/src/tls/tls_stream.rs
+++ b/client/src/tls/tls_stream.rs
@@ -171,7 +171,7 @@ impl TlsStreamBuilder {
     pub fn build(self,
                  name_server: SocketAddr,
                  subject_name: String,
-                 loop_handle: Handle)
+                 loop_handle: &Handle)
                  -> (Box<Future<Item = TlsStream, Error = io::Error>>, BufStreamHandle) {
         let (message_sender, outbound_messages) = unbounded();
         let tls_connector =

--- a/client/src/udp/udp_client_connection.rs
+++ b/client/src/udp/udp_client_connection.rs
@@ -44,7 +44,7 @@ impl UdpClientConnection {
     /// * `name_server` - address of the name server to use for queries
     pub fn new(name_server: SocketAddr) -> ClientResult<Self> {
         let io_loop = try!(Core::new());
-        let (udp_client_stream, handle) = UdpClientStream::new(name_server, io_loop.handle());
+        let (udp_client_stream, handle) = UdpClientStream::new(name_server, &io_loop.handle());
 
         Ok(UdpClientConnection {
                io_loop: io_loop,

--- a/client/src/udp/udp_client_stream.rs
+++ b/client/src/udp/udp_client_stream.rs
@@ -33,7 +33,7 @@ impl UdpClientStream {
     ///  handle which can be used to send messages into the stream.
     pub fn new
         (name_server: SocketAddr,
-         loop_handle: Handle)
+         loop_handle: &Handle)
          -> (Box<Future<Item = UdpClientStream, Error = io::Error>>, Box<ClientStreamHandle>) {
         let (stream_future, sender) = UdpStream::new(name_server, loop_handle);
 
@@ -152,7 +152,7 @@ fn udp_client_stream_test(server_addr: IpAddr) {
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5), &io_loop.handle());
-    let (stream, mut sender) = UdpClientStream::new(server_addr, io_loop.handle());
+    let (stream, mut sender) = UdpClientStream::new(server_addr, &io_loop.handle());
     let mut stream: UdpClientStream = io_loop.run(stream).ok().unwrap();
 
     for _ in 0..send_recv_times {

--- a/native-tls/src/tests.rs
+++ b/native-tls/src/tests.rs
@@ -173,7 +173,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     //     config_mtls(&root_pkey, &root_name, &root_cert, &mut builder);
     // }
 
-    let (stream, sender) = builder.build(server_addr, subject_name.to_string(), io_loop.handle());
+    let (stream, sender) = builder.build(server_addr, subject_name.to_string(), &io_loop.handle());
 
     // TODO: there is a race failure here... a race with the server thread most likely...
     let mut stream = io_loop

--- a/native-tls/src/tls_client_connection.rs
+++ b/native-tls/src/tls_client_connection.rs
@@ -87,7 +87,7 @@ impl TlsClientConnectionBuilder {
                  subject_name: String)
                  -> ClientResult<TlsClientConnection> {
         let io_loop = try!(Core::new());
-        let (tls_client_stream, handle) = self.0.build(name_server, subject_name, io_loop.handle());
+        let (tls_client_stream, handle) = self.0.build(name_server, subject_name, &io_loop.handle());
 
         Ok(TlsClientConnection {
                io_loop: io_loop,

--- a/native-tls/src/tls_client_stream.rs
+++ b/native-tls/src/tls_client_stream.rs
@@ -62,7 +62,7 @@ impl TlsClientStreamBuilder {
         (self,
          name_server: SocketAddr,
          subject_name: String,
-         loop_handle: Handle)
+         loop_handle: &Handle)
          -> (Box<Future<Item = TlsClientStream, Error = io::Error>>, Box<ClientStreamHandle>) {
         let (stream_future, sender) = self.0.build(name_server, subject_name, loop_handle);
 

--- a/native-tls/src/tls_stream.rs
+++ b/native-tls/src/tls_stream.rs
@@ -131,7 +131,7 @@ impl TlsStreamBuilder {
     pub fn build(self,
                  name_server: SocketAddr,
                  subject_name: String,
-                 loop_handle: Handle)
+                 loop_handle: &Handle)
                  -> (Box<Future<Item = TlsStream, Error = io::Error>>, BufStreamHandle) {
         let (message_sender, outbound_messages) = unbounded();
         let tls_connector =

--- a/resolver/src/lib.rs
+++ b/resolver/src/lib.rs
@@ -77,7 +77,7 @@
 //! let mut io_loop = Core::new().unwrap(); 
 //!
 //! // Construct a new Resolver with default configuration options
-//! let mut resolver = ResolverFuture::new(ResolverConfig::default(), ResolverOpts::default(), io_loop.handle());
+//! let mut resolver = ResolverFuture::new(ResolverConfig::default(), ResolverOpts::default(), &io_loop.handle());
 //! 
 //! // Lookup the IP addresses associated with a name.
 //! // NOTE: do not forget the final dot, as the resolver does not yet support search paths.

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -37,7 +37,7 @@ impl Resolver {
     /// A new Resolver
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> io::Result<Self> {
         let io_loop = Core::new()?;
-        let resolver = ResolverFuture::new(config, options, io_loop.handle());
+        let resolver = ResolverFuture::new(config, options, &io_loop.handle());
 
         Ok(Resolver {
             resolver_future: RefCell::new(resolver),

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -21,7 +21,7 @@ pub struct ResolverFuture {
 
 impl ResolverFuture {
     /// Construct a new ResolverFuture with the associated Client.
-    pub fn new(config: ResolverConfig, options: ResolverOpts, reactor: Handle) -> Self {
+    pub fn new(config: ResolverConfig, options: ResolverOpts, reactor: &Handle) -> Self {
         let pool = NameServerPool::from_config(&config, &options, reactor);
         ResolverFuture { options, pool }
     }
@@ -57,7 +57,7 @@ mod tests {
         let mut resolver = ResolverFuture::new(
             ResolverConfig::default(),
             ResolverOpts::default(),
-            io_loop.handle(),
+            &io_loop.handle(),
         );
 
         let response = io_loop.run(resolver.lookup_ip("www.example.com.")).expect("failed to run lookup");

--- a/rustls/src/tests.rs
+++ b/rustls/src/tests.rs
@@ -198,7 +198,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     //     config_mtls(&root_pkey, &root_name, &root_cert, &mut builder);
     // }
 
-    let (stream, sender) = builder.build(server_addr, subject_name.to_string(), io_loop.handle());
+    let (stream, sender) = builder.build(server_addr, subject_name.to_string(), &io_loop.handle());
 
     // TODO: there is a race failure here... a race with the server thread most likely...
     let mut stream = io_loop

--- a/rustls/src/tls_client_connection.rs
+++ b/rustls/src/tls_client_connection.rs
@@ -82,7 +82,7 @@ impl TlsClientConnectionBuilder {
                  subject_name: String)
                  -> ClientResult<TlsClientConnection> {
         let io_loop = try!(Core::new());
-        let (tls_client_stream, handle) = self.0.build(name_server, subject_name, io_loop.handle());
+        let (tls_client_stream, handle) = self.0.build(name_server, subject_name, &io_loop.handle());
 
         Ok(TlsClientConnection {
                io_loop: io_loop,

--- a/rustls/src/tls_client_stream.rs
+++ b/rustls/src/tls_client_stream.rs
@@ -53,7 +53,7 @@ impl TlsClientStreamBuilder {
         (self,
          name_server: SocketAddr,
          subject_name: String,
-         loop_handle: Handle)
+         loop_handle: &Handle)
          -> (Box<Future<Item = TlsClientStream, Error = io::Error>>, Box<ClientStreamHandle>) {
         let (stream_future, sender) = self.0.build(name_server, subject_name, loop_handle);
 

--- a/rustls/src/tls_stream.rs
+++ b/rustls/src/tls_stream.rs
@@ -119,7 +119,7 @@ impl TlsStreamBuilder {
     pub fn build(self,
                  name_server: SocketAddr,
                  subject_name: String,
-                 loop_handle: Handle)
+                 loop_handle: &Handle)
                  -> (Box<Future<Item = TlsStream, Error = io::Error>>, BufStreamHandle) {
         let (message_sender, outbound_messages) = unbounded();
         let tls_connector =

--- a/server/src/server/server_future.rs
+++ b/server/src/server/server_future.rs
@@ -45,7 +45,7 @@ impl <T: RequestHandler> ServerFuture <T> {
         debug!("registered udp: {:?}", socket);
 
         // create the new UdpStream
-        let (buf_stream, stream_handle) = UdpStream::with_bound(socket, self.io_loop.handle());
+        let (buf_stream, stream_handle) = UdpStream::with_bound(socket, &self.io_loop.handle());
         let request_stream = RequestStream::new(buf_stream, stream_handle);
         let handler = self.handler.clone();
 
@@ -93,7 +93,7 @@ impl <T: RequestHandler> ServerFuture <T> {
                 debug!("accepted request from: {}", src_addr);
                 // take the created stream...
                 let (buf_stream, stream_handle) = TcpStream::from_stream(tcp_stream, src_addr);
-                let timeout_stream = try!(TimeoutStream::new(buf_stream, timeout, handle.clone()));
+                let timeout_stream = try!(TimeoutStream::new(buf_stream, timeout, &handle));
                 let request_stream = RequestStream::new(timeout_stream, stream_handle);
                 let handler = handler.clone();
 
@@ -174,7 +174,7 @@ impl <T: RequestHandler> ServerFuture <T> {
                               .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, format!("tls error: {}", e)))
                               .and_then(move |tls_stream| {
                                   let (buf_stream, stream_handle) = TlsStream::from_stream(tls_stream, src_addr.clone());
-                                  let timeout_stream = try!(TimeoutStream::new(buf_stream, timeout, handle.clone()));
+                                  let timeout_stream = try!(TimeoutStream::new(buf_stream, timeout, &handle));
                                   let request_stream = RequestStream::new(timeout_stream, stream_handle);
                                   let handler = handler.clone();
 

--- a/server/src/server/timeout_stream.rs
+++ b/server/src/server/timeout_stream.rs
@@ -23,14 +23,14 @@ impl<S> TimeoutStream<S> {
     /// * `stream` - stream to wrap
     /// * `timeout_duration` - timeout between each request, once exceed the connection is killed
     /// * `reactor_handle` - reactor used for registering new timeouts
-    pub fn new(stream: S, timeout_duration: Duration, reactor_handle: Handle) -> io::Result<Self> {
+    pub fn new(stream: S, timeout_duration: Duration, reactor_handle: &Handle) -> io::Result<Self> {
         // store a Timeout for this message before sending
 
-        let timeout = try!(Self::timeout(timeout_duration, &reactor_handle));
+        let timeout = try!(Self::timeout(timeout_duration, reactor_handle));
 
         Ok(TimeoutStream {
             stream: stream,
-            reactor_handle: reactor_handle,
+            reactor_handle: reactor_handle.clone(),
             timeout_duration: timeout_duration,
             timeout: timeout,
         })

--- a/server/tests/client_future_tests.rs
+++ b/server/tests/client_future_tests.rs
@@ -37,7 +37,7 @@ fn test_query_nonet() {
 
     let mut io_loop = Core::new().unwrap();
     let (stream, sender) = TestClientStream::new(catalog);
-    let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
     io_loop.run(test_query(&mut client)).unwrap();
     io_loop.run(test_query(&mut client)).unwrap();
@@ -55,8 +55,8 @@ fn test_query_udp_ipv4() {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = UdpClientStream::new(addr, io_loop.handle());
-    let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let (stream, sender) = UdpClientStream::new(addr, &io_loop.handle());
+    let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
     // TODO: timeouts on these requests so that the test doesn't hang
     io_loop.run(test_query(&mut client)).unwrap();
@@ -75,8 +75,8 @@ fn test_query_udp_ipv6() {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = UdpClientStream::new(addr, io_loop.handle());
-    let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let (stream, sender) = UdpClientStream::new(addr, &io_loop.handle());
+    let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
     // TODO: timeouts on these requests so that the test doesn't hang
     io_loop.run(test_query(&mut client)).unwrap();
@@ -95,8 +95,8 @@ fn test_query_tcp_ipv4() {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-    let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+    let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
     // TODO: timeouts on these requests so that the test doesn't hang
     io_loop.run(test_query(&mut client)).unwrap();
@@ -115,8 +115,8 @@ fn test_query_tcp_ipv6() {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-    let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+    let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
     // TODO: timeouts on these requests so that the test doesn't hang
     io_loop.run(test_query(&mut client)).unwrap();
@@ -165,7 +165,7 @@ fn test_notify() {
 
     let mut io_loop = Core::new().unwrap();
     let (stream, sender) = TestClientStream::new(catalog);
-    let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
     let name = domain::Name::with_labels(vec!["ping".to_string(),
                                               "example".to_string(),
@@ -211,7 +211,7 @@ fn create_sig0_ready_client(io_loop: &Core) -> (BasicClientHandle, domain::Name)
     catalog.upsert(authority.origin().clone(), authority);
 
     let (stream, sender) = TestClientStream::new(catalog);
-    let client = ClientFuture::new(stream, sender, io_loop.handle(), Some(signer));
+    let client = ClientFuture::new(stream, sender, &io_loop.handle(), Some(signer));
 
     (client, origin)
 }
@@ -830,7 +830,7 @@ fn test_timeout_query_nonet() {
     let (stream, sender) = NeverReturnsClientStream::new();
     let client = ClientFuture::with_timeout(stream,
                                             sender,
-                                            io_loop.handle(),
+                                            &io_loop.handle(),
                                             std::time::Duration::from_millis(1),
                                             None);
     test_timeout_query(client, io_loop);
@@ -846,10 +846,10 @@ fn test_timeout_query_udp() {
         .next()
         .unwrap();
 
-    let (stream, sender) = UdpClientStream::new(addr, io_loop.handle());
+    let (stream, sender) = UdpClientStream::new(addr, &io_loop.handle());
     let client = ClientFuture::with_timeout(stream,
                                             sender,
-                                            io_loop.handle(),
+                                            &io_loop.handle(),
                                             std::time::Duration::from_millis(1),
                                             None);
     test_timeout_query(client, io_loop);
@@ -866,10 +866,10 @@ fn test_timeout_query_tcp() {
         .unwrap();
 
     let (stream, sender) =
-        TcpClientStream::with_timeout(addr, io_loop.handle(), std::time::Duration::from_millis(1));
+        TcpClientStream::with_timeout(addr, &io_loop.handle(), std::time::Duration::from_millis(1));
     let client = ClientFuture::with_timeout(stream,
                                             sender,
-                                            io_loop.handle(),
+                                            &io_loop.handle(),
                                             std::time::Duration::from_millis(1),
                                             None);
     test_timeout_query(client, io_loop);

--- a/server/tests/secure_client_handle_tests.rs
+++ b/server/tests/secure_client_handle_tests.rs
@@ -219,7 +219,7 @@ fn with_nonet<F>(test: F)
 
     let io_loop = Core::new().unwrap();
     let (stream, sender) = TestClientStream::new(catalog);
-    let client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
     let client = MemoizeClientHandle::new(client);
     let secure_client = SecureClientHandle::with_trust_anchor(client, trust_anchor);
 
@@ -255,8 +255,8 @@ fn with_udp<F>(test: F)
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = UdpClientStream::new(addr, io_loop.handle());
-    let client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let (stream, sender) = UdpClientStream::new(addr, &io_loop.handle());
+    let client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
     let client = MemoizeClientHandle::new(client);
     let secure_client = SecureClientHandle::new(client);
 
@@ -292,8 +292,8 @@ fn with_tcp<F>(test: F)
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-    let client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+    let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+    let client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
     let client = MemoizeClientHandle::new(client);
     let secure_client = SecureClientHandle::new(client);
 

--- a/server/tests/timeout_stream_tests.rs
+++ b/server/tests/timeout_stream_tests.rs
@@ -16,7 +16,7 @@ fn test_no_timeout() {
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
     let mut core = Core::new().expect("could not get core");
 
-    let timeout_stream = TimeoutStream::new(sequence, Duration::from_secs(360), core.handle())
+    let timeout_stream = TimeoutStream::new(sequence, Duration::from_secs(360), &core.handle())
         .expect("could not create timeout_stream");
 
     let (val, timeout_stream) =
@@ -52,7 +52,7 @@ impl Stream for NeverStream {
 fn test_timeout() {
     let mut core = Core::new().expect("could not get core");
     let timeout_stream =
-        TimeoutStream::new(NeverStream {}, Duration::from_millis(1), core.handle())
+        TimeoutStream::new(NeverStream {}, Duration::from_millis(1), &core.handle())
             .expect("could not create timeout_stream");
 
     assert!(core.run(timeout_stream.into_future()).is_err());

--- a/server/tests/z_named_native_tls_tests.rs
+++ b/server/tests/z_named_native_tls_tests.rs
@@ -43,8 +43,8 @@ fn test_example_tls_toml_startup() {
         let cert = to_trust_anchor(&cert_der);
         tls_conn_builder.add_ca(cert);
         let (stream, sender) =
-            tls_conn_builder.build(addr, "ns.example.com".to_string(), io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+            tls_conn_builder.build(addr, "ns.example.com".to_string(), &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         // ipv4 should succeed
         assert!(query(&mut io_loop, &mut client));
@@ -54,8 +54,8 @@ fn test_example_tls_toml_startup() {
         let cert = to_trust_anchor(&cert_der);
         tls_conn_builder.add_ca(cert);
         let (stream, sender) =
-            tls_conn_builder.build(addr, "ns.example.com".to_string(), io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+            tls_conn_builder.build(addr, "ns.example.com".to_string(), &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         // ipv6 should succeed
         assert!(query(&mut io_loop, &mut client));

--- a/server/tests/z_named_tests.rs
+++ b/server/tests/z_named_tests.rs
@@ -32,15 +32,15 @@ fn test_example_toml_startup() {
     named_test_harness("example.toml", |port, _| {
         let mut io_loop = Core::new().unwrap();
         let addr: SocketAddr = ("127.0.0.1", port).to_socket_addrs().unwrap().next().unwrap();
-        let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+        let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         assert!(query(&mut io_loop, &mut client));
 
         // just tests that multiple queries work
         let addr: SocketAddr = ("127.0.0.1", port).to_socket_addrs().unwrap().next().unwrap();
-        let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+        let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         assert!(query(&mut io_loop, &mut client));
     })
@@ -51,15 +51,15 @@ fn test_ipv4_only_toml_startup() {
     named_test_harness("ipv4_only.toml", |port, _| {
         let mut io_loop = Core::new().unwrap();
         let addr: SocketAddr = ("127.0.0.1", port).to_socket_addrs().unwrap().next().unwrap();
-        let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+        let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         // ipv4 should succeed
         assert!(query(&mut io_loop, &mut client));
 
         let addr: SocketAddr = ("::1", port).to_socket_addrs().unwrap().next().unwrap();
-        let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+        let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         // ipv6 should fail
         assert!(!query(&mut io_loop, &mut client));
@@ -75,15 +75,15 @@ fn test_ipv4_only_toml_startup() {
 //   named_test_harness("ipv6_only.toml", |port, _| {
 //     let mut io_loop = Core::new().unwrap();
 //     let addr: SocketAddr = ("127.0.0.1", port).to_socket_addrs().unwrap().next().unwrap();
-//     let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-//     let client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+//     let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+//     let client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 //
 //     // ipv4 should fail
 //     assert!(!query(&mut io_loop, client));
 //
 //     let addr: SocketAddr = ("::1", port).to_socket_addrs().unwrap().next().unwrap();
-//     let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-//     let client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+//     let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+//     let client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 //
 //     // ipv6 should succeed
 //     assert!(query(&mut io_loop, client));
@@ -98,15 +98,15 @@ fn test_ipv4_and_ipv6_toml_startup() {
     named_test_harness("ipv4_and_ipv6.toml", |port, _| {
         let mut io_loop = Core::new().unwrap();
         let addr: SocketAddr = ("127.0.0.1", port).to_socket_addrs().unwrap().next().unwrap();
-        let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+        let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         // ipv4 should succeed
         assert!(query(&mut io_loop, &mut client));
 
         let addr: SocketAddr = ("::1", port).to_socket_addrs().unwrap().next().unwrap();
-        let (stream, sender) = TcpClientStream::new(addr, io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+        let (stream, sender) = TcpClientStream::new(addr, &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         // ipv6 should succeed
         assert!(query(&mut io_loop, &mut client));
@@ -133,8 +133,8 @@ fn test_example_tls_toml_startup() {
         let cert = to_trust_anchor(&cert_der);
         tls_conn_builder.add_ca(cert);
         let (stream, sender) =
-            tls_conn_builder.build(addr, "ns.example.com".to_string(), io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+            tls_conn_builder.build(addr, "ns.example.com".to_string(), &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         // ipv4 should succeed
         assert!(query(&mut io_loop, &mut client));
@@ -144,8 +144,8 @@ fn test_example_tls_toml_startup() {
         let cert = to_trust_anchor(&cert_der);
         tls_conn_builder.add_ca(cert);
         let (stream, sender) =
-            tls_conn_builder.build(addr, "ns.example.com".to_string(), io_loop.handle());
-        let mut client = ClientFuture::new(stream, sender, io_loop.handle(), None);
+            tls_conn_builder.build(addr, "ns.example.com".to_string(), &io_loop.handle());
+        let mut client = ClientFuture::new(stream, sender, &io_loop.handle(), None);
 
         // ipv6 should succeed
         assert!(query(&mut io_loop, &mut client));


### PR DESCRIPTION
Fixes https://github.com/bluejekyll/trust-dns/issues/167