### PR TITLE
clippy fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,13 @@ matrix:
       env: MODULES="client integration-tests proto resolver server"
            OPTIONS="--no-default-features --features=dnssec-ring"
            RUN_KCOV=1
-           
+
     # just tls using openssl
     - rust: stable
       env: MODULES="integration-tests server"
            OPTIONS="--no-default-features --features=tls-openssl"
            RUN_KCOV=1
-           
+
     # min rust version
     # - rust: 1.14.0
     - rust: beta
@@ -58,5 +58,7 @@ matrix:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then scripts/install_openssl_deb.sh ; fi
   - if [[ "$MODULES" == "compatibility-tests" ]]; then scripts/install_bind.sh ; fi
-script: scripts/run_tests.sh
+script:
+    - scripts/run_tests.sh
+    - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]] ; then cargo install clippy --force && scripts/run_clippy.sh ; fi'
 after_success: scripts/run_kcov.sh

--- a/client/src/client/client.rs
+++ b/client/src/client/client.rs
@@ -415,7 +415,7 @@ where
     fn new_future(&self, handle: &Handle) -> ClientResult<BasicClientHandle> {
         let (stream, stream_handle) = self.conn.new_stream(handle)?;
 
-        let client = ClientFuture::new(stream, stream_handle, &handle, self.signer.clone());
+        let client = ClientFuture::new(stream, stream_handle, handle, self.signer.clone());
         Ok(client)
     }
 }
@@ -495,7 +495,7 @@ where
     fn new_future(&self, handle: &Handle) -> ClientResult<SecureClientHandle<BasicClientHandle>> {
         let (stream, stream_handle) = self.conn.new_stream(handle)?;
 
-        let client = ClientFuture::new(stream, stream_handle, &handle, self.signer.clone());
+        let client = ClientFuture::new(stream, stream_handle, handle, self.signer.clone());
         Ok(SecureClientHandle::new(client))
     }
 }

--- a/client/src/client/memoize_client_handle.rs
+++ b/client/src/client/memoize_client_handle.rs
@@ -70,7 +70,7 @@ where
         let mut map = self.active_queries.borrow_mut();
         map.insert(query, request.clone());
 
-        return Box::new(request);
+        Box::new(request)
     }
 }
 

--- a/client/src/client/rc_future.rs
+++ b/client/src/client/rc_future.rs
@@ -49,11 +49,11 @@ impl<F> Future for RcFuture<F>
 
         // TODO convert this to try_borrow_mut when that stabilizes...
         match self.rc_future.borrow_mut().poll() {
-            result @ Ok(Async::NotReady) => return result,
-            result @ _ => {
+            result @ Ok(Async::NotReady) => result,
+            result => {
                 let mut store = self.result.borrow_mut();
                 *store = Some(result.clone());
-                return result;
+                result
             }
         }
     }
@@ -65,8 +65,8 @@ impl<F> Clone for RcFuture<F>
 {
     fn clone(&self) -> Self {
         RcFuture {
-            rc_future: self.rc_future.clone(),
-            result: self.result.clone(),
+            rc_future: Rc::clone(&self.rc_future),
+            result: Rc::clone(&self.result),
         }
     }
 }

--- a/client/src/error/client_error.rs
+++ b/client/src/error/client_error.rs
@@ -90,8 +90,8 @@ impl<T> From<SendError<T>> for Error {
 
 impl Clone for Error {
     fn clone(&self) -> Self {
-        match self.kind() {
-            &ErrorKind::Timeout => ErrorKind::Timeout.into(),
+        match *self.kind() {
+            ErrorKind::Timeout => ErrorKind::Timeout.into(),
             _ => ErrorKind::Msg(format!("Cloned error: {}", self)).into(),
         }
     }
@@ -108,8 +108,8 @@ impl<'a> From<&'a io::Error> for Error {
 
 impl From<Error> for io::Error {
     fn from(e: Error) -> Self {
-        match e.kind() {
-            &ErrorKind::Timeout => io::ErrorKind::TimedOut.into(),
+        match *e.kind() {
+            ErrorKind::Timeout => io::ErrorKind::TimedOut.into(),
             _ => io::Error::new(io::ErrorKind::Other, format!("ClientError: {}", e)),
         }
     }

--- a/client/src/rr/dnssec/key_format.rs
+++ b/client/src/rr/dnssec/key_format.rs
@@ -41,7 +41,7 @@ impl KeyFormat {
             #[cfg(feature = "openssl")]
             e @ Algorithm::RSASHA1 |
             e @ Algorithm::RSASHA1NSEC3SHA1 => {
-                return Err(format!("unsupported Algorithm (insecure): {:?}", e).into())
+                Err(format!("unsupported Algorithm (insecure): {:?}", e).into())
             }
             #[cfg(feature = "openssl")]
             Algorithm::RSASHA256 |
@@ -59,7 +59,7 @@ impl KeyFormat {
                             format!("could not decode RSA from PEM, bad password?: {}", e)
                         }))
                     }
-                    e @ _ => {
+                    e => {
                         return Err(
                             format!(
                                 "unsupported key format with RSA (DER or PEM only): \
@@ -70,9 +70,9 @@ impl KeyFormat {
                     }
                 };
 
-                return Ok(try!(KeyPair::from_rsa(key).map_err(|e| {
+                Ok(try!(KeyPair::from_rsa(key).map_err(|e| {
                     format!("could not tranlate RSA to KeyPair: {}", e)
-                })));
+                })))
             }
             #[cfg(feature = "openssl")]
             Algorithm::ECDSAP256SHA256 |
@@ -90,20 +90,20 @@ impl KeyFormat {
                             format!("could not decode EC from PEM, bad password?: {}", e)
                         }))
                     }
-                    e @ _ => {
+                    e => {
                         return Err(
                             format!(
                                 "unsupported key format with EC (DER or PEM only): \
                                             {:?}",
                                 e
                             ).into(),
-                        )
+                        );
                     }
                 };
 
-                return Ok(try!(KeyPair::from_ec_key(key).map_err(|e| {
+                Ok(try!(KeyPair::from_ec_key(key).map_err(|e| {
                     format!("could not tranlate RSA to KeyPair: {}", e)
-                })));
+                })))
             }
             Algorithm::ED25519 => {
                 match self {
@@ -111,10 +111,10 @@ impl KeyFormat {
                     KeyFormat::Pkcs8 => {
                         let key = try!(Ed25519KeyPair::from_pkcs8(Input::from(bytes)));
 
-                        return Ok(KeyPair::from_ed25519(key));
+                        Ok(KeyPair::from_ed25519(key))
                     }
-                    e @ _ => {
-                        return Err(
+                    e => {
+                        Err(
                             format!(
                                 "unsupported key format with ED25519 (only Pkcs8 supported): {:?}",
                                 e
@@ -124,7 +124,7 @@ impl KeyFormat {
                 }
             }
             #[cfg(not(all(feature = "openssl", feature = "ring")))]
-            e @ _ => {
+            e => {
                 return Err(
                     format!(
                         "unsupported Algorithm, enable openssl or ring feature: {:?}",
@@ -165,7 +165,7 @@ impl KeyFormat {
             #[cfg(feature = "ring")]
             Algorithm::ED25519 => return KeyPair::generate_pkcs8(algorithm),
             #[cfg(not(all(feature = "openssl", feature = "ring")))]
-            e @ _ => {
+            e => {
                 return Err(
                     format!(
                         "unsupported Algorithm, enable openssl or ring feature: {:?}",
@@ -187,9 +187,9 @@ impl KeyFormat {
                         if password.is_some() {
                             return Err(format!("Can only password protect PEM: {:?}", self).into());
                         }
-                        return pkey.private_key_to_der().map_err(|e| {
+                        pkey.private_key_to_der().map_err(|e| {
                             format!("error writing key as DER: {}", e).into()
-                        });
+                        })
                     }
                     KeyFormat::Pem => {
                         let key = if let Some(password) = password {
@@ -198,10 +198,10 @@ impl KeyFormat {
                             pkey.private_key_to_pem()
                         };
 
-                        return key.map_err(|e| format!("error writing key as PEM: {}", e).into());
+                        key.map_err(|e| format!("error writing key as PEM: {}", e).into())
                     }
-                    e @ _ => {
-                        return Err(
+                    e => {
+                        Err(
                             format!(
                                 "unsupported key format with RSA or EC (DER or PEM \
                                             only): {:?}",
@@ -214,7 +214,7 @@ impl KeyFormat {
             #[cfg(feature = "ring")]
             KeyPair::ED25519(..) => panic!("should have returned early"),
             #[cfg(not(any(feature = "openssl", feature = "ring")))]
-            _ => return Err(format!("unsupported Algorithm, enable openssl feature (encode not supported with ring)").into()),
+            _ => Err(format!("unsupported Algorithm, enable openssl feature (encode not supported with ring)").into()),
         }
     }
 
@@ -239,9 +239,9 @@ impl KeyFormat {
                         if password.is_some() {
                             return Err(format!("Can only password protect PEM: {:?}", self).into());
                         }
-                        return pkey.private_key_to_der().map_err(|e| {
+                        pkey.private_key_to_der().map_err(|e| {
                             format!("error writing key as DER: {}", e).into()
-                        });
+                        })
                     }
                     KeyFormat::Pem => {
                         let key = if let Some(password) = password {
@@ -250,10 +250,10 @@ impl KeyFormat {
                             pkey.private_key_to_pem()
                         };
 
-                        return key.map_err(|e| format!("error writing key as PEM: {}", e).into());
+                        key.map_err(|e| format!("error writing key as PEM: {}", e).into())
                     }
-                    e @ _ => {
-                        return Err(
+                    e => {
+                        Err(
                             format!(
                                 "unsupported key format with RSA or EC (DER or PEM \
                                             only): {:?}",
@@ -264,7 +264,7 @@ impl KeyFormat {
                 }
             }
             #[cfg(any(feature = "ring", not(feature = "openssl")))]
-            _ => return Err(format!("unsupported Algorithm, enable openssl feature (encode not supported with ring)").into()),
+            _ => Err("unsupported Algorithm, enable openssl feature (encode not supported with ring)".into()),
         }
     }
 }

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -354,10 +354,10 @@ impl Signer {
     /// Internal checksum function (used for non-RSAMD5 hashes only,
     /// however, RSAMD5 is considered deprecated and not implemented in
     /// trust-dns, anyways).
-    fn calculate_key_tag_internal(bytes: &Vec<u8>) -> u16 {
+    fn calculate_key_tag_internal(bytes: &[u8]) -> u16 {
         let mut ac: u32 = 0;
         for (i, k) in bytes.iter().enumerate() {
-            ac += (*k as u32) << if i & 0x01 != 0 { 0 } else { 8 };
+            ac += u32::from(*k) << if i & 0x01 != 0 { 0 } else { 8 };
         }
         ac += ac >> 16;
         (ac & 0xFFFF) as u16

--- a/client/src/serialize/txt/rdata_parsers/a.rs
+++ b/client/src/serialize/txt/rdata_parsers/a.rs
@@ -25,7 +25,7 @@ pub fn parse<'i, I: Iterator<Item=&'i str>>(mut tokens: I) -> ParseResult<Ipv4Ad
     let address: Ipv4Addr = 
         tokens
             .next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("ipv4 address".to_string()),
             ))
             .and_then(|s| Ipv4Addr::from_str(s).map_err(Into::into))?;

--- a/client/src/serialize/txt/rdata_parsers/aaaa.rs
+++ b/client/src/serialize/txt/rdata_parsers/aaaa.rs
@@ -27,7 +27,7 @@ pub fn parse<'i, I: Iterator<Item=&'i str>>(mut tokens: I) -> ParseResult<Ipv6Ad
     let address: Ipv6Addr = 
         tokens
             .next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("ipv6 address".to_string()),
             ))
             .and_then(|s| Ipv6Addr::from_str(s).map_err(Into::into))?;

--- a/client/src/serialize/txt/rdata_parsers/mx.rs
+++ b/client/src/serialize/txt/rdata_parsers/mx.rs
@@ -27,13 +27,13 @@ pub fn parse<'i, I: Iterator<Item = &'i str>>(
 ) -> ParseResult<MX> {
     let preference: u16 = tokens
         .next()
-        .ok_or(ParseError::from(
+        .ok_or_else(|| ParseError::from(
             ParseErrorKind::MissingToken("preference".to_string()),
         ))
         .and_then(|s| s.parse().map_err(Into::into))?;
     let exchange: Name = tokens
         .next()
-        .ok_or(ParseErrorKind::MissingToken("exchange".to_string()).into())
+        .ok_or_else(|| ParseErrorKind::MissingToken("exchange".to_string()).into())
         .and_then(|s| Name::parse(s, origin).map_err(ParseError::from))?;
 
     Ok(MX::new(preference, exchange))

--- a/client/src/serialize/txt/rdata_parsers/name.rs
+++ b/client/src/serialize/txt/rdata_parsers/name.rs
@@ -27,7 +27,7 @@ pub fn parse<'i, I: Iterator<Item = &'i str>>(
     let name: Name = 
         tokens
             .next()
-            .ok_or(ParseErrorKind::MissingToken("name".to_string()).into())
+            .ok_or_else(|| ParseErrorKind::MissingToken("name".to_string()).into())
             .and_then(|s| Name::parse(s, origin).map_err(ParseError::from))?;
     Ok(name)
 }

--- a/client/src/serialize/txt/rdata_parsers/soa.rs
+++ b/client/src/serialize/txt/rdata_parsers/soa.rs
@@ -26,46 +26,46 @@ pub fn parse<'i, I: Iterator<Item=&'i str>>(mut tokens: I, origin: Option<&Name>
     let mname: Name =
         tokens
             .next()
-            .ok_or(ParseErrorKind::MissingToken("mname".to_string()).into())
+            .ok_or_else(|| ParseErrorKind::MissingToken("mname".to_string()).into())
             .and_then(|s| Name::parse(s, origin).map_err(ParseError::from))?;
     
     let rname: Name =
         tokens
             .next()
-            .ok_or(ParseErrorKind::MissingToken("rname".to_string()).into())
+            .ok_or_else(|| ParseErrorKind::MissingToken("rname".to_string()).into())
             .and_then(|s| Name::parse(s, origin).map_err(ParseError::from))?;
     
     let serial: u32 = 
         tokens.next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("serial".to_string()),
             ))
             .and_then(|s| u32::from_str(s).map_err(Into::into))?;
     
     let refresh: i32 = 
         tokens.next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("refresh".to_string()),
             ))
             .and_then(|s| i32::from_str(s).map_err(Into::into))?;
     
     let retry: i32 =
         tokens.next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("retry".to_string()),
             ))
             .and_then(|s| i32::from_str(s).map_err(Into::into))?;
     
     let expire: i32 =
         tokens.next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("expire".to_string()),
             ))
             .and_then(|s| i32::from_str(s).map_err(Into::into))?;
     
     let minimum: u32 = 
         tokens.next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("minimum".to_string()),
             ))
             .and_then(|s| u32::from_str(s).map_err(Into::into))?;

--- a/client/src/serialize/txt/rdata_parsers/srv.rs
+++ b/client/src/serialize/txt/rdata_parsers/srv.rs
@@ -28,7 +28,7 @@ pub fn parse<'i, I: Iterator<Item = &'i str>>(
 ) -> ParseResult<SRV> {
     let priority: u16 = tokens
         .next()
-        .ok_or(ParseError::from(
+        .ok_or_else(|| ParseError::from(
             ParseErrorKind::MissingToken("priority".to_string()),
         ))
         .and_then(|s| u16::from_str(s).map_err(Into::into))?;
@@ -36,7 +36,7 @@ pub fn parse<'i, I: Iterator<Item = &'i str>>(
     let weight: u16 = 
         tokens
             .next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("weight".to_string()),
             ))
             .and_then(|s| u16::from_str(s).map_err(Into::into))?;
@@ -44,7 +44,7 @@ pub fn parse<'i, I: Iterator<Item = &'i str>>(
     let port: u16 = 
         tokens
             .next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("port".to_string()),
             ))
             .and_then(|s| u16::from_str(s).map_err(Into::into))?;
@@ -52,7 +52,7 @@ pub fn parse<'i, I: Iterator<Item = &'i str>>(
     let target: Name =
         tokens
             .next()
-            .ok_or(ParseError::from(
+            .ok_or_else(|| ParseError::from(
                 ParseErrorKind::MissingToken("target".to_string()),
             ))
             .and_then(|s| Name::parse(s, origin).map_err(ParseError::from))?;

--- a/client/src/serialize/txt/rdata_parsers/tlsa.rs
+++ b/client/src/serialize/txt/rdata_parsers/tlsa.rs
@@ -68,7 +68,7 @@ pub fn parse<'i, I: Iterator<Item = &'i str>>(tokens: I) -> ParseResult<TLSA> {
     // these are all in hex: "a string of hexadecimal characters"
     //   aside: personally I find it funny that the other fields are decimal, while this is hex encoded...
     let cert_data = iter.fold(String::new(), |mut cert_data, data| {
-        cert_data.extend(data.chars());
+        cert_data.push_str(data);
         cert_data
     });
     println!("cert_data: {}", cert_data);

--- a/integration-tests/tests/client_future_tests.rs
+++ b/integration-tests/tests/client_future_tests.rs
@@ -572,10 +572,10 @@ fn test_compare_and_swap_multi() {
     );
 
     let current1 = current
-        .new_record(RData::A(Ipv4Addr::new(100, 10, 100, 10)))
+        .new_record(&RData::A(Ipv4Addr::new(100, 10, 100, 10)))
         .clone();
     let current2 = current
-        .new_record(RData::A(Ipv4Addr::new(100, 10, 100, 11)))
+        .new_record(&RData::A(Ipv4Addr::new(100, 10, 100, 11)))
         .clone();
     let current = current;
 
@@ -585,9 +585,9 @@ fn test_compare_and_swap_multi() {
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     let mut new = RecordSet::with_ttl(current.name().clone(), current.record_type(), current.ttl());
-    let new1 = new.new_record(RData::A(Ipv4Addr::new(100, 10, 101, 10)))
+    let new1 = new.new_record(&RData::A(Ipv4Addr::new(100, 10, 101, 10)))
         .clone();
-    let new2 = new.new_record(RData::A(Ipv4Addr::new(100, 10, 101, 11)))
+    let new2 = new.new_record(&RData::A(Ipv4Addr::new(100, 10, 101, 11)))
         .clone();
     let new = new;
 
@@ -704,16 +704,16 @@ fn test_delete_by_rdata_multi() {
     );
 
     let record1 = rrset
-        .new_record(RData::A(Ipv4Addr::new(100, 10, 100, 10)))
+        .new_record(&RData::A(Ipv4Addr::new(100, 10, 100, 10)))
         .clone();
     let record2 = rrset
-        .new_record(RData::A(Ipv4Addr::new(100, 10, 100, 11)))
+        .new_record(&RData::A(Ipv4Addr::new(100, 10, 100, 11)))
         .clone();
     let record3 = rrset
-        .new_record(RData::A(Ipv4Addr::new(100, 10, 100, 12)))
+        .new_record(&RData::A(Ipv4Addr::new(100, 10, 100, 12)))
         .clone();
     let record4 = rrset
-        .new_record(RData::A(Ipv4Addr::new(100, 10, 100, 13)))
+        .new_record(&RData::A(Ipv4Addr::new(100, 10, 100, 13)))
         .clone();
     let rrset = rrset;
 
@@ -736,8 +736,8 @@ fn test_delete_by_rdata_multi() {
         Duration::minutes(5).num_seconds() as u32,
     );
 
-    let record1 = rrset.new_record(record1.rdata().clone()).clone();
-    let record3 = rrset.new_record(record3.rdata().clone()).clone();
+    let record1 = rrset.new_record(record1.rdata()).clone();
+    let record3 = rrset.new_record(record3.rdata()).clone();
     let rrset = rrset;
 
     let result = io_loop

--- a/integration-tests/tests/secure_client_handle_tests.rs
+++ b/integration-tests/tests/secure_client_handle_tests.rs
@@ -214,7 +214,7 @@ where
 
 
         let mut trust_anchor = TrustAnchor::new();
-        trust_anchor.insert_trust_anchor(public_key);
+        trust_anchor.insert_trust_anchor(&public_key);
 
         trust_anchor
     };

--- a/proto/src/dns_handle.rs
+++ b/proto/src/dns_handle.rs
@@ -178,7 +178,7 @@ where
     fn drop_cancelled(&mut self) {
         // TODO: should we have a timeout here? or always expect the caller to do this?
         let mut canceled = HashSet::new();
-        for (&id, &mut (ref mut req, ref mut timeout)) in self.active_requests.iter_mut() {
+        for (&id, &mut (ref mut req, ref mut timeout)) in &mut self.active_requests {
             if let Ok(Async::Ready(())) = req.poll_cancel() {
               canceled.insert(id);
             }
@@ -382,7 +382,7 @@ where
         }
 
         // Finally, return not ready to keep the 'driver task' alive.
-        return Ok(Async::NotReady);
+        Ok(Async::NotReady)
     }
 }
 
@@ -413,10 +413,10 @@ where
                     .expect("error notifying wait, possible future leak");
 
                 task::current().notify();
-                return Ok(Async::NotReady);
+                Ok(Async::NotReady)
             }
-            Ok(Async::Ready(None)) => return Ok(Async::Ready(())),            
-            _ => return Err(E::from(ProtoErrorKind::NoError.into())),
+            Ok(Async::Ready(None)) => Ok(Async::Ready(())),
+            _ => Err(E::from(ProtoErrorKind::NoError.into())),
         }
     }
 }

--- a/proto/src/op/header.rs
+++ b/proto/src/op/header.rs
@@ -82,10 +82,8 @@ pub enum MessageType {
     Response,
 }
 
-impl Header {
-    // TODO: we should make id, message_type and op_code all required and non-editable
-    /// A default Header, not very useful.
-    pub fn new() -> Self {
+impl Default for Header {
+    fn default() -> Self {
         Header {
             id: 0,
             message_type: MessageType::Query,
@@ -102,6 +100,14 @@ impl Header {
             name_server_count: 0,
             additional_count: 0,
         }
+    }
+}
+
+impl Header {
+    // TODO: we should make id, message_type and op_code all required and non-editable
+    /// A default Header, not very useful.
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Length of the header, always 12 bytes
@@ -468,7 +474,7 @@ impl BinSerializable<Header> for Header {
         } else {
             0b0000_0000
         };
-        r_z_ad_cd_rcod |= u8::from(self.response_code);
+        r_z_ad_cd_rcod |= self.response_code;
         try!(encoder.emit(r_z_ad_cd_rcod));
 
         try!(encoder.emit_u16(self.query_count));

--- a/proto/src/op/message.rs
+++ b/proto/src/op/message.rs
@@ -69,7 +69,7 @@ use rr::dnssec::rdata::DNSSECRecordType;
 ///
 /// By default Message is a Query. Use the Message::as_update() to create and update, or
 ///  Message::new_update()
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Message {
     header: Header,
     queries: Vec<Query>,
@@ -574,7 +574,7 @@ impl Message {
         Ok((records, edns, sig0s))
     }
 
-    fn emit_records(encoder: &mut BinEncoder, records: &Vec<Record>) -> ProtoResult<()> {
+    fn emit_records(encoder: &mut BinEncoder, records: &[Record]) -> ProtoResult<()> {
         for r in records {
             try!(r.emit(encoder));
         }

--- a/proto/src/op/query.rs
+++ b/proto/src/op/query.rs
@@ -56,14 +56,21 @@ pub struct Query {
     query_class: DNSClass,
 }
 
-impl Query {
-    /// return a default query with an empty name and A, IN for the query_type and query_class
-    pub fn new() -> Self {
+impl Default for Query {
+    /// Return a default query with an empty name and A, IN for the query_type and query_class
+    fn default() -> Self {
         Query {
             name: Name::new(),
             query_type: RecordType::A,
             query_class: DNSClass::IN,
         }
+    }
+}
+
+impl Query {
+    /// Return a default query with an empty name and A, IN for the query_type and query_class
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Create a new query from name and type, class defaults to IN

--- a/proto/src/op/response_code.rs
+++ b/proto/src/op/response_code.rs
@@ -134,13 +134,13 @@ impl ResponseCode {
     }
 
     /// returns the high 12 bits for the edns portion of the response code
-    pub fn high(&self) {
-        (u16::from(*self) & 0x0FF0) >> 4;
+    pub fn high(&self) -> u16 {
+        (u16::from(*self) & 0x0FF0) >> 4
     }
 
     /// Combines the EDNS high and low from the Header to produce the Extended ResponseCode
     pub fn from(high: u8, low: u8) -> ResponseCode {
-        (((high as u16) << 4) | ((low as u16) & 0x000F)).into()
+        ((u16::from(high) << 4) | ((u16::from(low)) & 0x000F)).into()
     }
 
     /// Transforms the response code into the human message
@@ -191,27 +191,31 @@ impl Display for ResponseCode {
 impl From<ResponseCode> for u16 {
     fn from(rt: ResponseCode) -> Self {
         match rt {
-            ResponseCode::NoError => 0,  // 0	  NoError	No Error	[RFC1035]
-            ResponseCode::FormErr => 1,  // 1	  FormErr	Format Error	[RFC1035]
-            ResponseCode::ServFail => 2,  // 2	  ServFail	Server Failure	[RFC1035]
-            ResponseCode::NXDomain => 3,  // 3	  NXDomain	Non-Existent Domain	[RFC1035]
-            ResponseCode::NotImp => 4,  // 4	  NotImp	Not Implemented	[RFC1035]
-            ResponseCode::Refused => 5,  // 5	  Refused	Query Refused	[RFC1035]
-            ResponseCode::YXDomain => 6,  // 6	  YXDomain	Name Exists when it should not	[RFC2136][RFC6672]
-            ResponseCode::YXRRSet => 7,  // 7	  YXRRSet	RR Set Exists when it should not	[RFC2136]
-            ResponseCode::NXRRSet => 8,  // 8	  NXRRSet	RR Set that should exist does not	[RFC2136]
-            ResponseCode::NotAuth => 9,  // 9	  NotAuth	Server Not Authoritative for zone	[RFC2136]
-            ResponseCode::NotZone => 10, // 10	NotZone	Name not contained in zone	[RFC2136]
-            // 11-15	Unassigned
-            ResponseCode::BADVERS => 16, // 16	BADVERS	Bad OPT Version	[RFC6891]
-            ResponseCode::BADSIG => 16, // 16	BADSIG	TSIG Signature Failure	[RFC2845]
-            ResponseCode::BADKEY => 17, // 17	BADKEY	Key not recognized	[RFC2845]
-            ResponseCode::BADTIME => 18, // 18	BADTIME	Signature out of time window	[RFC2845]
-            ResponseCode::BADMODE => 19, // 19	BADMODE	Bad TKEY Mode	[RFC2930]
-            ResponseCode::BADNAME => 20, // 20	BADNAME	Duplicate key name	[RFC2930]
-            ResponseCode::BADALG => 21, // 21	BADALG	Algorithm not supported	[RFC2930]
-            ResponseCode::BADTRUNC => 22, // 22	BADTRUNC	Bad Truncation	[RFC4635]
-            ResponseCode::BADCOOKIE => 23, // 23	BADCOOKIE (TEMPORARY - registered 2015-07-26, expires 2016-07-26)	Bad/missing server cookie	[draft-ietf-dnsop-cookies]
+            ResponseCode::NoError => 0,    // 0   NoError    No Error                           [RFC1035]
+            ResponseCode::FormErr => 1,    // 1   FormErr    Format Error                       [RFC1035]
+            ResponseCode::ServFail => 2,   // 2   ServFail   Server Failure                     [RFC1035]
+            ResponseCode::NXDomain => 3,   // 3   NXDomain   Non-Existent Domain                [RFC1035]
+            ResponseCode::NotImp => 4,     // 4   NotImp     Not Implemented                    [RFC1035]
+            ResponseCode::Refused => 5,    // 5   Refused    Query Refused                      [RFC1035]
+            ResponseCode::YXDomain => 6,   // 6   YXDomain   Name Exists when it should not     [RFC2136][RFC6672]
+            ResponseCode::YXRRSet => 7,    // 7   YXRRSet    RR Set Exists when it should not   [RFC2136]
+            ResponseCode::NXRRSet => 8,    // 8   NXRRSet    RR Set that should exist does not  [RFC2136]
+            ResponseCode::NotAuth => 9,    // 9   NotAuth    Server Not Authoritative for zone  [RFC2136]
+            ResponseCode::NotZone => 10,   // 10  NotZone    Name not contained in zone         [RFC2136]
+            //
+            // 11-15    Unassigned
+            //
+            // 16  BADVERS  Bad OPT Version         [RFC6891]
+            // 16  BADSIG   TSIG Signature Failure  [RFC2845]
+            ResponseCode::BADVERS | ResponseCode::BADSIG => 16,
+            ResponseCode::BADKEY => 17,    // 17  BADKEY    Key not recognized              [RFC2845]
+            ResponseCode::BADTIME => 18,   // 18  BADTIME   Signature out of time window    [RFC2845]
+            ResponseCode::BADMODE => 19,   // 19  BADMODE   Bad TKEY Mode                   [RFC2930]
+            ResponseCode::BADNAME => 20,   // 20  BADNAME   Duplicate key name              [RFC2930]
+            ResponseCode::BADALG => 21,    // 21  BADALG    Algorithm not supported         [RFC2930]
+            ResponseCode::BADTRUNC => 22,  // 22  BADTRUNC  Bad Truncation                  [RFC4635]
+            // 23  BADCOOKIE (TEMPORARY - registered 2015-07-26, expires 2016-07-26)    Bad/missing server cookie    [draft-ietf-dnsop-cookies]
+            ResponseCode::BADCOOKIE => 23,
         }
     }
 }

--- a/proto/src/retry_dns_handle.rs
+++ b/proto/src/retry_dns_handle.rs
@@ -35,7 +35,7 @@ where
     ///
     /// * `handle` - handle to the dns connection
     /// * `attempts` - number of attempts before failing
-    pub fn new(handle: H, attempts: usize) -> RetryDnsHandle<H> {
+    pub fn new(handle: H, attempts: usize) -> Self {
         RetryDnsHandle { handle, attempts }
     }
 }
@@ -52,12 +52,12 @@ where
         //  obviously it would be nice to be lazy about this...
         let future = self.handle.send(message.clone());
 
-        return Box::new(RetrySendFuture {
+        Box::new(RetrySendFuture {
             message: message,
             handle: self.handle.clone(),
             future: future,
             remaining_attempts: self.attempts,
-        });
+        })
     }
 }
 
@@ -88,7 +88,7 @@ where
                         return Err(e);
                     }
 
-                    self.remaining_attempts = self.remaining_attempts - 1;
+                    self.remaining_attempts -= 1;
                     // TODO: if the "sent" Message is part of the error result,
                     //  then we can just reuse it... and no clone necessary
                     self.future = self.handle.send(self.message.clone());

--- a/proto/src/rr/dns_class.rs
+++ b/proto/src/rr/dns_class.rs
@@ -11,6 +11,7 @@ use std::convert::From;
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 use serialize::binary::*;
 use error::*;
@@ -33,16 +34,19 @@ pub enum DNSClass {
     OPT(u16),
 }
 
-impl DNSClass {
-    /// Convert from &str to DNSClass
+impl FromStr for DNSClass {
+    type Err = ProtoError;
+
+    /// Convert from `&str` to `DNSClass`
     ///
     /// ```
+    /// use std::str::FromStr;
     /// use trust_dns_proto::rr::dns_class::DNSClass;
     ///
     /// let var: DNSClass = DNSClass::from_str("IN").unwrap();
     /// assert_eq!(DNSClass::IN, var);
     /// ```
-    pub fn from_str(str: &str) -> ProtoResult<Self> {
+    fn from_str(str: &str) -> ProtoResult<Self> {
         match str {
             "IN" => Ok(DNSClass::IN),
             "CH" => Ok(DNSClass::CH),
@@ -52,8 +56,9 @@ impl DNSClass {
             _ => Err(ProtoErrorKind::UnknownDnsClassStr(str.to_string()).into()),
         }
     }
+}
 
-
+impl DNSClass {
     /// Convert from u16 to DNSClass
     ///
     /// ```

--- a/proto/src/rr/dnssec/digest_type.rs
+++ b/proto/src/rr/dnssec/digest_type.rs
@@ -149,9 +149,9 @@ impl From<Algorithm> for DigestType {
         match a {
             Algorithm::RSASHA1 |
             Algorithm::RSASHA1NSEC3SHA1 => DigestType::SHA1,
-            Algorithm::RSASHA256 => DigestType::SHA256,
-            Algorithm::RSASHA512 => DigestType::SHA512,
+            Algorithm::RSASHA256 |
             Algorithm::ECDSAP256SHA256 => DigestType::SHA256,
+            Algorithm::RSASHA512 => DigestType::SHA512,
             Algorithm::ECDSAP384SHA384 => DigestType::SHA384,
             Algorithm::ED25519 => DigestType::ED25519,
         }

--- a/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -233,7 +233,7 @@ impl DNSKEY {
             }
         }
 
-        digest_type.hash(&buf).map_err(|e| e.into())
+        digest_type.hash(&buf)
     }
 
     /// This will always return an error unless the Ring or OpenSSL features are enabled
@@ -258,7 +258,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<DNSKEY> 
     //    Bits 0-6 and 8-14 are reserved: these bits MUST have value 0 upon
     //    creation of the DNSKEY RR and MUST be ignored upon receipt.
     let zone_key: bool = flags & 0b0000_0001_0000_0000 == 0b0000_0001_0000_0000;
-    let secure_entry_point: bool = flags & 0b0000_0000_0000_0001 == 0b0000_0000_0000_00001;
+    let secure_entry_point: bool = flags & 0b0000_0000_0000_0001 == 0b0000_0000_0000_0001;
     let revoke: bool = flags & 0b0000_0000_1000_0000 == 0b0000_0000_1000_0000;
     let protocol: u8 = try!(decoder.read_u8());
 
@@ -324,7 +324,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/dnssec/rdata/ds.rs
+++ b/proto/src/rr/dnssec/rdata/ds.rs
@@ -174,7 +174,6 @@ impl DS {
     #[cfg(any(feature = "openssl", feature = "ring"))]
     pub fn covers(&self, name: &Name, key: &DNSKEY) -> ProtoResult<bool> {
         key.to_digest(name, self.digest_type())
-            .map_err(|e| e.into())
             .map(|hash| hash.as_ref() == self.digest())
     }
 
@@ -223,7 +222,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/dnssec/rdata/key.rs
+++ b/proto/src/rr/dnssec/rdata/key.rs
@@ -844,7 +844,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/proto/src/rr/dnssec/rdata/nsec.rs
@@ -160,7 +160,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/dnssec/rdata/nsec3.rs
+++ b/proto/src/rr/dnssec/rdata/nsec3.rs
@@ -356,7 +356,7 @@ pub fn decode_type_bit_maps(
                     if bit_map & 0b1000_0000 == 0b1000_0000 {
                         // len - left is the block in the bitmap, times 8 for the bits, + the bit in the current_byte
                         let low_byte = ((len - left) * 8) + i;
-                        let rr_type: u16 = (window as u16) << 8 | low_byte as u16;
+                        let rr_type: u16 = (u16::from(window) << 8) | u16::from(low_byte);
                         record_types.push(try!(RecordType::from_u16(rr_type)));
                     }
                     // shift left and look at the next bit
@@ -424,7 +424,7 @@ pub fn encode_bit_maps(encoder: &mut BinEncoder, type_bit_maps: &[RecordType]) -
         let window: u8 = (code >> 8) as u8;
         let low: u8 = (code & 0x00FF) as u8;
 
-        let bit_map: &mut Vec<u8> = hash.entry(window).or_insert(Vec::new());
+        let bit_map: &mut Vec<u8> = hash.entry(window).or_insert_with(Vec::new);
         // len + left is the block in the bitmap, divided by 8 for the bits, + the bit in the current_byte
         let index: u8 = low / 8;
         let bit: u8 = 0b1000_0000 >> (low % 8);
@@ -471,7 +471,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 
@@ -521,7 +521,7 @@ pub fn test_dups() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata_with_dups).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/dnssec/rdata/nsec3param.rs
+++ b/proto/src/rr/dnssec/rdata/nsec3param.rs
@@ -184,7 +184,7 @@ pub fn emit(encoder: &mut BinEncoder, rdata: &NSEC3PARAM) -> ProtoResult<()> {
     try!(encoder.emit(flags));
     try!(encoder.emit_u16(rdata.iterations()));
     try!(encoder.emit(rdata.salt().len() as u8));
-    try!(encoder.emit_vec(&rdata.salt()));
+    try!(encoder.emit_vec(rdata.salt()));
 
     Ok(())
 }
@@ -196,7 +196,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/dnssec/rdata/sig.rs
+++ b/proto/src/rr/dnssec/rdata/sig.rs
@@ -588,7 +588,7 @@ fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/dnssec/supported_algorithm.rs
+++ b/proto/src/rr/dnssec/supported_algorithm.rs
@@ -37,7 +37,7 @@ impl SupportedAlgorithms {
 
     /// Specify the entire set is supported
     pub fn all() -> Self {
-        SupportedAlgorithms { bit_map: 0b01111111 }
+        SupportedAlgorithms { bit_map: 0b0111_1111 }
     }
 
     /// Based on the set of Algorithms, return the supported set
@@ -62,8 +62,6 @@ impl SupportedAlgorithms {
             Algorithm::ECDSAP384SHA384 => 5,
             Algorithm::ED25519 => 6,
         };
-
-        assert!(bit_pos <= u8::max_value());
         1u8 << bit_pos
     }
 

--- a/proto/src/rr/dnssec/tbs.rs
+++ b/proto/src/rr/dnssec/tbs.rs
@@ -135,7 +135,7 @@ pub fn rrset_tbs(
                 sig_expiration,
                 sig_inception,
                 key_tag,
-                &signer_name,
+                signer_name,
             ).is_ok()
         );
 
@@ -189,7 +189,7 @@ pub fn rrset_tbs(
 ///
 /// binary hash of the RRSet with the information from the RRSIG record
 pub fn rrset_tbs_with_rrsig(rrsig: &Record, records: &[Record]) -> ProtoResult<TBS> {
-    if let &RData::DNSSEC(DNSSECRData::SIG(ref sig)) = rrsig.rdata() {
+    if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *rrsig.rdata() {
         rrset_tbs_with_sig(rrsig.name(), rrsig.dns_class(), sig, records)
     } else {
         return Err(

--- a/proto/src/rr/dnssec/trust_anchor.rs
+++ b/proto/src/rr/dnssec/trust_anchor.rs
@@ -56,8 +56,8 @@ impl TrustAnchor {
     }
 
     /// inserts the trust_anchor to the trusted chain
-    pub fn insert_trust_anchor<P: PublicKey>(&mut self, public_key: P) {
-        if !self.contains(&public_key) {
+    pub fn insert_trust_anchor<P: PublicKey>(&mut self, public_key: &P) {
+        if !self.contains(public_key) {
             self.pkeys.push(public_key.public_bytes().to_vec())
         }
     }

--- a/proto/src/rr/rdata/mx.rs
+++ b/proto/src/rr/rdata/mx.rs
@@ -121,7 +121,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/rdata/name.rs
+++ b/proto/src/rr/rdata/name.rs
@@ -79,7 +79,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/rdata/null.rs
+++ b/proto/src/rr/rdata/null.rs
@@ -36,7 +36,7 @@ use error::*;
 /// allowed in master files.  NULLs are used as placeholders in some
 /// experimental extensions of the DNS.
 /// ```
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NULL {
     anything: Option<Vec<u8>>,
 }
@@ -44,7 +44,7 @@ pub struct NULL {
 impl NULL {
     /// Construct a new NULL RData
     pub fn new() -> NULL {
-        NULL { anything: None }
+        Default::default()
     }
 
     /// Constructs a new NULL RData with the associated data
@@ -80,7 +80,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<NULL> {
 
 /// Write the RData from the given Decoder
 pub fn emit(encoder: &mut BinEncoder, nil: &NULL) -> ProtoResult<()> {
-    if let Some(ref anything) = nil.anything() {
+    if let Some(anything) = nil.anything() {
         for b in anything.iter() {
             try!(encoder.emit(*b));
         }
@@ -96,7 +96,7 @@ pub fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/rdata/soa.rs
+++ b/proto/src/rr/rdata/soa.rs
@@ -268,7 +268,7 @@ fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/rdata/srv.rs
+++ b/proto/src/rr/rdata/srv.rs
@@ -245,7 +245,7 @@ fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/rdata/tlsa.rs
+++ b/proto/src/rr/rdata/tlsa.rs
@@ -427,7 +427,7 @@ mod tests {
         let mut bytes = Vec::new();
         let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
         emit(&mut encoder, &rdata).expect("failed to emit tlsa");
-        let bytes = encoder.as_bytes();
+        let bytes = encoder.into_bytes();
 
         println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/rdata/txt.rs
+++ b/proto/src/rr/rdata/txt.rs
@@ -86,7 +86,7 @@ fn test() {
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);
     assert!(emit(&mut encoder, &rdata).is_ok());
-    let bytes = encoder.as_bytes();
+    let bytes = encoder.into_bytes();
 
     println!("bytes: {:?}", bytes);
 

--- a/proto/src/rr/record_data.rs
+++ b/proto/src/rr/record_data.rs
@@ -416,10 +416,9 @@ impl RData {
                 debug!("reading AAAA");
                 RData::AAAA(rdata::aaaa::read(decoder)?)
             }
-            rt @ RecordType::ANY => {
-                return Err(ProtoErrorKind::UnknownRecordTypeValue(rt.into()).into())
-            }
-            rt @ RecordType::AXFR => {
+            rt @ RecordType::ANY |
+            rt @ RecordType::AXFR |
+            rt @ RecordType::IXFR => {
                 return Err(ProtoErrorKind::UnknownRecordTypeValue(rt.into()).into())
             }
             RecordType::CAA => {
@@ -429,9 +428,6 @@ impl RData {
             RecordType::CNAME => {
                 debug!("reading CNAME");
                 RData::CNAME(try!(rdata::name::read(decoder)))
-            }
-            rt @ RecordType::IXFR => {
-                return Err(ProtoErrorKind::UnknownRecordTypeValue(rt.into()).into())
             }
             RecordType::MX => {
                 debug!("reading MX");
@@ -507,15 +503,11 @@ impl RData {
             RData::AAAA(ref address) => rdata::aaaa::emit(encoder, address),
             RData::CAA(ref caa) => rdata::caa::emit(encoder, caa),
             // to_lowercase for rfc4034 and rfc6840
-            RData::CNAME(ref name) => rdata::name::emit(encoder, name),
+            RData::CNAME(ref name) | RData::NS(ref name) | RData::PTR(ref name) => rdata::name::emit(encoder, name),
             // to_lowercase for rfc4034 and rfc6840
             RData::MX(ref mx) => rdata::mx::emit(encoder, mx),
             RData::NULL(ref null) => rdata::null::emit(encoder, null),
-            // to_lowercase for rfc4034 and rfc6840
-            RData::NS(ref name) => rdata::name::emit(encoder, name),
             RData::OPT(ref opt) => rdata::opt::emit(encoder, opt),
-            // to_lowercase for rfc4034 and rfc6840
-            RData::PTR(ref name) => rdata::name::emit(encoder, name),
             // to_lowercase for rfc4034 and rfc6840
             RData::SOA(ref soa) => rdata::soa::emit(encoder, soa),
             // to_lowercase for rfc4034 and rfc6840
@@ -560,7 +552,7 @@ impl RData {
 
 impl PartialOrd<RData> for RData {
     fn partial_cmp(&self, other: &RData) -> Option<Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/proto/src/rr/record_type.rs
+++ b/proto/src/rr/record_type.rs
@@ -20,6 +20,7 @@ use std::convert::From;
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 use serialize::binary::*;
 use error::*;
@@ -89,16 +90,19 @@ pub enum RecordType {
     DNSSEC(DNSSECRecordType),
 }
 
-impl RecordType {
-    /// Convert from RecordType to &str
+impl FromStr for RecordType {
+    type Err = ProtoError;
+
+    /// Convert `&str` to `RecordType`
     ///
     /// ```
+    /// use std::str::FromStr;
     /// use trust_dns_proto::rr::record_type::RecordType;
     ///
     /// let var: RecordType = RecordType::from_str("A").unwrap();
     /// assert_eq!(RecordType::A, var);
     /// ```
-    pub fn from_str(str: &str) -> ProtoResult<Self> {
+    fn from_str(str: &str) -> ProtoResult<Self> {
         match str {
             "A" => Ok(RecordType::A),
             "AAAA" => Ok(RecordType::AAAA),
@@ -117,8 +121,10 @@ impl RecordType {
             _ => Err(ProtoErrorKind::UnknownRecordTypeStr(str.to_string()).into()),
         }
     }
+}
 
-    /// Convert from RecordType to &str
+impl RecordType {
+    /// Convert from `u16` to `RecordType`
     ///
     /// ```
     /// use trust_dns_proto::rr::record_type::RecordType;

--- a/proto/src/rr/resource.rs
+++ b/proto/src/rr/resource.rs
@@ -70,12 +70,8 @@ pub struct Record {
     rdata: RData,
 }
 
-impl Record {
-    /// Creates a default record, use the setters to build a more useful object.
-    ///
-    /// There are no optional elements in this object, defaults are an empty name, type A, class IN,
-    /// ttl of 0 and the 0.0.0.0 ip address.
-    pub fn new() -> Record {
+impl Default for Record {
+    fn default() -> Self {
         Record {
             // TODO: these really should all be Optionals, I was lazy.
             name_labels: domain::Name::new(),
@@ -84,6 +80,16 @@ impl Record {
             ttl: 0,
             rdata: RData::NULL(NULL::new()),
         }
+    }
+}
+
+impl Record {
+    /// Creates a default record, use the setters to build a more useful object.
+    ///
+    /// There are no optional elements in this object, defaults are an empty name, type A, class IN,
+    /// ttl of 0 and the 0.0.0.0 ip address.
+    pub fn new() -> Record {
+        Default::default()
     }
 
     /// Create a record with the specified initial values.
@@ -327,10 +333,6 @@ impl PartialEq for Record {
         // self == other && // the same pointer
         self.name_labels == other.name_labels && self.rr_type == other.rr_type &&
             self.dns_class == other.dns_class && self.rdata == other.rdata
-    }
-
-    fn ne(&self, other: &Self) -> bool {
-        !self.eq(other)
     }
 }
 

--- a/proto/src/serialize/binary/decoder.rs
+++ b/proto/src/serialize/binary/decoder.rs
@@ -58,6 +58,11 @@ impl<'a> BinDecoder<'a> {
         self.buffer.len() - self.index
     }
 
+    /// Returns `true` if the buffer is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Peed one byte forward, without moving the current index forward
     pub fn peek(&self) -> Option<u8> {
         if self.index < self.buffer.len() {
@@ -69,7 +74,7 @@ impl<'a> BinDecoder<'a> {
 
     /// Returns the current index in the buffer
     pub fn index(&self) -> usize {
-        return self.index;
+        self.index
     }
 
     /// This is a pretty efficient clone, as the buffer is never cloned, and only the index is set
@@ -164,7 +169,7 @@ impl<'a> BinDecoder<'a> {
         let b2: u8 = try!(self.pop());
 
         // translate from network byte order, i.e. big endian
-        Ok(((b1 as u16) << 8) + (b2 as u16))
+        Ok((u16::from(b1) << 8) + u16::from(b2))
     }
 
     /// Reads the next four bytes into i32.
@@ -184,7 +189,7 @@ impl<'a> BinDecoder<'a> {
 
         // translate from network byte order, i.e. big endian
         Ok(
-            ((b1 as i32) << 24) + ((b2 as i32) << 16) + ((b3 as i32) << 8) + (b4 as i32),
+            (i32::from(b1) << 24) + (i32::from(b2) << 16) + (i32::from(b3) << 8) + (i32::from(b4) as i32),
         )
     }
 
@@ -205,7 +210,7 @@ impl<'a> BinDecoder<'a> {
 
         // translate from network byte order, i.e. big endian
         Ok(
-            ((b1 as u32) << 24) + ((b2 as u32) << 16) + ((b3 as u32) << 8) + (b4 as u32),
+            (u32::from(b1) << 24) + (u32::from(b2) << 16) + (u32::from(b3) << 8) + u32::from(b4),
         )
     }
 }

--- a/proto/src/serialize/binary/encoder.rs
+++ b/proto/src/serialize/binary/encoder.rs
@@ -64,13 +64,18 @@ impl<'a> BinEncoder<'a> {
     }
 
     /// Returns a reference to the internal buffer
-    pub fn as_bytes(self) -> &'a Vec<u8> {
+    pub fn into_bytes(self) -> &'a Vec<u8> {
         self.buffer
     }
 
     /// Returns the length of the buffer
     pub fn len(&self) -> usize {
         self.buffer.len()
+    }
+
+    /// Returns `true` if the buffer is empty
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
     }
 
     /// Returns the current offset into the buffer
@@ -117,7 +122,7 @@ impl<'a> BinEncoder<'a> {
 
     /// Looks up the index of an already written label
     pub fn get_label_pointer(&self, labels: &[Rc<String>]) -> Option<u16> {
-        self.name_pointers.get(labels).map(|i| *i)
+        self.name_pointers.get(labels).cloned()
     }
 
     /// matches description from above.

--- a/resolver/src/hosts.rs
+++ b/resolver/src/hosts.rs
@@ -27,7 +27,7 @@ impl Hosts {
 
     /// lookup_static_host looks up the addresses for the given host from /etc/hosts.
     pub fn lookup_static_host(&self, name: &Name) -> Option<Lookup> {
-        if self.by_name.len() > 0 {
+        if !self.by_name.is_empty() {
             if let Some(val) = self.by_name.get(name) {
                 return Some(val.clone());
             }
@@ -72,13 +72,12 @@ pub fn read_hosts_conf<P: AsRef<Path>>(path: P) -> io::Result<Hosts> {
             continue;
         };
 
-        for i in 1..fields.len() {
-            let domain = fields[i].to_lowercase();
+        for domain in fields.iter().skip(1).map(|domain| domain.to_lowercase()) {
             if let Ok(name) = Name::from_str(&domain) {
                 let lookup = hosts
                     .by_name
                     .entry(name.clone())
-                    .or_insert(Lookup::new(Arc::new(vec![])))
+                    .or_insert_with(|| Lookup::new(Arc::new(vec![])))
                     .append(Lookup::new(Arc::new(vec![addr.clone()])));
 
                 hosts.by_name.insert(name, lookup);

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -183,7 +183,7 @@ impl ResolverFuture {
                 Self::push_name(name_search, &mut names);
             }
 
-            let domain = name.clone().append_domain(&self.config.domain());
+            let domain = name.clone().append_domain(self.config.domain());
             Self::push_name(domain, &mut names);
 
             // this is the direct name lookup

--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# This script is used for CI and assumes clippy is installed already.
+# TODO: run clippy on the other crates, for now we only fixed the clippy warning on the client crate
+
+pushd client
+cargo clippy --all-features -- \
+    --allow type_complexity \
+    --allow doc_markdown \
+    --allow module_inception
+popd
+
+pushd proto
+# FIXME: we should probably not allow `block_in_if_condition_stmt
+cargo clippy --all-features -- \
+    --allow doc_markdown \
+    --allow type_complexity \
+    --allow many_single_char_names \
+    --allow needless_lifetimes \
+    --allow block_in_if_condition_stmt \
+    --allow too_many_arguments \
+    --allow new_ret_no_self \
+    --allow enum_variant_names
+popd

--- a/server/tests/z_named_test_rsa_dnssec.rs
+++ b/server/tests/z_named_test_rsa_dnssec.rs
@@ -50,7 +50,7 @@ fn trust_anchor(public_key_path: &Path, format: KeyFormat, algorithm: Algorithm)
     let public_key = key_pair.to_public_key().unwrap();
     let mut trust_anchor = TrustAnchor::new();
 
-    trust_anchor.insert_trust_anchor(public_key);
+    trust_anchor.insert_trust_anchor(&public_key);
     trust_anchor
 }
 


### PR DESCRIPTION
I'm interested in starting contributing to trust-dns, and clippy is a good way to get a little bit familiar with the codebase, so here we go :)

With these fixes the client builds with clippy with no warning:

```
~/r/t/client ❯❯❯ cargo clippy -- --allow doc_markdown  --allow type_complexity --allow module_inception --allow new_ret_no_self 
   Compiling trust-dns v0.12.0 (file:///home/little-dude/rust/trust-dns/client)
    Finished dev [unoptimized + debuginfo] target(s) in 3.54 secs
```

Let me know if you're interested in more clippy fixes. While on topic of cosmetic changes, I noticed you use `try!`. Do you plan to move to `?` at some point or do you prefer `try!`? If so I can make a PR for that.