### PR TITLE
Client: Don't make dnssec-openssl a default feature (breaking change).

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -40,7 +40,6 @@ appveyor = { repository = "bluejekyll/trust-dns", branch = "master", service = "
 codecov = { repository = "bluejekyll/trust-dns", branch = "master", service = "github" }
 
 [features]
-default = ["dnssec-openssl"]
 dnssec-openssl = ["dnssec", "openssl", "trust-dns-proto/dnssec-openssl"]
 dnssec-ring = ["dnssec", "ring", "trust-dns-proto/dnssec-ring", "untrusted"]
 dnssec = []

--- a/compatibility-tests/Cargo.toml
+++ b/compatibility-tests/Cargo.toml
@@ -49,5 +49,4 @@ env_logger = "0.4.2"
 futures = "^0.1.6"
 openssl = { version = "^0.9.8", features = ["v102", "v110"] }
 rand = "^0.3"
-trust-dns = { version = "*", path="../client", features = ["openssl"] }
-
+trust-dns = { version = "*", path="../client", features = ["dnssec-openssl"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -75,7 +75,7 @@ rusqlite = { version = "^0.9.5", features = ["bundled"] }
 time = "^0.1"
 tokio-core = "^0.1"
 toml = "^0.1"
-trust-dns = { version = "^0.12", path = "../client" }
+trust-dns = { version = "^0.12", path = "../client", features = ["dnssec-openssl"] }
 trust-dns-proto = { version = "^0.1", path = "../proto" }
 trust-dns-openssl = { version = "^0.1.0", path = "../openssl", optional = true }
 


### PR DESCRIPTION
It is too easy to accidentally add the dnssec-openssl feature when it
wasn't intended when it is a default feature. This was happening in
trust-dns-server, for example.