### PR TITLE
Support `from_system_conf` on windows 32-bit targets

### DIFF
--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -37,7 +37,6 @@ appveyor = { repository = "bluejekyll/trust-dns", branch = "master", service = "
 codecov = { repository = "bluejekyll/trust-dns", branch = "master", service = "github" }
 
 [features]
-default = ["ipconfig"]
 dnssec-openssl = ["dnssec", "trust-dns-proto/dnssec-openssl"]
 dnssec-ring = ["dnssec", "trust-dns-proto/dnssec-ring"]
 dnssec = []
@@ -59,5 +58,5 @@ regex = "0.2.1"
 tokio-core = "^0.1"
 trust-dns-proto = { version = "^0.2", path = "../proto" }
 
-[target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
-ipconfig = { version = "^0.1.1", optional = true }
+[target.'cfg(windows)'.dependencies]
+ipconfig = { version = "^0.1.4" }

--- a/resolver/src/lib.rs
+++ b/resolver/src/lib.rs
@@ -128,7 +128,7 @@
 #[macro_use]
 extern crate error_chain;
 extern crate futures;
-#[cfg(all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64"))]
+#[cfg(target_os = "windows")]
 extern crate ipconfig;
 extern crate lalrpop_util;
 #[macro_use]

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -95,8 +95,7 @@ impl Resolver {
     /// Constructs a new Resolver with the system configuration.
     ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
-    #[cfg(any(unix,
-              all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64")))]
+    #[cfg(any(unix, target_os = "windows"))]
     pub fn from_system_conf() -> io::Result<Self> {
         let (config, options) = super::system_conf::read_system_conf()?;
         Self::new(config, options)
@@ -216,8 +215,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    #[cfg(any(unix,
-              all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64")))]
+    #[cfg(any(unix, target_os = "windows"))]
     fn test_system_lookup() {
         let resolver = Resolver::from_system_conf().unwrap();
 

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -166,8 +166,7 @@ impl ResolverFuture {
     /// Constructs a new Resolver with the system configuration.
     ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
-    #[cfg(any(unix,
-              all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64")))]
+    #[cfg(any(unix, target_os = "windows"))]
     pub fn from_system_conf(reactor: &Handle) -> ResolveResult<Self> {
         let (config, options) = super::system_conf::read_system_conf()?;
         Ok(Self::new(config, options, reactor))
@@ -458,8 +457,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    #[cfg(any(unix,
-              all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64")))]
+    #[cfg(any(unix, target_os = "windows"))]
     fn test_system_lookup() {
         let mut io_loop = Core::new().unwrap();
         let resolver = ResolverFuture::from_system_conf(&io_loop.handle()).unwrap();

--- a/resolver/src/system_conf/mod.rs
+++ b/resolver/src/system_conf/mod.rs
@@ -15,7 +15,7 @@
 /// resolv.conf parser
 // TODO: make crate only...
 mod resolv_conf_ast;
-#[cfg(all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64"))]
+#[cfg(target_os = "windows")]
 mod windows;
 
 use std::fs::File;
@@ -40,8 +40,7 @@ pub(crate) fn read_system_conf() -> io::Result<(ResolverConfig, ResolverOpts)> {
     read_resolv_conf("/etc/resolv.conf")
 }
 
-/// Support only 64-bit until https://github.com/liranringel/ipconfig/issues/1 is resolved.
-#[cfg(all(feature = "ipconfig", target_os = "windows", target_pointer_width = "64"))]
+#[cfg(target_os = "windows")]
 pub(crate) use self::windows::read_system_conf;
 
 pub fn read_resolv_conf<P: AsRef<Path>>(path: P) -> io::Result<(ResolverConfig, ResolverOpts)> {


### PR DESCRIPTION
The `ipconfig` crate supports 32-bit, so I removed the restriction of 64-bit.
Also removed the `ipconfig` feature, as discussed here: https://github.com/bluejekyll/trust-dns/pull/269