### PR TITLE
minor optimizations for deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
 name = "trust-dns-proto"
 version = "0.2.0"
 dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -47,6 +47,7 @@ name = "trust_dns_proto"
 path = "src/lib.rs"
 
 [dependencies]
+byteorder = "^1.2.1"
 data-encoding = { version = "2.1.0", optional = true }
 error-chain = "0.1.12"
 futures = "^0.1.17"

--- a/proto/benches/lib.rs
+++ b/proto/benches/lib.rs
@@ -1,0 +1,128 @@
+#![feature(test)]
+
+extern crate trust_dns_proto;
+extern crate test;
+
+use trust_dns_proto::op::{MessageType, Header, ResponseCode, OpCode, Message};
+use trust_dns_proto::rr::Record;
+use trust_dns_proto::serialize::binary::{BinDecoder, BinEncoder, BinSerializable};
+
+use test::Bencher;
+
+
+#[bench]
+fn bench_emit_header(b: &mut Bencher) {
+    let header = Header::new();
+    b.iter(|| {
+        // we need to create the vector here, otherwise its length is already big enough and the
+        // encoder does not need to resize it
+        let mut bytes = Vec::with_capacity(512);
+        let mut encoder = BinEncoder::new(&mut bytes);
+        header.emit(&mut encoder)
+    })
+}
+
+// FIXME:
+// This is a bit silly, because everywhere in the codebase, we reserve 512 bytes for the buffer.
+// But what we want to measure here is the cost of reserving more space, which can happen for big
+// messages exceeding 512 bytes. A better benchmark would be to emit such a big message.
+#[bench]
+fn bench_parse_header_no_reservation(b: &mut Bencher) {
+    let header = Header::new();
+    b.iter(|| {
+        let mut bytes = Vec::with_capacity(0);
+        let mut encoder = BinEncoder::new(&mut bytes);
+        header.emit(&mut encoder)
+    })
+}
+
+
+#[bench]
+fn bench_parse_header(b: &mut Bencher) {
+    let byte_vec = vec![
+        0x01, 0x10, 0xAA, 0x83,
+        0x88, 0x77, 0x66, 0x55,
+        0x44, 0x33, 0x22, 0x11
+    ];
+    b.iter(|| {
+        let mut decoder = BinDecoder::new(&byte_vec);
+        Header::read(&mut decoder)
+    })
+}
+
+#[bench]
+fn bench_emit_message(b: &mut Bencher) {
+    let mut message = Message::new();
+    message
+        .set_id(10)
+        .set_message_type(MessageType::Response)
+        .set_op_code(OpCode::Update)
+        .set_authoritative(true)
+        .set_truncated(true)
+        .set_recursion_desired(true)
+        .set_recursion_available(true)
+        .set_authentic_data(true)
+        .set_checking_disabled(true)
+        .set_response_code(ResponseCode::ServFail);
+    message.add_answer(Record::new());
+    message.add_name_server(Record::new());
+    message.add_additional(Record::new());
+    b.iter(|| {
+        let mut byte_vec: Vec<u8> = Vec::with_capacity(512);
+        let mut encoder = BinEncoder::new(&mut byte_vec);
+        message.emit(&mut encoder)
+    })
+}
+
+#[bench]
+fn bench_emit_message_no_reservation(b: &mut Bencher) {
+    let mut message = Message::new();
+    message
+        .set_id(10)
+        .set_message_type(MessageType::Response)
+        .set_op_code(OpCode::Update)
+        .set_authoritative(true)
+        .set_truncated(true)
+        .set_recursion_desired(true)
+        .set_recursion_available(true)
+        .set_authentic_data(true)
+        .set_checking_disabled(true)
+        .set_response_code(ResponseCode::ServFail);
+    message.add_answer(Record::new());
+    message.add_name_server(Record::new());
+    message.add_additional(Record::new());
+    b.iter(|| {
+        let mut byte_vec: Vec<u8> = Vec::with_capacity(0);
+        let mut encoder = BinEncoder::new(&mut byte_vec);
+        message.emit(&mut encoder)
+    })
+}
+
+#[bench]
+fn bench_parse_message(b: &mut Bencher) {
+    let mut message = Message::new();
+    message
+        .set_id(10)
+        .set_message_type(MessageType::Response)
+        .set_op_code(OpCode::Update)
+        .set_authoritative(true)
+        .set_truncated(true)
+        .set_recursion_desired(true)
+        .set_recursion_available(true)
+        .set_authentic_data(true)
+        .set_checking_disabled(true)
+        .set_response_code(ResponseCode::ServFail);
+
+    message.add_answer(Record::new());
+    message.add_name_server(Record::new());
+    message.add_additional(Record::new());
+    let mut byte_vec: Vec<u8> = Vec::with_capacity(512);
+    {
+        let mut encoder = BinEncoder::new(&mut byte_vec);
+        message.emit(&mut encoder).unwrap();
+    }
+    b.iter(|| {
+        let mut decoder = BinDecoder::new(&byte_vec);
+        Message::read(&mut decoder)
+    })
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -30,6 +30,7 @@ extern crate tokio_io;
 #[cfg(feature = "ring")]
 extern crate untrusted;
 extern crate url;
+extern crate byteorder;
 
 use std::marker::PhantomData;
 use std::net::SocketAddr;

--- a/proto/src/serialize/binary/decoder.rs
+++ b/proto/src/serialize/binary/decoder.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 use error::{ProtoErrorKind, ProtoResult};
+use byteorder::{ByteOrder, NetworkEndian};
 
 /// This is non-destructive to the inner buffer, b/c for pointer types we need to perform a reverse
 ///  seek to lookup names
@@ -142,8 +143,6 @@ impl<'a> BinDecoder<'a> {
         if end > self.buffer.len() {
             return Err(ProtoErrorKind::Message("buffer exhausted").into());
         }
-
-
         let slice: &'a [u8] = &self.buffer[self.index..end];
         self.index += len;
         Ok(slice)
@@ -163,11 +162,7 @@ impl<'a> BinDecoder<'a> {
     ///
     /// Return the u16 from the buffer
     pub fn read_u16(&mut self) -> ProtoResult<u16> {
-        let b1: u8 = self.pop()?;
-        let b2: u8 = self.pop()?;
-
-        // translate from network byte order, i.e. big endian
-        Ok((u16::from(b1) << 8) + u16::from(b2))
+        Ok(NetworkEndian::read_u16(self.read_slice(2)?))
     }
 
     /// Reads the next four bytes into i32.
@@ -179,17 +174,7 @@ impl<'a> BinDecoder<'a> {
     ///
     /// Return the i32 from the buffer
     pub fn read_i32(&mut self) -> ProtoResult<i32> {
-        // TODO should this use a default rather than the panic! that will happen in the None case?
-        let b1: u8 = self.pop()?;
-        let b2: u8 = self.pop()?;
-        let b3: u8 = self.pop()?;
-        let b4: u8 = self.pop()?;
-
-        // translate from network byte order, i.e. big endian
-        Ok(
-            (i32::from(b1) << 24) + (i32::from(b2) << 16) + (i32::from(b3) << 8)
-                + (i32::from(b4) as i32),
-        )
+        Ok(NetworkEndian::read_i32(self.read_slice(4)?))
     }
 
     /// Reads the next four bytes into u32.
@@ -201,14 +186,7 @@ impl<'a> BinDecoder<'a> {
     ///
     /// Return the u32 from the buffer
     pub fn read_u32(&mut self) -> ProtoResult<u32> {
-        // TODO should this use a default rather than the panic! that will happen in the None case?
-        let b1: u8 = self.pop()?;
-        let b2: u8 = self.pop()?;
-        let b3: u8 = self.pop()?;
-        let b4: u8 = self.pop()?;
-
-        // translate from network byte order, i.e. big endian
-        Ok((u32::from(b1) << 24) + (u32::from(b2) << 16) + (u32::from(b3) << 8) + u32::from(b4))
+        Ok(NetworkEndian::read_u32(self.read_slice(4)?))
     }
 }
 


### PR DESCRIPTION
I added some benchmarks to quantify the win (pretty minor, but a win is a win :p)
Before:
```
test bench_parse_header  ... bench:         145 ns/iter (+/- 1)
test bench_parse_message ... bench:         926 ns/iter (+/- 67)
```
After:
```
test bench_parse_header  ... bench:         117 ns/iter (+/- 0) 
test bench_parse_message ... bench:         816 ns/iter (+/- 11)
```

I've [experimented](https://github.com/little-dude/trust-dns/tree/byteorder) with more ambitious changes but it was not conclusive.