### PR TITLE
Allow disabling the ipconfig dependency.

### DIFF
--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -37,7 +37,7 @@ appveyor = { repository = "bluejekyll/trust-dns", branch = "master", service = "
 coveralls = { repository = "bluejekyll/trust-dns", branch = "master", service = "github" }
 
 [features]
-default = ["dnssec-openssl"]
+default = ["dnssec-openssl", "ipconfig"]
 dnssec-openssl = ["dnssec", "trust-dns-proto/dnssec-openssl"]
 dnssec-ring = ["dnssec", "trust-dns-proto/dnssec-ring"]
 dnssec = []
@@ -60,4 +60,4 @@ tokio-core = "^0.1"
 trust-dns-proto = { version = "^0.1", path = "../proto" }
 
 [target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
-ipconfig = "^0.1.1"
+ipconfig = { version = "^0.1.1", optional = true }

--- a/resolver/src/lib.rs
+++ b/resolver/src/lib.rs
@@ -134,7 +134,7 @@ extern crate log;
 extern crate lru_cache;
 extern crate tokio_core;
 extern crate trust_dns_proto;
-#[cfg(all(target_os = "windows", target_pointer_width = "64"))]
+#[cfg(all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64"))]
 extern crate ipconfig;
 
 pub mod config;

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -20,7 +20,6 @@ use lookup;
 use lookup::Lookup;
 use lookup_ip::LookupIp;
 use ResolverFuture;
-use system_conf;
 
 /// The Resolver is used for performing DNS queries.
 ///
@@ -86,9 +85,10 @@ impl Resolver {
     /// Constructs a new Resolver with the system configuration.
     ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
-    #[cfg(not(all(target_os = "windows", target_pointer_width = "32")))]
+    #[cfg(any(unix,
+              all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64")))]
     pub fn from_system_conf() -> io::Result<Self> {
-        let (config, options) = system_conf::read_system_conf()?;
+        let (config, options) = super::system_conf::read_system_conf()?;
         Self::new(config, options)
     }
 
@@ -192,7 +192,8 @@ mod tests {
 
     #[test]
     #[ignore]
-    #[cfg(not(all(target_os = "windows", target_pointer_width = "32")))]
+    #[cfg(any(unix,
+             all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64")))]
     fn test_system_lookup() {
         let resolver = Resolver::from_system_conf().unwrap();
 

--- a/resolver/src/system_conf/mod.rs
+++ b/resolver/src/system_conf/mod.rs
@@ -15,7 +15,7 @@
 /// resolv.conf parser
 // TODO: make crate only...
 mod resolv_conf_ast;
-#[cfg(all(target_os = "windows", target_pointer_width = "64"))]
+#[cfg(all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64"))]
 mod windows;
 
 use std::fs::File;
@@ -41,7 +41,7 @@ pub(crate) fn read_system_conf() -> io::Result<(ResolverConfig, ResolverOpts)> {
 }
 
 /// Support only 64-bit until https://github.com/liranringel/ipconfig/issues/1 is resolved.
-#[cfg(all(target_os = "windows", target_pointer_width = "64"))]
+#[cfg(all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64"))]
 pub(crate) use self::windows::read_system_conf;
 
 pub fn read_resolv_conf<P: AsRef<Path>>(path: P) -> io::Result<(ResolverConfig, ResolverOpts)> {


### PR DESCRIPTION
If one doesn't need the ipconfig functionality then the ipconfig
dependency is a overly-heavy and overly-risky dependency. Allow users
to disable the feature to avoid the dependency.

In particular, ipconfig seems to require clang.dll and has trouble
finding it on my system, which means that I cannot actually use
Trust-DNS on Windows when ipconfig is enabled. Of course, that should
be fixed in ipconfig, but for people won't need it's functionality,
this is a much simpler and more bulletproof workaround.