### PR TITLE
Allow resolver to be used without openssl.

### DIFF
--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -57,7 +57,7 @@ log = "^0.3.5"
 lru-cache = "^0.1.1"
 regex = "0.2.1"
 tokio-core = "^0.1"
-trust-dns = { version = "^0.12.0", path = "../client" }
+trust-dns = { version = "^0.12.0", path = "../client", default-features = false }
 trust-dns-proto = { version = "^0.1", path = "../proto" }
 
 [target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]


### PR DESCRIPTION
* Turn off default features in `trust-dns` (these will be enabled by the default features of the resolver).
* Conditional compile out the secure client handles if not available.

Happy to tidy up the conditional compilation if you can think of a way it can be done better!