### PR TITLE
Add RecordType::ZERO && RData::ZERO fixing SIG(0)

### DIFF
--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -541,7 +541,7 @@ impl MessageFinalizer for Signer {
         sig0.set_rr_type(RecordType::DNSSEC(DNSSECRecordType::SIG));
         let pre_sig0 = SIG::new(
             // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
-            RecordType::NULL,
+            RecordType::ZERO,
             self.algorithm(),
             num_labels,
             // see above, original_ttl is meaningless, The TTL fields SHOULD be zero
@@ -598,7 +598,7 @@ mod tests {
     fn pre_sig0(signer: &Signer, inception_time: u32, expiration_time: u32) -> SIG {
         SIG::new(
             // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
-            RecordType::NULL,
+            RecordType::ZERO,
             signer.algorithm(),
             0,
             // see above, original_ttl is meaningless, The TTL fields SHOULD be zero

--- a/client/src/serialize/txt/parse_rdata.rs
+++ b/client/src/serialize/txt/parse_rdata.rs
@@ -82,6 +82,7 @@ impl RDataParser for RData {
                 // TODO: add a way to associate generic record types to the zone
                 panic!("Unknown record type, if you want to support this type, please file an issue against TRust-DNS: {}", code)
             }
+            RecordType::ZERO => RData::ZERO,
         };
 
         Ok(rdata)

--- a/proto/src/rr/record_data.rs
+++ b/proto/src/rr/record_data.rs
@@ -392,6 +392,9 @@ pub enum RData {
         /// RData associated to the record
         rdata: NULL,
     },
+
+    /// This corresponds to a record type of 0, unspecified
+    ZERO,
 }
 
 impl RData {
@@ -434,6 +437,10 @@ impl RData {
             RecordType::CNAME => {
                 debug!("reading CNAME");
                 rdata::name::read(decoder).map(RData::CNAME)
+            }
+            RecordType::ZERO => {
+                debug!("reading EMPTY");
+                return Ok(RData::ZERO)
             }
             RecordType::MX => {
                 debug!("reading MX");
@@ -517,6 +524,7 @@ impl RData {
             RData::CNAME(ref name) | RData::NS(ref name) | RData::PTR(ref name) => {
                 rdata::name::emit(encoder, name)
             }
+            RData::ZERO => Ok(()),
             // to_lowercase for rfc4034 and rfc6840
             RData::MX(ref mx) => rdata::mx::emit(encoder, mx),
             RData::NULL(ref null) => rdata::null::emit(encoder, null),
@@ -552,6 +560,7 @@ impl RData {
             #[cfg(feature = "dnssec")]
             RData::DNSSEC(ref rdata) => RecordType::DNSSEC(DNSSECRData::to_record_type(rdata)),
             RData::Unknown { code, .. } => RecordType::Unknown(code),
+            RData::ZERO => RecordType::ZERO,
         }
     }
 
@@ -907,6 +916,7 @@ mod tests {
             #[cfg(feature = "dnssec")]
             RData::DNSSEC(ref rdata) => RecordType::DNSSEC(rdata.to_record_type()),
             RData::Unknown { code, .. } => RecordType::Unknown(code),
+            RData::ZERO => RecordType::ZERO,        
         }
     }
 

--- a/proto/src/rr/record_type.rs
+++ b/proto/src/rr/record_type.rs
@@ -91,6 +91,9 @@ pub enum RecordType {
 
     /// Unknown Record type, or unsupported
     Unknown(u16),
+
+    /// This corresponds to a record type of 0, unspecified
+    ZERO,
 }
 
 impl RecordType {
@@ -163,6 +166,7 @@ impl From<u16> for RecordType {
             252 => RecordType::AXFR,
             257 => RecordType::CAA,
             5 => RecordType::CNAME,
+            0 => RecordType::ZERO,
             15 => RecordType::MX,
             2 => RecordType::NS,
             10 => RecordType::NULL,
@@ -224,6 +228,7 @@ impl From<RecordType> for &'static str {
             RecordType::AXFR => "AXFR",
             RecordType::CAA => "CAA",
             RecordType::CNAME => "CNAME",
+            RecordType::ZERO => "",
             RecordType::IXFR => "IXFR",
             RecordType::MX => "MX",
             RecordType::NULL => "NULL",
@@ -259,6 +264,7 @@ impl From<RecordType> for u16 {
             RecordType::AXFR => 252,
             RecordType::CAA => 257,
             RecordType::CNAME => 5,
+            RecordType::ZERO => 0,
             RecordType::IXFR => 251,
             RecordType::MX => 15,
             RecordType::NS => 2,


### PR DESCRIPTION
After merging #329 it was noticed that `SIG(0)` compatibility tests started failing. This was due to the `SIG(0)` signing process relying on the `RecordType` being set to `0`. After changing `NULL` to it's correct type of `10`, this exposed an erroneous usage of `NULL` for `0`. There is now an explicit `ZERO` type to compliment the `NULL` type. The `ZERO` type will always be `0`, it will serialize no bytes (or deserialize), i.e. the RData length is `0`.