### PR TITLE
Introduce a Label type instead of using Rc<String>

### DIFF
--- a/compatibility-tests/tests/sig0_tests.rs
+++ b/compatibility-tests/tests/sig0_tests.rs
@@ -83,7 +83,7 @@ where
     let signer = Signer::sig0(
         sig0key,
         key,
-        Name::from_labels(vec!["update", "example", "com"]),
+        Name::from(&["update", "example", "com"] as &[_]),
     );
 
     assert_eq!(signer.calculate_key_tag().unwrap(), 56935_u16);
@@ -100,11 +100,11 @@ fn test_create() {
     let conn = UdpClientConnection::new(socket).unwrap();
 
     let client = create_sig0_ready_client(conn);
-    let origin = Name::from_labels(vec!["example", "com"]);
+    let origin = Name::from(&["example", "com"] as &[_]);
 
     // create a record
     let mut record = Record::with(
-        Name::from_labels(vec!["new", "example", "com"]),
+        Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );

--- a/integration-tests/tests/authority_tests.rs
+++ b/integration-tests/tests/authority_tests.rs
@@ -175,8 +175,8 @@ fn test_authorize() {
 
 #[test]
 fn test_prerequisites() {
-    let not_zone = Name::from_labels(vec!["not", "a", "domain", "com"]);
-    let not_in_zone = Name::from_labels(vec!["not", "example", "com"]);
+    let not_zone = Name::from(&["not", "a", "domain", "com"] as &[_]);
+    let not_in_zone = Name::from(&["not", "example", "com"] as &[_]);
 
     let mut authority: Authority = create_example();
     authority.set_allow_update(true);
@@ -372,8 +372,8 @@ fn test_prerequisites() {
 
 #[test]
 fn test_pre_scan() {
-    let up_name = Name::from_labels(vec!["www", "example", "com"]);
-    let not_zone = Name::from_labels(vec!["not", "zone", "com"]);
+    let up_name = Name::from(&["www", "example", "com"] as &[_]);
+    let not_zone = Name::from(&["not", "zone", "com"] as &[_]);
 
     let authority: Authority = create_example();
 
@@ -619,8 +619,8 @@ fn test_pre_scan() {
 
 #[test]
 fn test_update() {
-    let new_name = Name::from_labels(vec!["new", "example", "com"]);
-    let www_name = Name::from_labels(vec!["www", "example", "com"]);
+    let new_name = Name::from(&["new", "example", "com"] as &[_]);
+    let www_name = Name::from(&["www", "example", "com"] as &[_]);
     let mut authority: Authority = create_example();
     let serial = authority.serial();
 
@@ -952,7 +952,7 @@ fn test_zone_signing() {
 
 #[test]
 fn test_get_nsec() {
-    let name = Name::from_labels(vec!["zzz", "example", "com"]);
+    let name = Name::from(&["zzz", "example", "com"] as &[_]);
     let authority: Authority = create_secure_example();
 
     let results = authority.get_nsec_records(&name, true, SupportedAlgorithms::all());
@@ -973,8 +973,8 @@ fn test_journal() {
     authority.set_journal(journal);
     authority.persist_to_journal().unwrap();
 
-    let new_name = Name::from_labels(vec!["new", "example", "com"]);
-    let delete_name = Name::from_labels(vec!["www", "example", "com"]);
+    let new_name = Name::from(&["new", "example", "com"] as &[_]);
+    let delete_name = Name::from(&["www", "example", "com"] as &[_]);
     let new_record = Record::new()
         .set_name(new_name.clone())
         .set_rdata(RData::A(Ipv4Addr::new(10, 11, 12, 13)))

--- a/integration-tests/tests/client_future_tests.rs
+++ b/integration-tests/tests/client_future_tests.rs
@@ -117,7 +117,7 @@ fn test_query_tcp_ipv6() {
 
 #[cfg(test)]
 fn test_query(client: &mut BasicClientHandle) -> Box<Future<Item = (), Error = ()>> {
-    let name = domain::Name::from_labels(vec!["WWW", "example", "com"]);
+    let name = domain::Name::from(&["WWW", "example", "com"] as &[_]);
 
     Box::new(
         client
@@ -161,7 +161,7 @@ fn test_notify() {
     let (stream, sender) = TestClientStream::new(Arc::new(catalog));
     let mut client = ClientFuture::new(stream, Box::new(sender), &io_loop.handle(), None);
 
-    let name = domain::Name::from_labels(vec!["ping", "example", "com"]);
+    let name = domain::Name::from(&["ping", "example", "com"] as &[_]);
 
     let message = io_loop.run(client.notify(
         name.clone(),
@@ -187,7 +187,7 @@ fn create_sig0_ready_client(io_loop: &Core) -> (BasicClientHandle, domain::Name)
     authority.set_allow_update(true);
     let origin = authority.origin().clone();
 
-    let trusted_name = domain::Name::from_labels(vec!["trusted", "example", "com"]);
+    let trusted_name = domain::Name::from(&["trusted", "example", "com"] as &[_]);
 
     let rsa = Rsa::generate(2048).unwrap();
     let key = KeyPair::from_rsa(rsa).unwrap();
@@ -226,7 +226,7 @@ fn test_create() {
 
     // create a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -273,7 +273,7 @@ fn test_create_multi() {
 
     // create a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -329,7 +329,7 @@ fn test_append() {
 
     // append a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -407,7 +407,7 @@ fn test_append_multi() {
 
     // append a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -491,7 +491,7 @@ fn test_compare_and_swap() {
 
     // create a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -563,7 +563,7 @@ fn test_compare_and_swap_multi() {
 
     // create a record
     let mut current = RecordSet::with_ttl(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -645,7 +645,7 @@ fn test_delete_by_rdata() {
 
     // append a record
     let mut record1 = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -695,7 +695,7 @@ fn test_delete_by_rdata_multi() {
 
     // append a record
     let mut rrset = RecordSet::with_ttl(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -728,7 +728,7 @@ fn test_delete_by_rdata_multi() {
 
     // append a record
     let mut rrset = RecordSet::with_ttl(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -770,7 +770,7 @@ fn test_delete_rrset() {
 
     // append a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -819,7 +819,7 @@ fn test_delete_all() {
 
     // append a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -881,7 +881,7 @@ fn test_delete_all() {
 }
 
 fn test_timeout_query(mut client: BasicClientHandle, mut io_loop: Core) {
-    let name = domain::Name::from_labels(vec!["www", "example", "com"]);
+    let name = domain::Name::from(&["www", "example", "com"] as &[_]);
 
     let err = io_loop
         .run(client.query(name.clone(), DNSClass::IN, RecordType::A))

--- a/integration-tests/tests/client_tests.rs
+++ b/integration-tests/tests/client_tests.rs
@@ -102,7 +102,7 @@ where
     <CC as ClientConnection>::MessageStream: Stream<Item = Vec<u8>, Error = io::Error> + 'static,
 {
     use std::cmp::Ordering;
-    let name = domain::Name::from_labels(vec!["WWW", "example", "com"]);
+    let name = domain::Name::from(&["WWW", "example", "com"] as &[_]);
 
     let response = client.query(&name, DNSClass::IN, RecordType::A);
     assert!(response.is_ok(), "query failed: {}", response.unwrap_err());
@@ -160,7 +160,7 @@ where
     CC: ClientConnection,
     <CC as ClientConnection>::MessageStream: Stream<Item = Vec<u8>, Error = io::Error> + 'static,
 {
-    let name = domain::Name::from_labels(vec!["www", "example", "com"]);
+    let name = domain::Name::from(&["www", "example", "com"] as &[_]);
     let response = client.secure_query(&name, DNSClass::IN, RecordType::A);
 
     assert!(
@@ -192,7 +192,7 @@ where
     CC: ClientConnection,
     <CC as ClientConnection>::MessageStream: Stream<Item = Vec<u8>, Error = io::Error> + 'static,
 {
-    let name = domain::Name::from_labels(vec!["WWW", "example", "com"]);
+    let name = domain::Name::from(&["WWW", "example", "com"] as &[_]);
 
     let response = client.query(&name, DNSClass::IN, RecordType::A);
     assert!(response.is_err());
@@ -309,7 +309,7 @@ where
     CC: ClientConnection,
     <CC as ClientConnection>::MessageStream: Stream<Item = Vec<u8>, Error = io::Error> + 'static,
 {
-    let name = domain::Name::from_labels(vec!["none", "example", "com"]);
+    let name = domain::Name::from(&["none", "example", "com"] as &[_]);
 
     let response = client.secure_query(&name, DNSClass::IN, RecordType::A);
     assert!(response.is_ok(), "query failed: {}", response.unwrap_err());
@@ -323,7 +323,7 @@ where
 #[ignore]
 #[allow(deprecated)]
 fn test_nsec_query_type() {
-    let name = domain::Name::from_labels(vec!["www", "example", "com"]);
+    let name = domain::Name::from(&["www", "example", "com"] as &[_]);
 
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
     let conn = TcpClientConnection::new(addr).unwrap();
@@ -346,7 +346,7 @@ fn test_nsec_query_type() {
 // fn test_nsec3_sdsmt() {
 //   let addr: SocketAddr = ("75.75.75.75",53).to_socket_addrs().unwrap().next().unwrap();
 //   let conn = TcpClientConnection::new(addr).unwrap();
-//   let name = domain::Name::from_labels(vec!["none", "sdsmt", "edu"]);
+//   let name = domain::Name::from(&["none", "sdsmt", "edu"] as &[_]);
 //   let client = Client::new(conn);
 //
 //   let response = client.secure_query(&name, DNSClass::IN, RecordType::NS);
@@ -363,7 +363,7 @@ fn test_nsec_query_type() {
 // fn test_nsec3_sdsmt_type() {
 //   let addr: SocketAddr = ("75.75.75.75",53).to_socket_addrs().unwrap().next().unwrap();
 //   let conn = TcpClientConnection::new(addr).unwrap();
-//   let name = domain::Name::from_labels(vec!["www", "sdsmt", "edu"]);
+//   let name = domain::Name::from(&["www", "sdsmt", "edu"] as &[_]);
 //   let client = Client::new(conn);
 //
 //   let response = client.secure_query(&name, DNSClass::IN, RecordType::NS);
@@ -387,7 +387,7 @@ fn create_sig0_ready_client(
     let signer = Signer::new(
         Algorithm::RSASHA256,
         key,
-        domain::Name::from_labels(vec!["trusted", "example", "com"]),
+        domain::Name::from(&["trusted", "example", "com"] as &[_]),
         Duration::max_value(),
         true,
         true,
@@ -395,7 +395,7 @@ fn create_sig0_ready_client(
 
     // insert the KEY for the trusted.example.com
     let mut auth_key = Record::with(
-        domain::Name::from_labels(vec!["trusted", "example", "com"]),
+        domain::Name::from(&["trusted", "example", "com"] as &[_]),
         RecordType::DNSSEC(DNSSECRecordType::KEY),
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -422,7 +422,7 @@ fn test_create() {
 
     // create a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -464,7 +464,7 @@ fn test_append() {
 
     // append a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -540,7 +540,7 @@ fn test_compare_and_swap() {
 
     // create a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -603,7 +603,7 @@ fn test_delete_by_rdata() {
 
     // append a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -655,7 +655,7 @@ fn test_delete_rrset() {
 
     // append a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );
@@ -700,7 +700,7 @@ fn test_delete_all() {
 
     // append a record
     let mut record = Record::with(
-        domain::Name::from_labels(vec!["new", "example", "com"]),
+        domain::Name::from(&["new", "example", "com"] as &[_]),
         RecordType::A,
         Duration::minutes(5).num_seconds() as u32,
     );

--- a/integration-tests/tests/secure_client_handle_tests.rs
+++ b/integration-tests/tests/secure_client_handle_tests.rs
@@ -44,7 +44,7 @@ fn test_secure_query_example<H>(mut client: SecureClientHandle<H>, mut io_loop: 
 where
     H: ClientHandle + 'static,
 {
-    let name = domain::Name::from_labels(vec!["www", "example", "com"]);
+    let name = domain::Name::from(&["www", "example", "com"] as &[_]);
     let response = io_loop
         .run(client.query(name.clone(), DNSClass::IN, RecordType::A))
         .expect("query failed");
@@ -86,7 +86,7 @@ fn test_nsec_query_example<H>(mut client: SecureClientHandle<H>, mut io_loop: Co
 where
     H: ClientHandle + 'static,
 {
-    let name = domain::Name::from_labels(vec!["none", "example", "com"]);
+    let name = domain::Name::from(&["none", "example", "com"] as &[_]);
 
     let response = io_loop
         .run(client.query(name.clone(), DNSClass::IN, RecordType::A))
@@ -116,7 +116,7 @@ fn test_nsec_query_type<H>(mut client: SecureClientHandle<H>, mut io_loop: Core)
 where
     H: ClientHandle + 'static,
 {
-    let name = domain::Name::from_labels(vec!["www", "example", "com"]);
+    let name = domain::Name::from(&["www", "example", "com"] as &[_]);
 
     let response = io_loop
         .run(client.query(name.clone(), DNSClass::IN, RecordType::NS))

--- a/integration-tests/tests/server_future_tests.rs
+++ b/integration-tests/tests/server_future_tests.rs
@@ -195,7 +195,7 @@ fn client_thread_www<C: ClientConnection>(conn: C)
 where
     C::MessageStream: Stream<Item = Vec<u8>, Error = io::Error> + 'static,
 {
-    let name = Name::from_labels(vec!["www", "example", "com"]);
+    let name = Name::from(&["www", "example", "com"] as &[_]);
     let client = SyncClient::new(conn);
 
     let response = client

--- a/proto/src/op/query.rs
+++ b/proto/src/op/query.rs
@@ -168,7 +168,7 @@ impl Display for Query {
 #[test]
 fn test_read_and_emit() {
     let expect = Query {
-        name: Name::from_labels(vec!["WWW", "example", "com"]),
+        name: Name::from(&["WWW", "example", "com"]),
         query_type: RecordType::AAAA,
         query_class: DNSClass::IN,
     };

--- a/proto/src/op/query.rs
+++ b/proto/src/op/query.rs
@@ -168,7 +168,7 @@ impl Display for Query {
 #[test]
 fn test_read_and_emit() {
     let expect = Query {
-        name: Name::from(&["WWW", "example", "com"]),
+        name: Name::from(&["WWW", "example", "com"] as &[_]),
         query_type: RecordType::AAAA,
         query_class: DNSClass::IN,
     };

--- a/proto/src/rr/dnssec/nsec3.rs
+++ b/proto/src/rr/dnssec/nsec3.rs
@@ -185,7 +185,7 @@ impl From<Nsec3HashAlgorithm> for u8 {
 #[test]
 #[cfg(any(feature = "openssl", feature = "ring"))]
 fn test_hash() {
-    let name = Name::from(vec!["www", "example", "com"]);
+    let name = Name::from(&["www", "example", "com"] as &[_]);
     let salt: Vec<u8> = vec![1, 2, 3, 4];
 
     assert_eq!(

--- a/proto/src/rr/dnssec/nsec3.rs
+++ b/proto/src/rr/dnssec/nsec3.rs
@@ -185,7 +185,7 @@ impl From<Nsec3HashAlgorithm> for u8 {
 #[test]
 #[cfg(any(feature = "openssl", feature = "ring"))]
 fn test_hash() {
-    let name = Name::from_labels(vec!["www", "example", "com"]);
+    let name = Name::from(vec!["www", "example", "com"]);
     let salt: Vec<u8> = vec![1, 2, 3, 4];
 
     assert_eq!(

--- a/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/proto/src/rr/dnssec/rdata/nsec.rs
@@ -148,7 +148,7 @@ pub fn test() {
     use rr::dnssec::rdata::DNSSECRecordType;
 
     let rdata = NSEC::new(
-        Name::from(vec!["www", "example", "com"]),
+        Name::from(&["www", "example", "com"] as &[_]),
         vec![
             RecordType::A,
             RecordType::AAAA,

--- a/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/proto/src/rr/dnssec/rdata/nsec.rs
@@ -148,7 +148,7 @@ pub fn test() {
     use rr::dnssec::rdata::DNSSECRecordType;
 
     let rdata = NSEC::new(
-        Name::from_labels(vec!["www", "example", "com"]),
+        Name::from(vec!["www", "example", "com"]),
         vec![
             RecordType::A,
             RecordType::AAAA,

--- a/proto/src/rr/dnssec/rdata/sig.rs
+++ b/proto/src/rr/dnssec/rdata/sig.rs
@@ -546,7 +546,7 @@ fn test() {
         2,
         1,
         5,
-        Name::from_labels(vec!["www", "example", "com"]),
+        Name::from(vec!["www", "example", "com"]),
         vec![
             0,
             1,

--- a/proto/src/rr/dnssec/rdata/sig.rs
+++ b/proto/src/rr/dnssec/rdata/sig.rs
@@ -546,7 +546,7 @@ fn test() {
         2,
         1,
         5,
-        Name::from(vec!["www", "example", "com"]),
+        Name::from(&["www", "example", "com"] as &[_]),
         vec![
             0,
             1,

--- a/proto/src/rr/dnssec/tbs.rs
+++ b/proto/src/rr/dnssec/tbs.rs
@@ -278,7 +278,7 @@ pub fn determine_name(name: &Name, num_labels: u8) -> Option<Name> {
     //                   name = "*." | the rightmost rrsig_label labels of the
     //                                 fqdn
     if num_labels < fqdn_labels {
-        let mut star_name: Name = Name::from_labels(vec!["*"]);
+        let mut star_name: Name = Name::from(vec!["*"]);
         let rightmost = name.trim_to(num_labels as usize);
         if !rightmost.is_root() {
             star_name = star_name.append_name(&rightmost);

--- a/proto/src/rr/dnssec/tbs.rs
+++ b/proto/src/rr/dnssec/tbs.rs
@@ -278,7 +278,7 @@ pub fn determine_name(name: &Name, num_labels: u8) -> Option<Name> {
     //                   name = "*." | the rightmost rrsig_label labels of the
     //                                 fqdn
     if num_labels < fqdn_labels {
-        let mut star_name: Name = Name::from(vec!["*"]);
+        let mut star_name: Name = Name::from(&["*"] as &[_]);
         let rightmost = name.trim_to(num_labels as usize);
         if !rightmost.is_root() {
             star_name = star_name.append_name(&rightmost);

--- a/proto/src/rr/domain.rs
+++ b/proto/src/rr/domain.rs
@@ -242,9 +242,9 @@ impl Name {
     /// use trust_dns_proto::rr::domain::Name;
     /// use std::cmp::Ordering;
     ///
-    /// let example_com = Name::from(&["Example", "Com"]);
-    /// assert_eq!(example_com.cmp_with_case(&Name::from(&["example", "com"]), false), Ordering::Less);
-    /// assert_eq!(example_com.to_lowercase().cmp_with_case(&Name::from(&["example", "com"]), false), Ordering::Equal);
+    /// let example_com = Name::from(&["Example", "Com"] as &[_]);
+    /// assert_eq!(example_com.cmp_with_case(&Name::from(&["example", "com"] as &[_]), false), Ordering::Less);
+    /// assert_eq!(example_com.to_lowercase().cmp_with_case(&Name::from(&["example", "com"] as &[_]), false), Ordering::Equal);
     /// ```
     pub fn to_lowercase(&self) -> Self {
         let mut new_labels = Vec::with_capacity(self.labels.len());
@@ -264,9 +264,9 @@ impl Name {
     /// ```
     /// use trust_dns_proto::rr::domain::Name;
     ///
-    /// let example_com = Name::from(&["example", "com"]);
-    /// assert_eq!(example_com.base_name(), Name::from(&["com"]));
-    /// assert_eq!(Name::from(&["com"]).base_name(), Name::root());
+    /// let example_com = Name::from(&["example", "com"] as &[_]);
+    /// assert_eq!(example_com.base_name(), Name::from(&["com"] as &[_]));
+    /// assert_eq!(Name::from(&["com"] as &[_]).base_name(), Name::root());
     /// assert_eq!(Name::root().base_name(), Name::root());
     /// ```
     pub fn base_name(&self) -> Name {
@@ -284,9 +284,9 @@ impl Name {
     /// ```
     /// use trust_dns_proto::rr::domain::Name;
     ///
-    /// let example_com = Name::from(&["example", "com"]);
-    /// assert_eq!(example_com.trim_to(2), Name::from(&["example", "com"]));
-    /// assert_eq!(example_com.trim_to(1), Name::from(&["com"]));
+    /// let example_com = Name::from(&["example", "com"] as &[_]);
+    /// assert_eq!(example_com.trim_to(2), Name::from(&["example", "com"] as &[_]));
+    /// assert_eq!(example_com.trim_to(1), Name::from(&["com"] as &[_]));
     /// assert_eq!(example_com.trim_to(0), Name::root());
     /// ```
     pub fn trim_to(&self, num_labels: usize) -> Name {
@@ -308,10 +308,10 @@ impl Name {
     /// ```rust
     /// use trust_dns_proto::rr::domain::Name;
     ///
-    /// let name = Name::from(&["www", "example", "com"]);
-    /// let name = Name::from(&["www", "example", "com"]);
-    /// let zone = Name::from(&["example", "com"]);
-    /// let another = Name::from(&["example", "net"]);
+    /// let name = Name::from(&["www", "example", "com"] as &[_]);
+    /// let name = Name::from(&["www", "example", "com"] as &[_]);
+    /// let zone = Name::from(&["example", "com"] as &[_]);
+    /// let another = Name::from(&["example", "net"] as &[_]);
     /// assert!(zone.zone_of(&name));
     /// assert!(!another.zone_of(&name));
     /// ```
@@ -351,10 +351,10 @@ impl Name {
     /// let root = Name::root();
     /// assert_eq!(root.num_labels(), 0);
     ///
-    /// let example_com = Name::from(&["example", "com"]);
+    /// let example_com = Name::from(&["example", "com"] as &[_]);
     /// assert_eq!(example_com.num_labels(), 2);
     ///
-    /// let star_example_com = Name::from(&["*", "example", "com"]);
+    /// let star_example_com = Name::from(&["*", "example", "com"] as &[_]);
     /// assert_eq!(star_example_com.num_labels(), 2);
     /// ```
     pub fn num_labels(&self) -> u8 {
@@ -394,7 +394,7 @@ impl Name {
     /// use trust_dns_proto::rr::domain::Name;
     ///
     /// let name = Name::parse("example.com.", None).unwrap();
-    /// assert_eq!(name.base_name(), Name::from(&["com"]));
+    /// assert_eq!(name.base_name(), Name::from(&["com"] as &[_]));
     /// assert_eq!(*name[0], String::from("example"));
     /// ```
     pub fn parse(local: &str, origin: Option<&Self>) -> ProtoResult<Self> {
@@ -866,13 +866,13 @@ mod tests {
     fn get_data() -> Vec<(Name, Vec<u8>)> {
         vec![
             (Name::new(), vec![0]),                           // base case, only the root
-            (Name::from(&["a"]), vec![1, b'a', 0]), // a single 'a' label
+            (Name::from(&["a"] as &[_]), vec![1, b'a', 0]), // a single 'a' label
             (
-                Name::from(&["a", "bc"]),
+                Name::from(&["a", "bc"] as &[_]),
                 vec![1, b'a', 2, b'b', b'c', 0],
             ), // two labels, 'a.bc'
             (
-                Name::from(&["a", "♥"]),
+                Name::from(&["a", "♥"] as &[_]),
                 vec![1, b'a', 3, 0xE2, 0x99, 0xA5, 0],
             ), // two labels utf8, 'a.♥'
         ]
@@ -880,12 +880,12 @@ mod tests {
 
     #[test]
     fn test_num_labels() {
-        assert_eq!(Name::from(&["*"]).num_labels(), 0);
-        assert_eq!(Name::from(&["a"]).num_labels(), 1);
-        assert_eq!(Name::from(&["*", "b"]).num_labels(), 1);
-        assert_eq!(Name::from(&["a", "b"]).num_labels(), 2);
-        assert_eq!(Name::from(&["*", "b", "c"]).num_labels(), 2);
-        assert_eq!(Name::from(&["a", "b", "c"]).num_labels(), 3);
+        assert_eq!(Name::from(&["*"] as &[_]).num_labels(), 0);
+        assert_eq!(Name::from(&["a"] as &[_]).num_labels(), 1);
+        assert_eq!(Name::from(&["*", "b"] as &[_]).num_labels(), 1);
+        assert_eq!(Name::from(&["a", "b"] as &[_]).num_labels(), 2);
+        assert_eq!(Name::from(&["*", "b", "c"] as &[_]).num_labels(), 2);
+        assert_eq!(Name::from(&["a", "b", "c"] as &[_]).num_labels(), 3);
     }
 
     #[test]
@@ -902,10 +902,10 @@ mod tests {
     fn test_pointer() {
         let mut bytes: Vec<u8> = Vec::with_capacity(512);
 
-        let first = Name::from(&["ra", "rb", "rc"]);
-        let second = Name::from(&["rb", "rc"]);
-        let third = Name::from(&["rc"]);
-        let fourth = Name::from(&["z", "ra", "rb", "rc"]);
+        let first = Name::from(&["ra", "rb", "rc"] as &[_]);
+        let second = Name::from(&["rb", "rc"] as &[_]);
+        let third = Name::from(&["rc"] as &[_]);
+        let fourth = Name::from(&["z", "ra", "rb", "rc"] as &[_]);
 
         {
             let mut e = BinEncoder::new(&mut bytes);
@@ -942,18 +942,18 @@ mod tests {
 
     #[test]
     fn test_base_name() {
-        let zone = Name::from(&["example", "com"]);
+        let zone = Name::from(&["example", "com"] as &[_]);
 
-        assert_eq!(zone.base_name(), Name::from(&["com"]));
+        assert_eq!(zone.base_name(), Name::from(&["com"] as &[_]));
         assert!(zone.base_name().base_name().is_root());
         assert!(zone.base_name().base_name().base_name().is_root());
     }
 
     #[test]
     fn test_zone_of() {
-        let zone = Name::from(&["example", "com"]);
-        let www = Name::from(&["www", "example", "com"]);
-        let none = Name::from(&["none", "com"]);
+        let zone = Name::from(&["example", "com"] as &[_]);
+        let www = Name::from(&["www", "example", "com"] as &[_]);
+        let none = Name::from(&["none", "com"] as &[_]);
         let root = Name::root();
 
         assert!(zone.zone_of(&zone));
@@ -965,9 +965,9 @@ mod tests {
 
     #[test]
     fn test_zone_of_case() {
-        let zone = Name::from(&["examplE", "cOm"]);
-        let www = Name::from(&["www", "example", "com"]);
-        let none = Name::from(&["none", "com"]);
+        let zone = Name::from(&["examplE", "cOm"] as &[_]);
+        let www = Name::from(&["www", "example", "com"] as &[_]);
+        let none = Name::from(&["none", "com"] as &[_]);
 
         assert!(zone.zone_of(&zone));
         assert!(zone.zone_of(&www));
@@ -1058,7 +1058,7 @@ mod tests {
     #[test]
     fn test_from_ipv4() {
         let ip = IpAddr::V4(Ipv4Addr::new(26, 3, 0, 103));
-        let name = Name::from(&["103", "0", "3", "26", "in-addr", "arpa"]);
+        let name = Name::from(&["103", "0", "3", "26", "in-addr", "arpa"] as &[_]);
 
         assert_eq!(Into::<Name>::into(ip), name);
     }
@@ -1101,7 +1101,7 @@ mod tests {
             "2",
             "ip6",
             "arpa",
-        ]);
+        ] as &[_]);
 
         assert_eq!(Into::<Name>::into(ip), name);
     }
@@ -1110,7 +1110,7 @@ mod tests {
     fn test_from_str() {
         assert_eq!(
             Name::from_str("www.example.com.").unwrap(),
-            Name::from(&["www", "example", "com"])
+            Name::from(&["www", "example", "com"] as &[_])
         );
         assert_eq!(
             Name::from_str(".").unwrap(),
@@ -1123,7 +1123,7 @@ mod tests {
         assert!(Name::root().is_fqdn());
         assert!(Name::from_str(".").unwrap().is_fqdn());
         assert!(Name::from_str("www.example.com.").unwrap().is_fqdn());
-        assert!(Name::from(&["www", "example", "com"]).is_fqdn());
+        assert!(Name::from(&["www", "example", "com"] as &[_]).is_fqdn());
 
         assert!(!Name::new().is_fqdn());
         assert!(!Name::from_str("www.example.com").unwrap().is_fqdn());

--- a/proto/src/rr/domain.rs
+++ b/proto/src/rr/domain.rs
@@ -24,9 +24,68 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::ops::Index;
 use std::str::FromStr;
 use std::sync::Arc as Rc;
+use std::borrow::Borrow;
 
 use serialize::binary::*;
 use error::*;
+
+/// Represent a label, used to build domain names.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Label(Rc<String>);
+
+impl fmt::Display for Label {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.0.as_ref().fmt(f)
+    }
+}
+
+impl Borrow<str> for Label {
+    fn borrow(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsRef<str> for Label {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl Borrow<String> for Label {
+    fn borrow(&self) -> &String {
+        self.0.as_ref()
+    }
+}
+
+impl Clone for Label {
+    fn clone(&self) -> Self {
+        Label(Rc::clone(&self.0))
+    }
+}
+
+impl<'a> From<&'a str> for Label {
+    fn from(s: &'a str) -> Self {
+        Label(Rc::new(s.into()))
+    }
+}
+
+impl<'a> From<&'a Label> for Label {
+    fn from(label: &'a Label) -> Self {
+        label.clone()
+    }
+}
+
+impl<'a> From<&'a String> for Label {
+    fn from(s: &'a String) -> Self {
+        Label(Rc::new(s.clone()))
+    }
+}
+
+impl From<String> for Label {
+    fn from(s: String) -> Self {
+        Label(Rc::new(s))
+    }
+}
 
 /// TODO: all Names should be stored in a global "intern" space, and then everything that uses
 ///  them should be through references. As a workaround the Strings are all Rc as well as the array
@@ -34,7 +93,7 @@ use error::*;
 #[derive(Default, Debug, Eq, Clone)]
 pub struct Name {
     is_fqdn: bool,
-    labels: Vec<Rc<String>>,
+    labels: Vec<Label>,
 }
 
 impl Name {
@@ -111,36 +170,10 @@ impl Name {
     /// let name = name.append_label("com");
     /// assert_eq!(name, Name::from_str("www.example.com").unwrap());
     /// ```
-    pub fn append_label<S: Into<String>>(mut self, label: S) -> Self {
-        self.labels.push(Rc::new(label.into()));
+    pub fn append_label<S: Into<Label>>(mut self, label: S) -> Self {
+        self.labels.push(label.into());
         assert!(self.labels.len() < 256); // TODO: should this be an Error?
         self
-    }
-
-    /// Creates a new Name from the specified labels
-    ///
-    /// # Arguments
-    ///
-    /// * `labels` - vector of items which will be stored as Strings.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use std::str::FromStr;
-    /// use trust_dns_proto::rr::domain::Name;
-    ///
-    /// let from_labels = Name::from_labels(vec!["www", "example", "com"]);
-    /// assert_eq!(from_labels, Name::from_str("www.example.com").unwrap());
-    ///
-    /// let root = Name::from_labels::<String>(vec![]);
-    /// assert!(root.is_root());
-    /// ```
-    pub fn from_labels<S: Into<String>>(labels: Vec<S>) -> Self {
-        assert!(labels.len() < 256); // this should be an error
-        Name {
-            is_fqdn: true,
-            labels: labels.into_iter().map(|s| Rc::new(s.into())).collect(),
-        }
     }
 
     /// Appends `other` to `self`, returning a new `Name`
@@ -171,7 +204,7 @@ impl Name {
     pub fn append_name(mut self, other: &Self) -> Self {
         self.labels.reserve_exact(other.labels.len());
         for label in &other.labels {
-            self.labels.push(Rc::clone(label));
+            self.labels.push(label.clone());
         }
 
         self.is_fqdn = other.is_fqdn;
@@ -209,17 +242,17 @@ impl Name {
     /// use trust_dns_proto::rr::domain::Name;
     /// use std::cmp::Ordering;
     ///
-    /// let example_com = Name::from_labels(vec!["Example", "Com"]);
-    /// assert_eq!(example_com.cmp_with_case(&Name::from_labels(vec!["example", "com"]), false), Ordering::Less);
-    /// assert_eq!(example_com.to_lowercase().cmp_with_case(&Name::from_labels(vec!["example", "com"]), false), Ordering::Equal);
+    /// let example_com = Name::from(&["Example", "Com"]);
+    /// assert_eq!(example_com.cmp_with_case(&Name::from(&["example", "com"]), false), Ordering::Less);
+    /// assert_eq!(example_com.to_lowercase().cmp_with_case(&Name::from(&["example", "com"]), false), Ordering::Equal);
     /// ```
     pub fn to_lowercase(&self) -> Self {
         let mut new_labels = Vec::with_capacity(self.labels.len());
         for label in &self.labels {
-            new_labels.push(label.to_lowercase());
+            new_labels.push(label.as_ref().to_lowercase().to_string());
         }
 
-        let mut this = Self::from_labels(new_labels);
+        let mut this: Self = Self::from(new_labels);
         this.is_fqdn = self.is_fqdn;
         this
     }
@@ -231,9 +264,9 @@ impl Name {
     /// ```
     /// use trust_dns_proto::rr::domain::Name;
     ///
-    /// let example_com = Name::from_labels(vec!["example", "com"]);
-    /// assert_eq!(example_com.base_name(), Name::from_labels(vec!["com"]));
-    /// assert_eq!(Name::from_labels(vec!["com"]).base_name(), Name::root());
+    /// let example_com = Name::from(&["example", "com"]);
+    /// assert_eq!(example_com.base_name(), Name::from(&["com"]));
+    /// assert_eq!(Name::from(&["com"]).base_name(), Name::root());
     /// assert_eq!(Name::root().base_name(), Name::root());
     /// ```
     pub fn base_name(&self) -> Name {
@@ -251,9 +284,9 @@ impl Name {
     /// ```
     /// use trust_dns_proto::rr::domain::Name;
     ///
-    /// let example_com = Name::from_labels(vec!["example", "com"]);
-    /// assert_eq!(example_com.trim_to(2), Name::from_labels(vec!["example", "com"]));
-    /// assert_eq!(example_com.trim_to(1), Name::from_labels(vec!["com"]));
+    /// let example_com = Name::from(&["example", "com"]);
+    /// assert_eq!(example_com.trim_to(2), Name::from(&["example", "com"]));
+    /// assert_eq!(example_com.trim_to(1), Name::from(&["com"]));
     /// assert_eq!(example_com.trim_to(0), Name::root());
     /// ```
     pub fn trim_to(&self, num_labels: usize) -> Name {
@@ -275,10 +308,10 @@ impl Name {
     /// ```rust
     /// use trust_dns_proto::rr::domain::Name;
     ///
-    /// let name = Name::from_labels(vec!["www", "example", "com"]);
-    /// let name = Name::from_labels(vec!["www", "example", "com"]);
-    /// let zone = Name::from_labels(vec!["example", "com"]);
-    /// let another = Name::from_labels(vec!["example", "net"]);
+    /// let name = Name::from(&["www", "example", "com"]);
+    /// let name = Name::from(&["www", "example", "com"]);
+    /// let zone = Name::from(&["example", "com"]);
+    /// let another = Name::from(&["example", "net"]);
     /// assert!(zone.zone_of(&name));
     /// assert!(!another.zone_of(&name));
     /// ```
@@ -318,10 +351,10 @@ impl Name {
     /// let root = Name::root();
     /// assert_eq!(root.num_labels(), 0);
     ///
-    /// let example_com = Name::from_labels(vec!["example", "com"]);
+    /// let example_com = Name::from(&["example", "com"]);
     /// assert_eq!(example_com.num_labels(), 2);
     ///
-    /// let star_example_com = Name::from_labels(vec!["*", "example", "com"]);
+    /// let star_example_com = Name::from(&["*", "example", "com"]);
     /// assert_eq!(star_example_com.num_labels(), 2);
     /// ```
     pub fn num_labels(&self) -> u8 {
@@ -344,7 +377,7 @@ impl Name {
         } else {
             1
         };
-        self.labels.iter().fold(dots, |acc, item| acc + item.len())
+        self.labels.iter().fold(dots, |acc, item| acc + item.as_ref().len())
     }
 
     /// Returns whether the length of the labels, in bytes is 0. In practive, since '.' counts as
@@ -361,7 +394,7 @@ impl Name {
     /// use trust_dns_proto::rr::domain::Name;
     ///
     /// let name = Name::parse("example.com.", None).unwrap();
-    /// assert_eq!(name.base_name(), Name::from_labels(vec!["com"]));
+    /// assert_eq!(name.base_name(), Name::from(&["com"]));
     /// assert_eq!(*name[0], String::from("example"));
     /// ```
     pub fn parse(local: &str, origin: Option<&Self>) -> ProtoResult<Self> {
@@ -381,7 +414,7 @@ impl Name {
             match state {
                 ParseState::Label => match ch {
                     '.' => {
-                        name.labels.push(Rc::new(label.clone()));
+                        name.labels.push(label.clone().into());
                         label.clear();
                     }
                     '\\' => state = ParseState::Escape1,
@@ -427,7 +460,7 @@ impl Name {
         }
 
         if !label.is_empty() {
-            name.labels.push(Rc::new(label));
+            name.labels.push(label.into());
         }
 
         if local.ends_with('.') {
@@ -446,11 +479,11 @@ impl Name {
         let buf_len = encoder.len(); // lazily assert the size is less than 255...
                                      // lookup the label in the BinEncoder
                                      // if it exists, write the Pointer
-        let mut labels: &[Rc<String>] = &self.labels;
+        let mut labels: &[Label] = &self.labels;
 
         if canonical {
             for label in labels {
-                encoder.emit_character_data(label)?;
+                encoder.emit_character_data(label.as_ref())?;
             }
         } else {
             while let Some(label) = labels.first() {
@@ -463,13 +496,13 @@ impl Name {
                     // we found a pointer don't write more, break
                     return Ok(());
                 } else {
-                    if label.len() > 63 {
-                        return Err(ProtoErrorKind::LabelBytesTooLong(label.len()).into());
+                    if label.as_ref().len() > 63 {
+                        return Err(ProtoErrorKind::LabelBytesTooLong(label.as_ref().len()).into());
                     }
 
                     // to_owned is cloning the the vector, but the Rc's at least don't clone the strings.
                     encoder.store_label_pointer(labels.to_owned());
-                    encoder.emit_character_data(label)?;
+                    encoder.emit_character_data(label.as_ref())?;
 
                     // return the next parts of the labels
                     //  this should be safe, the labels.first() wouldn't have let us here if there wasn't
@@ -519,12 +552,12 @@ impl Name {
 
         for (l, r) in self_labels.zip(other_labels) {
             if ignore_case {
-                match (*l).to_lowercase().cmp(&(*r).to_lowercase()) {
+                match l.as_ref().to_lowercase().cmp(&r.as_ref().to_lowercase()) {
                     o @ Ordering::Less | o @ Ordering::Greater => return o,
                     Ordering::Equal => continue,
                 }
             } else {
-                match l.cmp(r) {
+                match l.as_ref().cmp(r.as_ref()) {
                     o @ Ordering::Less | o @ Ordering::Greater => return o,
                     Ordering::Equal => continue,
                 }
@@ -541,6 +574,33 @@ impl Name {
     ///  qualified Name.
     pub fn to_string(&self) -> String {
         format!("{}", self)
+    }
+
+    /// Return the labels constituting the domain name as a slice.
+    pub fn as_slice(&self) -> &[Label] {
+        self.labels.as_slice()
+    }
+}
+
+impl<'a, L: AsRef<str>> From<&'a [L]> for Name {
+    fn from(labels: &'a [L]) -> Self {
+        assert!(labels.len() < 256); // this should be an error
+        Name {
+            is_fqdn: true,
+            labels: labels.into_iter().map(|s| s.as_ref().into()).collect(),
+        }
+    }
+}
+
+// This is a slightly more efficient implementation that From<L: AsRef<str>> because we don't need
+// to allocate for each String.
+impl From<Vec<String>> for Name {
+    fn from(vec: Vec<String>) -> Self {
+        assert!(vec.len() < 256); // this should be an error
+        Name {
+            is_fqdn: true,
+            labels: vec.into_iter().map(|s| Label::from(s)).collect(),
+        }
     }
 }
 
@@ -568,7 +628,7 @@ impl From<Ipv4Addr> for Name {
         labels.push("in-addr".to_string());
         labels.push("arpa".to_string());
 
-        Self::from_labels(labels)
+        Self::from(labels)
     }
 }
 
@@ -590,7 +650,7 @@ impl From<Ipv6Addr> for Name {
         labels.push("ip6".to_string());
         labels.push("arpa".to_string());
 
-        Self::from_labels(labels)
+        Self::from(labels)
     }
 }
 
@@ -601,7 +661,7 @@ impl Hash for Name {
         H: Hasher,
     {
         for label in &self.labels {
-            state.write(label.to_lowercase().as_bytes());
+            state.write(label.as_ref().to_lowercase().as_bytes());
         }
     }
 }
@@ -626,7 +686,7 @@ impl BinSerializable<Name> for Name {
     /// This will consume the portions of the Vec which it is reading...
     fn read(decoder: &mut BinDecoder) -> ProtoResult<Name> {
         let mut state: LabelParseState = LabelParseState::LabelLengthOrPointer;
-        let mut labels: Vec<Rc<String>> = Vec::with_capacity(3); // most labels will be around three, e.g. www.example.com
+        let mut labels: Vec<Label> = Vec::with_capacity(3); // most labels will be around three, e.g. www.example.com
 
         // assume all chars are utf-8. We're doing byte-by-byte operations, no endianess issues...
         // reserved: (1000 0000 aka 0800) && (0100 0000 aka 0400)
@@ -647,7 +707,7 @@ impl BinSerializable<Name> for Name {
                     }
                 }
                 LabelParseState::Label => {
-                    labels.push(Rc::new(decoder.read_character_data()?));
+                    labels.push(decoder.read_character_data()?.into());
 
                     // reset to collect more data
                     LabelParseState::LabelLengthOrPointer
@@ -679,7 +739,7 @@ impl BinSerializable<Name> for Name {
                     let pointed = Name::read(&mut pointer)?;
 
                     for l in &*pointed.labels {
-                        labels.push(Rc::clone(l));
+                        labels.push(l.clone());
                     }
 
                     // Pointers always finish the name, break like Root.
@@ -727,8 +787,8 @@ impl fmt::Display for Name {
 impl Index<usize> for Name {
     type Output = String;
 
-    fn index(&self, _index: usize) -> &String {
-        &*(self.labels[_index])
+    fn index(&self, index: usize) -> &String {
+        self.labels[index].borrow()
     }
 }
 
@@ -806,13 +866,13 @@ mod tests {
     fn get_data() -> Vec<(Name, Vec<u8>)> {
         vec![
             (Name::new(), vec![0]),                           // base case, only the root
-            (Name::from_labels(vec!["a"]), vec![1, b'a', 0]), // a single 'a' label
+            (Name::from(&["a"]), vec![1, b'a', 0]), // a single 'a' label
             (
-                Name::from_labels(vec!["a", "bc"]),
+                Name::from(&["a", "bc"]),
                 vec![1, b'a', 2, b'b', b'c', 0],
             ), // two labels, 'a.bc'
             (
-                Name::from_labels(vec!["a", "♥"]),
+                Name::from(&["a", "♥"]),
                 vec![1, b'a', 3, 0xE2, 0x99, 0xA5, 0],
             ), // two labels utf8, 'a.♥'
         ]
@@ -820,12 +880,12 @@ mod tests {
 
     #[test]
     fn test_num_labels() {
-        assert_eq!(Name::from_labels(vec!["*"]).num_labels(), 0);
-        assert_eq!(Name::from_labels(vec!["a"]).num_labels(), 1);
-        assert_eq!(Name::from_labels(vec!["*", "b"]).num_labels(), 1);
-        assert_eq!(Name::from_labels(vec!["a", "b"]).num_labels(), 2);
-        assert_eq!(Name::from_labels(vec!["*", "b", "c"]).num_labels(), 2);
-        assert_eq!(Name::from_labels(vec!["a", "b", "c"]).num_labels(), 3);
+        assert_eq!(Name::from(&["*"]).num_labels(), 0);
+        assert_eq!(Name::from(&["a"]).num_labels(), 1);
+        assert_eq!(Name::from(&["*", "b"]).num_labels(), 1);
+        assert_eq!(Name::from(&["a", "b"]).num_labels(), 2);
+        assert_eq!(Name::from(&["*", "b", "c"]).num_labels(), 2);
+        assert_eq!(Name::from(&["a", "b", "c"]).num_labels(), 3);
     }
 
     #[test]
@@ -842,10 +902,10 @@ mod tests {
     fn test_pointer() {
         let mut bytes: Vec<u8> = Vec::with_capacity(512);
 
-        let first = Name::from_labels(vec!["ra", "rb", "rc"]);
-        let second = Name::from_labels(vec!["rb", "rc"]);
-        let third = Name::from_labels(vec!["rc"]);
-        let fourth = Name::from_labels(vec!["z", "ra", "rb", "rc"]);
+        let first = Name::from(&["ra", "rb", "rc"]);
+        let second = Name::from(&["rb", "rc"]);
+        let third = Name::from(&["rc"]);
+        let fourth = Name::from(&["z", "ra", "rb", "rc"]);
 
         {
             let mut e = BinEncoder::new(&mut bytes);
@@ -882,18 +942,18 @@ mod tests {
 
     #[test]
     fn test_base_name() {
-        let zone = Name::from_labels(vec!["example", "com"]);
+        let zone = Name::from(&["example", "com"]);
 
-        assert_eq!(zone.base_name(), Name::from_labels(vec!["com"]));
+        assert_eq!(zone.base_name(), Name::from(&["com"]));
         assert!(zone.base_name().base_name().is_root());
         assert!(zone.base_name().base_name().base_name().is_root());
     }
 
     #[test]
     fn test_zone_of() {
-        let zone = Name::from_labels(vec!["example", "com"]);
-        let www = Name::from_labels(vec!["www", "example", "com"]);
-        let none = Name::from_labels(vec!["none", "com"]);
+        let zone = Name::from(&["example", "com"]);
+        let www = Name::from(&["www", "example", "com"]);
+        let none = Name::from(&["none", "com"]);
         let root = Name::root();
 
         assert!(zone.zone_of(&zone));
@@ -905,9 +965,9 @@ mod tests {
 
     #[test]
     fn test_zone_of_case() {
-        let zone = Name::from_labels(vec!["examplE", "cOm"]);
-        let www = Name::from_labels(vec!["www", "example", "com"]);
-        let none = Name::from_labels(vec!["none", "com"]);
+        let zone = Name::from(&["examplE", "cOm"]);
+        let www = Name::from(&["www", "example", "com"]);
+        let none = Name::from(&["none", "com"]);
 
         assert!(zone.zone_of(&zone));
         assert!(zone.zone_of(&www));
@@ -916,7 +976,7 @@ mod tests {
 
     #[test]
     fn test_partial_cmp_eq() {
-        let root = Some(Name::from_labels(Vec::<String>::new()));
+        let root = Some(Name::from(Vec::<String>::new()));
         let comparisons: Vec<(Name, Name)> = vec![
             (root.clone().unwrap(), root.clone().unwrap()),
             (
@@ -933,7 +993,7 @@ mod tests {
 
     #[test]
     fn test_partial_cmp() {
-        let root = Some(Name::from_labels(Vec::<String>::new()));
+        let root = Some(Name::from(Vec::<String>::new()));
         let comparisons: Vec<(Name, Name)> = vec![
             (
                 Name::parse("example", root.as_ref()).unwrap(),
@@ -977,7 +1037,7 @@ mod tests {
 
     #[test]
     fn test_cmp_ignore_case() {
-        let root = Some(Name::from_labels(Vec::<String>::new()));
+        let root = Some(Name::from(Vec::<String>::new()));
         let comparisons: Vec<(Name, Name)> = vec![
             (
                 Name::parse("ExAmPle", root.as_ref()).unwrap(),
@@ -998,7 +1058,7 @@ mod tests {
     #[test]
     fn test_from_ipv4() {
         let ip = IpAddr::V4(Ipv4Addr::new(26, 3, 0, 103));
-        let name = Name::from_labels(vec!["103", "0", "3", "26", "in-addr", "arpa"]);
+        let name = Name::from(&["103", "0", "3", "26", "in-addr", "arpa"]);
 
         assert_eq!(Into::<Name>::into(ip), name);
     }
@@ -1006,7 +1066,7 @@ mod tests {
     #[test]
     fn test_from_ipv6() {
         let ip = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x1));
-        let name = Name::from_labels(vec![
+        let name = Name::from(&[
             "1",
             "0",
             "0",
@@ -1050,11 +1110,11 @@ mod tests {
     fn test_from_str() {
         assert_eq!(
             Name::from_str("www.example.com.").unwrap(),
-            Name::from_labels(vec!["www", "example", "com"])
+            Name::from(&["www", "example", "com"])
         );
         assert_eq!(
             Name::from_str(".").unwrap(),
-            Name::from_labels(Vec::<String>::new())
+            Name::from(Vec::<String>::new())
         );
     }
 
@@ -1063,7 +1123,7 @@ mod tests {
         assert!(Name::root().is_fqdn());
         assert!(Name::from_str(".").unwrap().is_fqdn());
         assert!(Name::from_str("www.example.com.").unwrap().is_fqdn());
-        assert!(Name::from_labels(vec!["www", "example", "com"]).is_fqdn());
+        assert!(Name::from(&["www", "example", "com"]).is_fqdn());
 
         assert!(!Name::new().is_fqdn());
         assert!(!Name::from_str("www.example.com").unwrap().is_fqdn());

--- a/proto/src/rr/rdata/mx.rs
+++ b/proto/src/rr/rdata/mx.rs
@@ -114,7 +114,7 @@ pub fn emit(encoder: &mut BinEncoder, mx: &MX) -> ProtoResult<()> {
 
 #[test]
 pub fn test() {
-    let rdata = MX::new(16, Name::from_labels(vec!["mail", "example", "com"]));
+    let rdata = MX::new(16, Name::from(&["mail", "example", "com"]));
 
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);

--- a/proto/src/rr/rdata/mx.rs
+++ b/proto/src/rr/rdata/mx.rs
@@ -114,7 +114,7 @@ pub fn emit(encoder: &mut BinEncoder, mx: &MX) -> ProtoResult<()> {
 
 #[test]
 pub fn test() {
-    let rdata = MX::new(16, Name::from(&["mail", "example", "com"]));
+    let rdata = MX::new(16, Name::from(&["mail", "example", "com"] as &[_]));
 
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);

--- a/proto/src/rr/rdata/name.rs
+++ b/proto/src/rr/rdata/name.rs
@@ -74,7 +74,7 @@ pub fn emit(encoder: &mut BinEncoder, name_data: &Name) -> ProtoResult<()> {
 
 #[test]
 pub fn test() {
-    let rdata = Name::from(&["WWW", "example", "com"]);
+    let rdata = Name::from(&["WWW", "example", "com"] as &[_]);
 
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);

--- a/proto/src/rr/rdata/name.rs
+++ b/proto/src/rr/rdata/name.rs
@@ -74,7 +74,7 @@ pub fn emit(encoder: &mut BinEncoder, name_data: &Name) -> ProtoResult<()> {
 
 #[test]
 pub fn test() {
-    let rdata = Name::from_labels(vec!["WWW", "example", "com"]);
+    let rdata = Name::from(&["WWW", "example", "com"]);
 
     let mut bytes = Vec::new();
     let mut encoder: BinEncoder = BinEncoder::new(&mut bytes);

--- a/proto/src/rr/rdata/soa.rs
+++ b/proto/src/rr/rdata/soa.rs
@@ -256,8 +256,8 @@ pub fn emit(encoder: &mut BinEncoder, soa: &SOA) -> ProtoResult<()> {
 #[test]
 fn test() {
     let rdata = SOA::new(
-        Name::from_labels(vec!["m", "example", "com"]),
-        Name::from_labels(vec!["r", "example", "com"]),
+        Name::from(&["m", "example", "com"]),
+        Name::from(&["r", "example", "com"]),
         1,
         2,
         3,

--- a/proto/src/rr/rdata/soa.rs
+++ b/proto/src/rr/rdata/soa.rs
@@ -256,8 +256,8 @@ pub fn emit(encoder: &mut BinEncoder, soa: &SOA) -> ProtoResult<()> {
 #[test]
 fn test() {
     let rdata = SOA::new(
-        Name::from(&["m", "example", "com"]),
-        Name::from(&["r", "example", "com"]),
+        Name::from(&["m", "example", "com"] as &[_]),
+        Name::from(&["r", "example", "com"] as &[_]),
         1,
         2,
         3,

--- a/proto/src/rr/rdata/srv.rs
+++ b/proto/src/rr/rdata/srv.rs
@@ -237,7 +237,7 @@ fn test() {
         1,
         2,
         3,
-        Name::from(&["_dns_tcp", "example", "com"]),
+        Name::from(&["_dns_tcp", "example", "com"] as &[_]),
     );
 
     let mut bytes = Vec::new();

--- a/proto/src/rr/rdata/srv.rs
+++ b/proto/src/rr/rdata/srv.rs
@@ -237,7 +237,7 @@ fn test() {
         1,
         2,
         3,
-        Name::from_labels(vec!["_dns_tcp", "example", "com"]),
+        Name::from(&["_dns_tcp", "example", "com"]),
     );
 
     let mut bytes = Vec::new();

--- a/proto/src/rr/record_data.rs
+++ b/proto/src/rr/record_data.rs
@@ -613,7 +613,7 @@ mod tests {
     fn get_data() -> Vec<(RData, Vec<u8>)> {
         vec![
             (
-                RData::CNAME(Name::from(&["www", "example", "com"])),
+                RData::CNAME(Name::from(&["www", "example", "com"] as &[_])),
                 vec![
                     3,
                     b'w',
@@ -635,11 +635,11 @@ mod tests {
                 ],
             ),
             (
-                RData::MX(MX::new(256, Name::from(&["n"]))),
+                RData::MX(MX::new(256, Name::from(&["n"] as &[_]))),
                 vec![1, 0, 1, b'n', 0],
             ),
             (
-                RData::NS(Name::from(&["www", "example", "com"])),
+                RData::NS(Name::from(&["www", "example", "com"] as &[_])),
                 vec![
                     3,
                     b'w',
@@ -661,7 +661,7 @@ mod tests {
                 ],
             ),
             (
-                RData::PTR(Name::from(&["www", "example", "com"])),
+                RData::PTR(Name::from(&["www", "example", "com"] as &[_])),
                 vec![
                     3,
                     b'w',
@@ -684,8 +684,8 @@ mod tests {
             ),
             (
                 RData::SOA(SOA::new(
-                    Name::from(&["www", "example", "com"]),
-                    Name::from(&["xxx", "example", "com"]),
+                    Name::from(&["www", "example", "com"] as &[_]),
+                    Name::from(&["xxx", "example", "com"] as &[_]),
                     u32::max_value(),
                     -1 as i32,
                     -1 as i32,
@@ -775,7 +775,7 @@ mod tests {
                     1,
                     2,
                     3,
-                    Name::from(&["www", "example", "com"]),
+                    Name::from(&["www", "example", "com"] as &[_]),
                 )),
                 vec![
                     0x00,
@@ -816,15 +816,15 @@ mod tests {
                 1,
                 2,
                 3,
-                Name::from(&["www", "example", "com"]),
+                Name::from(&["www", "example", "com"] as &[_]),
             )),
-            RData::MX(MX::new(256, Name::from(&["n"]))),
-            RData::CNAME(Name::from(&["www", "example", "com"])),
-            RData::PTR(Name::from(&["www", "example", "com"])),
-            RData::NS(Name::from(&["www", "example", "com"])),
+            RData::MX(MX::new(256, Name::from(&["n"] as &[_]))),
+            RData::CNAME(Name::from(&["www", "example", "com"] as &[_])),
+            RData::PTR(Name::from(&["www", "example", "com"] as &[_])),
+            RData::NS(Name::from(&["www", "example", "com"] as &[_])),
             RData::SOA(SOA::new(
-                Name::from(&["www", "example", "com"]),
-                Name::from(&["xxx", "example", "com"]),
+                Name::from(&["www", "example", "com"] as &[_]),
+                Name::from(&["xxx", "example", "com"] as &[_]),
                 u32::max_value(),
                 -1 as i32,
                 -1 as i32,
@@ -839,13 +839,13 @@ mod tests {
             ])),
         ];
         let mut unordered = vec![
-            RData::CNAME(Name::from(&["www", "example", "com"])),
-            RData::MX(MX::new(256, Name::from(&["n"]))),
-            RData::PTR(Name::from(&["www", "example", "com"])),
-            RData::NS(Name::from(&["www", "example", "com"])),
+            RData::CNAME(Name::from(&["www", "example", "com"] as &[_])),
+            RData::MX(MX::new(256, Name::from(&["n"] as &[_]))),
+            RData::PTR(Name::from(&["www", "example", "com"] as &[_])),
+            RData::NS(Name::from(&["www", "example", "com"] as &[_])),
             RData::SOA(SOA::new(
-                Name::from(&["www", "example", "com"]),
-                Name::from(&["xxx", "example", "com"]),
+                Name::from(&["www", "example", "com"] as &[_]),
+                Name::from(&["xxx", "example", "com"] as &[_]),
                 u32::max_value(),
                 -1 as i32,
                 -1 as i32,
@@ -864,7 +864,7 @@ mod tests {
                 1,
                 2,
                 3,
-                Name::from(&["www", "example", "com"]),
+                Name::from(&["www", "example", "com"] as &[_]),
             )),
         ];
 

--- a/proto/src/rr/record_data.rs
+++ b/proto/src/rr/record_data.rs
@@ -613,7 +613,7 @@ mod tests {
     fn get_data() -> Vec<(RData, Vec<u8>)> {
         vec![
             (
-                RData::CNAME(Name::from_labels(vec!["www", "example", "com"])),
+                RData::CNAME(Name::from(&["www", "example", "com"])),
                 vec![
                     3,
                     b'w',
@@ -635,11 +635,11 @@ mod tests {
                 ],
             ),
             (
-                RData::MX(MX::new(256, Name::from_labels(vec!["n"]))),
+                RData::MX(MX::new(256, Name::from(&["n"]))),
                 vec![1, 0, 1, b'n', 0],
             ),
             (
-                RData::NS(Name::from_labels(vec!["www", "example", "com"])),
+                RData::NS(Name::from(&["www", "example", "com"])),
                 vec![
                     3,
                     b'w',
@@ -661,7 +661,7 @@ mod tests {
                 ],
             ),
             (
-                RData::PTR(Name::from_labels(vec!["www", "example", "com"])),
+                RData::PTR(Name::from(&["www", "example", "com"])),
                 vec![
                     3,
                     b'w',
@@ -684,8 +684,8 @@ mod tests {
             ),
             (
                 RData::SOA(SOA::new(
-                    Name::from_labels(vec!["www", "example", "com"]),
-                    Name::from_labels(vec!["xxx", "example", "com"]),
+                    Name::from(&["www", "example", "com"]),
+                    Name::from(&["xxx", "example", "com"]),
                     u32::max_value(),
                     -1 as i32,
                     -1 as i32,
@@ -775,7 +775,7 @@ mod tests {
                     1,
                     2,
                     3,
-                    Name::from_labels(vec!["www", "example", "com"]),
+                    Name::from(&["www", "example", "com"]),
                 )),
                 vec![
                     0x00,
@@ -816,15 +816,15 @@ mod tests {
                 1,
                 2,
                 3,
-                Name::from_labels(vec!["www", "example", "com"]),
+                Name::from(&["www", "example", "com"]),
             )),
-            RData::MX(MX::new(256, Name::from_labels(vec!["n"]))),
-            RData::CNAME(Name::from_labels(vec!["www", "example", "com"])),
-            RData::PTR(Name::from_labels(vec!["www", "example", "com"])),
-            RData::NS(Name::from_labels(vec!["www", "example", "com"])),
+            RData::MX(MX::new(256, Name::from(&["n"]))),
+            RData::CNAME(Name::from(&["www", "example", "com"])),
+            RData::PTR(Name::from(&["www", "example", "com"])),
+            RData::NS(Name::from(&["www", "example", "com"])),
             RData::SOA(SOA::new(
-                Name::from_labels(vec!["www", "example", "com"]),
-                Name::from_labels(vec!["xxx", "example", "com"]),
+                Name::from(&["www", "example", "com"]),
+                Name::from(&["xxx", "example", "com"]),
                 u32::max_value(),
                 -1 as i32,
                 -1 as i32,
@@ -839,13 +839,13 @@ mod tests {
             ])),
         ];
         let mut unordered = vec![
-            RData::CNAME(Name::from_labels(vec!["www", "example", "com"])),
-            RData::MX(MX::new(256, Name::from_labels(vec!["n"]))),
-            RData::PTR(Name::from_labels(vec!["www", "example", "com"])),
-            RData::NS(Name::from_labels(vec!["www", "example", "com"])),
+            RData::CNAME(Name::from(&["www", "example", "com"])),
+            RData::MX(MX::new(256, Name::from(&["n"]))),
+            RData::PTR(Name::from(&["www", "example", "com"])),
+            RData::NS(Name::from(&["www", "example", "com"])),
             RData::SOA(SOA::new(
-                Name::from_labels(vec!["www", "example", "com"]),
-                Name::from_labels(vec!["xxx", "example", "com"]),
+                Name::from(&["www", "example", "com"]),
+                Name::from(&["xxx", "example", "com"]),
                 u32::max_value(),
                 -1 as i32,
                 -1 as i32,
@@ -864,7 +864,7 @@ mod tests {
                 1,
                 2,
                 3,
-                Name::from_labels(vec!["www", "example", "com"]),
+                Name::from(&["www", "example", "com"]),
             )),
         ];
 

--- a/proto/src/serialize/binary/encoder.rs
+++ b/proto/src/serialize/binary/encoder.rs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
-use std::sync::Arc as Rc;
 use byteorder::{ByteOrder, NetworkEndian};
 
+use super::Label;
 use error::{ProtoErrorKind, ProtoResult};
 
 /// Encode DNS messages and resource record types.
@@ -25,7 +25,7 @@ pub struct BinEncoder<'a> {
     buffer: &'a mut Vec<u8>,
     // TODO, it would be cool to make this slices, but then the stored slice needs to live longer
     //  than the callee of store_pointer which isn't obvious right now.
-    name_pointers: HashMap<Vec<Rc<String>>, u16>, // array of string, label, location in stream
+    name_pointers: HashMap<Vec<Label>, u16>, // array of string, label, location in stream
     mode: EncodeMode,
     canonical_names: bool,
 }
@@ -118,14 +118,14 @@ impl<'a> BinEncoder<'a> {
     ///
     /// The location is the current position in the buffer
     ///  implicitly, it is expected that the name will be written to the stream after the current index.
-    pub fn store_label_pointer(&mut self, labels: Vec<Rc<String>>) {
+    pub fn store_label_pointer(&mut self, labels: Vec<Label>) {
         if self.offset < 0x3FFFusize {
             self.name_pointers.insert(labels, self.offset as u16); // the next char will be at the len() location
         }
     }
 
     /// Looks up the index of an already written label
-    pub fn get_label_pointer(&self, labels: &[Rc<String>]) -> Option<u16> {
+    pub fn get_label_pointer(&self, labels: &[Label]) -> Option<u16> {
         self.name_pointers.get(labels).cloned()
     }
 

--- a/proto/src/serialize/binary/mod.rs
+++ b/proto/src/serialize/binary/mod.rs
@@ -19,6 +19,8 @@
 mod decoder;
 mod encoder;
 
+use super::Label;
+
 pub use self::decoder::BinDecoder;
 pub use self::encoder::BinEncoder;
 pub use self::encoder::EncodeMode;

--- a/proto/src/serialize/mod.rs
+++ b/proto/src/serialize/mod.rs
@@ -17,3 +17,5 @@
 //! Contains serialization libraries for `binary` and text, `txt`.
 
 pub mod binary;
+
+use super::rr::domain::Label;

--- a/resolver/src/system_conf/mod.rs
+++ b/resolver/src/system_conf/mod.rs
@@ -145,11 +145,11 @@ mod tests {
         );
         assert_eq!(
             resolv_conf::parse_basic_option(&mut errors, "search localnet.").expect("failed"),
-            BasicOption::Search(vec![Name::from_labels(vec!["localnet"])])
+            BasicOption::Search(vec![Name::from(&["localnet"] as &[_])])
         );
         assert_eq!(
             resolv_conf::parse_basic_option(&mut errors, "domain example.com.").expect("failed"),
-            BasicOption::Domain(Name::from_labels(vec!["example", "com"]))
+            BasicOption::Domain(Name::from(&["example", "com"] as &[_]))
         );
     }
 
@@ -193,12 +193,12 @@ mod tests {
 
     //     assert_eq!(
     //         resolv_conf::parse_name(&mut errors, "com.").unwrap(),
-    //         Name::from_labels(vec!["com"])
+    //         Name::from(&["com"] as &[_])
     //     );
 
     //     assert_eq!(
     //         resolv_conf::parse_name(&mut errors, "example.com.").unwrap(),
-    //         Name::from_labels(vec!["example", "com"])
+    //         Name::from(&["example", "com"] as &[_])
     //     );
     // }
 
@@ -309,11 +309,11 @@ mod tests {
                 AdvancedOption::Attempts(8),
             ]),
             ConfigOption::Basic(BasicOption::Domain(
-                Name::from_labels(vec!["example", "com"]),
+                Name::from(&["example", "com"] as &[_]),
             )),
             ConfigOption::Basic(BasicOption::Search(vec![
-                Name::from_labels(vec!["example", "com"]),
-                Name::from_labels(vec!["sub", "example", "com"]),
+                Name::from(&["example", "com"] as &[_]),
+                Name::from(&["sub", "example", "com"] as &[_]),
             ])),
             ConfigOption::Basic(BasicOption::Nameserver(
                 IpAddr::from_str("2001:4860:4860::8888").unwrap(),
@@ -349,11 +349,11 @@ mod tests {
                 AdvancedOption::Attempts(8),
             ]),
             ConfigOption::Basic(BasicOption::Domain(
-                Name::from_labels(vec!["example", "com"]),
+                Name::from(&["example", "com"] as &[_]),
             )),
             ConfigOption::Basic(BasicOption::Search(vec![
-                Name::from_labels(vec!["example", "com"]),
-                Name::from_labels(vec!["sub", "example", "com"]),
+                Name::from(&["example", "com"] as &[_]),
+                Name::from(&["sub", "example", "com"] as &[_]),
             ])),
             ConfigOption::Basic(BasicOption::Nameserver(
                 IpAddr::from_str("2001:4860:4860::8888").unwrap(),

--- a/server/benches/comparison_benches.rs
+++ b/server/benches/comparison_benches.rs
@@ -135,7 +135,7 @@ fn trust_dns_process() -> (NamedProcess, u16) {
 
 /// Runs the bench tesk using the specified client
 fn bench(b: &mut Bencher, io_loop: &mut Core, client: &mut BasicClientHandle) {
-    let name = domain::Name::from_labels(vec!["www", "example", "com"]);
+    let name = domain::Name::from(&["www", "example", "com"] as &[_]);
 
     // validate the request
     let response = io_loop.run(client.query(name.clone(), DNSClass::IN, RecordType::A));

--- a/server/tests/persistence_tests.rs
+++ b/server/tests/persistence_tests.rs
@@ -34,7 +34,7 @@ fn test_init_journal() {
 }
 
 fn create_test_journal() -> (Record, Journal) {
-    let www = Name::from_labels(vec!["www", "example", "com"]);
+    let www = Name::from(&["www", "example", "com"] as &[_]);
 
     let mut record = Record::new();
     record.set_name(www);

--- a/server/tests/server_harness/mod.rs
+++ b/server/tests/server_harness/mod.rs
@@ -159,7 +159,7 @@ pub fn query_message<C: ClientHandle>(
 //  i.e. more complex checks live with the clients and authorities to validate deeper funcionality
 #[allow(dead_code)]
 pub fn query_a<C: ClientHandle>(io_loop: &mut Core, client: &mut C) {
-    let name = Name::from_labels(vec!["www", "example", "com"]);
+    let name = Name::from(&["www", "example", "com"] as &[_]);
     let response = query_message(io_loop, client, name, RecordType::A);
     let record = &response.answers()[0];
 

--- a/server/tests/txt_tests.rs
+++ b/server/tests/txt_tests.rs
@@ -64,7 +64,7 @@ _443._tcp.www.example.com. IN TLSA (
 ",
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_labels(vec!["isi", "edu"])));
+    let records = Parser::new().parse(lexer, Some(Name::from(&["isi", "edu"] as &[_])));
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
     }
@@ -77,13 +77,13 @@ _443._tcp.www.example.com. IN TLSA (
     // SOA
     let soa_record = authority.soa().unwrap().first().cloned().unwrap();
     assert_eq!(RecordType::SOA, soa_record.rr_type());
-    assert_eq!(&Name::from_labels(vec!["isi", "edu"]), soa_record.name()); // i.e. the origin or domain
+    assert_eq!(&Name::from(&["isi", "edu"] as &[_]), soa_record.name()); // i.e. the origin or domain
     assert_eq!(3_600_000, soa_record.ttl());
     assert_eq!(DNSClass::IN, soa_record.dns_class());
     if let RData::SOA(ref soa) = *soa_record.rdata() {
         // this should all be lowercased
         assert_eq!(
-            &Name::from_labels(vec!["venera", "isi", "edu"]),
+            &Name::from(&["venera", "isi", "edu"] as &[_]),
             soa.mname()
         );
         assert_eq!(
@@ -102,7 +102,7 @@ _443._tcp.www.example.com. IN TLSA (
     // NS
     let mut ns_records: Vec<&Record> = authority
         .lookup(
-            &Name::from_labels(vec!["isi", "edu"]),
+            &Name::from(&["isi", "edu"] as &[_]),
             RecordType::NS,
             false,
             SupportedAlgorithms::new(),
@@ -110,9 +110,9 @@ _443._tcp.www.example.com. IN TLSA (
         .unwrap();
     let mut compare = vec![
         // this is cool, zip up the expected results... works as long as the order is good.
-        Name::from_labels(vec!["a", "isi", "edu"]),
-        Name::from_labels(vec!["venera", "isi", "edu"]),
-        Name::from_labels(vec!["vaxa", "isi", "edu"]),
+        Name::from(&["a", "isi", "edu"] as &[_]),
+        Name::from(&["venera", "isi", "edu"] as &[_]),
+        Name::from(&["vaxa", "isi", "edu"] as &[_]),
     ];
 
     compare.sort();
@@ -120,7 +120,7 @@ _443._tcp.www.example.com. IN TLSA (
     let compare = ns_records.iter().zip(compare);
 
     for (record, ref name) in compare {
-        assert_eq!(&Name::from_labels(vec!["isi", "edu"]), record.name());
+        assert_eq!(&Name::from(&["isi", "edu"] as &[_]), record.name());
         assert_eq!(60, record.ttl()); // TODO: should this be minimum or expire?
         assert_eq!(DNSClass::IN, record.dns_class());
         assert_eq!(RecordType::NS, record.rr_type());
@@ -134,15 +134,15 @@ _443._tcp.www.example.com. IN TLSA (
     // MX
     let mut mx_records: Vec<&Record> = authority
         .lookup(
-            &Name::from_labels(vec!["isi", "edu"]),
+            &Name::from(&["isi", "edu"] as &[_]),
             RecordType::MX,
             false,
             SupportedAlgorithms::new(),
         )
         .unwrap();
     let mut compare = vec![
-        (10, Name::from_labels(vec!["venera", "isi", "edu"])),
-        (20, Name::from_labels(vec!["vaxa", "isi", "edu"])),
+        (10, Name::from(&["venera", "isi", "edu"] as &[_])),
+        (20, Name::from(&["vaxa", "isi", "edu"] as &[_])),
     ];
 
     compare.sort();
@@ -151,7 +151,7 @@ _443._tcp.www.example.com. IN TLSA (
 
 
     for (record, (num, ref name)) in compare {
-        assert_eq!(&Name::from_labels(vec!["isi", "edu"]), record.name());
+        assert_eq!(&Name::from(&["isi", "edu"] as &[_]), record.name());
         assert_eq!(60, record.ttl()); // TODO: should this be minimum or expire?
         assert_eq!(DNSClass::IN, record.dns_class());
         assert_eq!(RecordType::MX, record.rr_type());
@@ -166,7 +166,7 @@ _443._tcp.www.example.com. IN TLSA (
     // A
     let a_record: &Record = authority
         .lookup(
-            &Name::from_labels(vec!["a", "isi", "edu"]),
+            &Name::from(&["a", "isi", "edu"] as &[_]),
             RecordType::A,
             false,
             SupportedAlgorithms::new(),
@@ -175,7 +175,7 @@ _443._tcp.www.example.com. IN TLSA (
         .first()
         .cloned()
         .unwrap();
-    assert_eq!(&Name::from_labels(vec!["a", "isi", "edu"]), a_record.name());
+    assert_eq!(&Name::from(&["a", "isi", "edu"] as &[_]), a_record.name());
     assert_eq!(60, a_record.ttl()); // TODO: should this be minimum or expire?
     assert_eq!(DNSClass::IN, a_record.dns_class());
     assert_eq!(RecordType::A, a_record.rr_type());
@@ -188,7 +188,7 @@ _443._tcp.www.example.com. IN TLSA (
     // AAAA
     let aaaa_record: &Record = authority
         .lookup(
-            &Name::from_labels(vec!["aaaa", "isi", "edu"]),
+            &Name::from(&["aaaa", "isi", "edu"] as &[_]),
             RecordType::AAAA,
             false,
             SupportedAlgorithms::new(),
@@ -198,7 +198,7 @@ _443._tcp.www.example.com. IN TLSA (
         .cloned()
         .unwrap();
     assert_eq!(
-        &Name::from_labels(vec!["aaaa", "isi", "edu"]),
+        &Name::from(&["aaaa", "isi", "edu"] as &[_]),
         aaaa_record.name()
     );
     if let RData::AAAA(ref address) = *aaaa_record.rdata() {
@@ -213,7 +213,7 @@ _443._tcp.www.example.com. IN TLSA (
     // SHORT
     let short_record: &Record = authority
         .lookup(
-            &Name::from_labels(vec!["short", "isi", "edu"]),
+            &Name::from(&["short", "isi", "edu"] as &[_]),
             RecordType::A,
             false,
             SupportedAlgorithms::new(),
@@ -223,7 +223,7 @@ _443._tcp.www.example.com. IN TLSA (
         .cloned()
         .unwrap();
     assert_eq!(
-        &Name::from_labels(vec!["short", "isi", "edu"]),
+        &Name::from(&["short", "isi", "edu"] as &[_]),
         short_record.name()
     );
     assert_eq!(70, short_record.ttl());
@@ -236,7 +236,7 @@ _443._tcp.www.example.com. IN TLSA (
     // TXT
     let mut txt_records: Vec<&Record> = authority
         .lookup(
-            &Name::from_labels(vec!["a", "isi", "edu"]),
+            &Name::from(&["a", "isi", "edu"] as &[_]),
             RecordType::TXT,
             false,
             SupportedAlgorithms::new(),
@@ -290,7 +290,7 @@ _443._tcp.www.example.com. IN TLSA (
         .cloned()
         .unwrap();
     if let RData::PTR(ref ptrdname) = *ptr_record.rdata() {
-        assert_eq!(&Name::from_labels(vec!["a", "isi", "edu"]), ptrdname);
+        assert_eq!(&Name::from(&["a", "isi", "edu"] as &[_]), ptrdname);
     } else {
         panic!("Not a PTR record!!!") // valid panic, test code
     }
@@ -298,7 +298,7 @@ _443._tcp.www.example.com. IN TLSA (
     // SRV
     let srv_record: &Record = authority
         .lookup(
-            &Name::from_labels(vec!["_ldap", "_tcp", "service", "isi", "edu"]),
+            &Name::from(&["_ldap", "_tcp", "service", "isi", "edu"] as &[_]),
             RecordType::SRV,
             false,
             SupportedAlgorithms::new(),
@@ -313,7 +313,7 @@ _443._tcp.www.example.com. IN TLSA (
         assert_eq!(rdata.port(), 3);
         assert_eq!(
             rdata.target(),
-            &Name::from_labels(vec!["short", "isi", "edu"])
+            &Name::from(&["short", "isi", "edu"] as &[_])
         );
     } else {
         panic!("Not an SRV record!!!") // valid panic, test code


### PR DESCRIPTION
I was looking again at https://github.com/bluejekyll/trust-dns/pull/305, and realized that I wanted to take a slice of Name. I started adding `Name.as_slice()`, but then thought it was not very nice to have to manipulate `Rc<String>`, so I decided to add a `Label` type.


4ac7e37 is a bit unfortunate, but in theory, we could get rif of it later.