### PR TITLE
Make read_system_conf() function public

### DIFF
--- a/resolver/src/system_conf/mod.rs
+++ b/resolver/src/system_conf/mod.rs
@@ -16,10 +16,10 @@
 mod unix;
 
 #[cfg(unix)]
-pub(crate) use self::unix::read_system_conf;
+pub use self::unix::read_system_conf;
 
 #[cfg(windows)]
 mod windows;
 
 #[cfg(target_os = "windows")]
-pub(crate) use self::windows::read_system_conf;
+pub use self::windows::read_system_conf;

--- a/resolver/src/system_conf/unix.rs
+++ b/resolver/src/system_conf/unix.rs
@@ -26,7 +26,7 @@ use config::*;
 
 const DEFAULT_PORT: u16 = 53;
 
-pub(crate) fn read_system_conf() -> io::Result<(ResolverConfig, ResolverOpts)> {
+pub fn read_system_conf() -> io::Result<(ResolverConfig, ResolverOpts)> {
     Ok(read_resolv_conf("/etc/resolv.conf")?)
 }
 

--- a/resolver/src/system_conf/windows.rs
+++ b/resolver/src/system_conf/windows.rs
@@ -48,7 +48,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
     Ok(name_servers)
 }
 
-pub(crate) fn read_system_conf() -> ResolveResult<(ResolverConfig, ResolverOpts)> {
+pub fn read_system_conf() -> ResolveResult<(ResolverConfig, ResolverOpts)> {
     let name_servers = get_name_servers()?;
 
     let search_list: Vec<Name> = map_ipconfig_error!(get_search_list())?


### PR DESCRIPTION
There are cases where it's useful to get configured DNS servers from running system. For example I'm using trust-dns DNS client with host's configured DNS servers from `/etc/resolv.conf`. Making this function public scratches that itch.

Before merging #335 the function `read_resolv_conf()` was public, but it has no equivalent on Windows side.  `read_system_conf()` is available on all platforms.