### PR TITLE
Remove private key and certificate generation features from the server.

### DIFF
--- a/openssl/src/tls_server.rs
+++ b/openssl/src/tls_server.rs
@@ -1,10 +1,4 @@
-use openssl::asn1::*;
-use openssl::bn::*;
-use openssl::{hash, nid};
 use openssl::pkcs12::*;
-use openssl::pkey::PKey;
-use openssl::x509::*;
-use openssl::x509::extension::*;
 use openssl::ssl;
 use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslMethod};
 
@@ -12,8 +6,6 @@ use std::fs::File;
 use std::io;
 use std::io::Read;
 use std::path::Path;
-
-use trust_dns::error::DnsSecResult;
 
 pub use openssl::pkcs12::ParsedPkcs12;
 pub use tokio_openssl::SslAcceptorExt;
@@ -33,56 +25,6 @@ pub fn read_cert(path: &Path, password: Option<&str>)
         .map_err(|e| format!("failed to open pkcs12 from: {:?}: {}", path, e))
 }
 
-/// generates a certificate
-pub fn generate_cert(subject_name: &str, pkey: PKey, password: Option<&str>)
-                     -> DnsSecResult<(X509, Pkcs12)> {
-    let mut x509_name = try!(X509NameBuilder::new());
-    try!(x509_name.append_entry_by_nid(nid::COMMONNAME, subject_name));
-    let x509_name = x509_name.build();
-
-    let mut serial: BigNum = try!(BigNum::new());
-    try!(serial.pseudo_rand(32, MSB_MAYBE_ZERO, false));
-    let serial = try!(serial.to_asn1_integer());
-
-    let mut x509_build = try!(X509::builder());
-    try!(Asn1Time::days_from_now(0).and_then(|t| x509_build.set_not_before(&t)));
-    try!(Asn1Time::days_from_now(256).and_then(|t| x509_build.set_not_after(&t)));
-    try!(x509_build.set_issuer_name(&x509_name));
-    try!(x509_build.set_subject_name(&x509_name));
-    try!(x509_build.set_pubkey(&pkey));
-    try!(x509_build.set_serial_number(&serial));
-
-    let ext_key_usage = try!(ExtendedKeyUsage::new()
-        .server_auth()
-        .client_auth()
-        .build());
-    try!(x509_build.append_extension(ext_key_usage));
-
-    let subject_key_identifier = try!(SubjectKeyIdentifier::new()
-        .build(&x509_build.x509v3_context(None, None)));
-    try!(x509_build.append_extension(subject_key_identifier));
-
-    let authority_key_identifier = try!(AuthorityKeyIdentifier::new()
-        .keyid(true)
-        .build(&x509_build.x509v3_context(None, None)));
-    try!(x509_build.append_extension(authority_key_identifier));
-
-    let subject_alternative_name = try!(SubjectAlternativeName::new()
-        .dns(subject_name)
-        .build(&x509_build.x509v3_context(None, None)));
-    try!(x509_build.append_extension(subject_alternative_name));
-
-    let basic_constraints = try!(BasicConstraints::new().critical().ca().build());
-    try!(x509_build.append_extension(basic_constraints));
-
-    try!(x509_build.sign(&pkey, hash::MessageDigest::sha256()));
-    let cert = x509_build.build();
-
-    let pkcs12_builder = Pkcs12::builder();
-    let pkcs12 = try!(pkcs12_builder.build(password.unwrap_or(""), subject_name, &pkey, &cert));
-
-    Ok((cert, pkcs12))
-}
 
 pub fn new_acceptor(pkcs12: &ParsedPkcs12) -> io::Result<SslAcceptor> {
     let mut builder = try!(SslAcceptorBuilder::mozilla_modern(SslMethod::tls(),

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -225,7 +225,6 @@ pub struct KeyConfig {
     signer_name: Option<String>,
     is_zone_signing_key: Option<bool>,
     is_zone_update_auth: Option<bool>,
-    create_if_absent: Option<bool>,
 }
 
 impl KeyConfig {
@@ -239,14 +238,12 @@ impl KeyConfig {
     /// * `signer_name` - the name to use when signing records, e.g. ns.example.com
     /// * `is_zone_signing_key` - specify that this key should be used for signing a zone
     /// * `is_zone_update_auth` - specifies that this key can be used for dynamic updates in the zone
-    /// * `do_auto_generate` - if the key does not exist, generate a new one (it will need to be signed)
     pub fn new(key_path: String,
                password: Option<String>,
                algorithm: Algorithm,
                signer_name: String,
                is_zone_signing_key: bool,
-               is_zone_update_auth: bool,
-               do_auto_generate: bool)
+               is_zone_update_auth: bool)
                -> Self {
         KeyConfig {
             key_path: key_path,
@@ -255,7 +252,6 @@ impl KeyConfig {
             signer_name: Some(signer_name),
             is_zone_signing_key: Some(is_zone_signing_key),
             is_zone_update_auth: Some(is_zone_update_auth),
-            create_if_absent: Some(do_auto_generate),
         }
     }
 
@@ -319,12 +315,6 @@ impl KeyConfig {
     /// it will be registered as a KEY record in the zone.
     pub fn is_zone_update_auth(&self) -> bool {
         self.is_zone_update_auth.unwrap_or(false)
-    }
-
-    /// auto generate/create the key if it doesn't already exist (the public portion can be
-    /// retrieved by a DNS query to the zone for DNSKEY and KEY records).
-    pub fn create_if_absent(&self) -> bool {
-        self.create_if_absent.unwrap_or(false)
     }
 }
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -333,8 +333,6 @@ impl KeyConfig {
 pub struct TlsCertConfig {
     path: String,
     password: Option<String>,
-    create_if_absent: Option<bool>,
-    subject_name: String,
 }
 
 impl TlsCertConfig {
@@ -345,13 +343,5 @@ impl TlsCertConfig {
     /// optional password for open the pkcs12, none assumes no password
     pub fn get_password(&self) -> Option<&str> {
         self.password.as_ref().map(|s| s.as_str())
-    }
-    /// if it does not exist, one will be generated (with an EC key)
-    pub fn create_if_absent(&self) -> bool {
-        self.create_if_absent.unwrap_or(false)
-    }
-    /// the certificate's subject name, e.g. "ns.example.com"
-    pub fn get_subject_name(&self) -> &str {
-        &self.subject_name
     }
 }

--- a/server/src/named.rs
+++ b/server/src/named.rs
@@ -200,7 +200,6 @@ fn load_zone(zone_dir: &Path, zone_config: &ZoneConfig) -> Result<Authority, Str
                 zone_name.clone().to_string(),
                 true,
                 true,
-                true,
             );
             let signer = try!(load_key(zone_name, &key_config).map_err(|e| {
                 format!("failed to load key: {:?} msg: {}", key_config.key_path(), e)
@@ -260,32 +259,8 @@ fn load_key(zone_name: Name, key_config: &KeyConfig) -> Result<Signer, String> {
         |e| format!("bad key format: {}", e),
     ));
 
-    // generate and write a new key if it does not exist
-    if !key_path.exists() && key_config.create_if_absent() {
-        info!("creating key: {:?}", key_path);
-
-        // TODO: establish proper ownership
-        let mut file = try!(File::create(&key_path).map_err(|e| {
-            format!("error creating private key file: {:?}: {}", key_path, e)
-        }));
-
-        let key_bytes: Vec<u8> = try!(
-            format
-                .generate_and_encode(algorithm, key_config.password())
-                .map_err(|e| format!("could not generate key: {}", e))
-        );
-
-        try!(
-            file.write_all(&key_bytes)
-                .or_else(|_| fs::remove_file(&key_path))
-                .map_err(|e| {
-                    format!("error writing private key file: {:?}: {}", key_path, e)
-                })
-        );
-    }
-
     // read the key in
-    let key: KeyPair = if key_path.exists() {
+    let key: KeyPair = {
         info!("reading key: {:?}", key_path);
 
         let mut file = try!(File::open(&key_path).map_err(|e| {
@@ -302,8 +277,6 @@ fn load_key(zone_name: Name, key_config: &KeyConfig) -> Result<Signer, String> {
                 .decode_key(&key_bytes, key_config.password(), algorithm)
                 .map_err(|e| format!("could not decode key: {}", e))
         )
-    } else {
-        return Err(format!("file not found: {:?}", key_path));
     };
 
     let name = try!(key_config.signer_name().map_err(|e| {

--- a/server/tests/config_tests.rs
+++ b/server/tests/config_tests.rs
@@ -198,8 +198,7 @@ fn test_parse_tls() {
     assert_eq!(config.get_tls_cert(), None);
 
     let config: Config = "
-tls_cert = { path = \"path/to/some.pkcs12\", create_if_absent = true, \
-                          subject_name = \"ns.example.com\" }
+tls_cert = { path = \"path/to/some.pkcs12\" }
 tls_listen_port = 8853
   "
             .parse()
@@ -208,7 +207,4 @@ tls_listen_port = 8853
     assert_eq!(config.get_tls_listen_port(), 8853);
     assert_eq!(config.get_tls_cert().unwrap().get_path(),
                Path::new("path/to/some.pkcs12"));
-    assert_eq!(config.get_tls_cert().unwrap().create_if_absent(), true);
-    assert_eq!(config.get_tls_cert().unwrap().get_subject_name(),
-               "ns.example.com");
 }

--- a/server/tests/config_tests.rs
+++ b/server/tests/config_tests.rs
@@ -141,8 +141,6 @@ algorithm = \"ED25519\"
          signer_name = \"ns.example.com.\"
 is_zone_signing_key = false
 is_zone_update_auth = true
-\
-         create_if_absent = true
 
 [[zones.keys]]
 key_path = \"/path/to/my_rsa.pem\"
@@ -168,7 +166,6 @@ signer_name = \"ns.example.com.\"
                false);
     assert_eq!(config.get_zones()[0].get_keys()[0].is_zone_update_auth(),
                true);
-    assert_eq!(config.get_zones()[0].get_keys()[0].create_if_absent(), true);
 
     assert_eq!(config.get_zones()[0].get_keys()[1].key_path(),
                Path::new("/path/to/my_rsa.pem"));
@@ -184,8 +181,6 @@ signer_name = \"ns.example.com.\"
     assert_eq!(config.get_zones()[0].get_keys()[1].is_zone_signing_key(),
                false);
     assert_eq!(config.get_zones()[0].get_keys()[1].is_zone_update_auth(),
-               false);
-    assert_eq!(config.get_zones()[0].get_keys()[1].create_if_absent(),
                false);
 }
 

--- a/server/tests/named_test_configs/dns_over_tls.toml
+++ b/server/tests/named_test_configs/dns_over_tls.toml
@@ -1,6 +1,6 @@
 listen_addrs_ipv4 = ["0.0.0.0"]
 
-tls_cert = { path = "sec/example.p12", subject_name = "ns.example.com", password = "testpass", create_if_absent = true }
+tls_cert = { path = "sec/example.p12", password = "testpass" }
 
 [[zones]]
 zone = "example.com"

--- a/server/tests/named_test_configs/example.toml
+++ b/server/tests/named_test_configs/example.toml
@@ -32,12 +32,7 @@
 # tcp_request_timeout = 5
 
 ## DNS over TLS certificate information.
-## if create_if_absent is true, a self-signed cert, with an Ellyptic Curve P256 key,
-##  will be created and used,
-##  beside the cert will be a CSR which can be used (if desired) to have a CA sign. Subsequent
-##  to signing, replace the pkcs12 file (with private key embedded) and restart
-##  the server.
-# tls_cert = { path = "path/to/some.pkcs12", create_if_absent = "false", subject_name = "ns.example.com", password = "if_encrypted" }
+# tls_cert = { path = "path/to/some.pkcs12", password = "if_encrypted" }
 
 ## port on which to listent, default 853 (should not be 53)
 # tls_listen_port = 853

--- a/server/tests/named_test_configs/example.toml
+++ b/server/tests/named_test_configs/example.toml
@@ -119,8 +119,6 @@ file = "example.com.zone"
 # is_zone_signing_key = true
 ## this key is authorized for dynamic update access to the zone via SIG0
 # is_zone_update_auth = true
-## create the key if it is not found
-# create_if_absent = false
 #
 # [[zones.keys]]
 # key = "/path/to/my_ed25519.raw"


### PR DESCRIPTION
This is probably a controversial change. I don't fully understand the original motivation for the features being removed (and possibly later moved somewhere else). Consider this more of an RFC or a request for an explanation of which scenerios the features could reasonably be used for.

This is a step towards removing `KeyPair::generate()`, KeyPair::generate_pkcs()`, and `KeyFormat::generate_and_encode()`, once the use of those functions is removed from the unit tests, in a separate PR.