### PR TITLE
fixes trust_dns_compatibility to work with none

### DIFF
--- a/compatibility-tests/Cargo.toml
+++ b/compatibility-tests/Cargo.toml
@@ -37,6 +37,7 @@ appveyor = { repository = "bluejekyll/trust-dns", branch = "master", service = "
 default = ["none"]
 none = []
 bind = []
+trust_dns = []
 
 [lib]
 name = "trust_dns_compatibility"

--- a/compatibility-tests/tests/sig0_tests.rs
+++ b/compatibility-tests/tests/sig0_tests.rs
@@ -30,6 +30,7 @@ use trust_dns::rr::dnssec::{Algorithm, Signer, KeyPair};
 use trust_dns::rr::rdata::key::{KEY, KeyUsage};
 use trust_dns_compatibility::named_process;
 
+#[cfg(not(feature = "none"))]
 #[test]
 #[allow(unused)]
 fn test_get() {
@@ -54,6 +55,7 @@ fn test_get() {
     }
 }
 
+#[allow(unused)]
 fn create_sig0_ready_client<CC>(conn: CC) -> SyncClient<CC>
 where
     CC: ClientConnection,
@@ -89,6 +91,7 @@ where
     SyncClient::with_signer(conn, signer)
 }
 
+#[cfg(not(feature = "none"))]
 #[test]
 #[allow(unused)]
 fn test_create() {


### PR DESCRIPTION
This allows `cargo test` to be run in the root of the project, without errors.