### PR TITLE
Migrate to use tokio-timer directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,7 @@ dependencies = [
  "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "socket2 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns 0.13.0",
  "trust-dns-openssl 0.2.0",
  "trust-dns-proto 0.3.2",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -38,8 +38,8 @@ name = "trust_dns_integration"
 path = "src/lib.rs"
 
 [features]
-dnssec-openssl = ["dnssec", 
-                  "trust-dns-resolver/dnssec-openssl", 
+dnssec-openssl = ["dnssec",
+                  "trust-dns-resolver/dnssec-openssl",
                   "trust-dns-server/dnssec-openssl",
                   "trust-dns/dnssec-openssl",
                   "trust-dns-proto/dnssec-openssl"]
@@ -70,6 +70,7 @@ rand = "^0.4"
 rusqlite = { version = "^0.13.0", features = ["bundled"] }
 rustls = { version = "^0.11.0" }
 tokio-core = "^0.1"
+tokio-timer = "^0.2"
 trust-dns = { version = "*", path = "../client" }
 trust-dns-openssl = { version = "*", path = "../openssl" }
 trust-dns-proto = { version = "*", path = "../proto" }

--- a/integration-tests/tests/client_future_tests.rs
+++ b/integration-tests/tests/client_future_tests.rs
@@ -806,7 +806,7 @@ fn test_timeout_query(mut client: BasicClientHandle, mut io_loop: Core) {
 #[test]
 fn test_timeout_query_nonet() {
     let io_loop = Core::new().unwrap();
-    let (stream, sender) = NeverReturnsClientStream::new(&io_loop.handle());
+    let (stream, sender) = NeverReturnsClientStream::new();
     let client = ClientFuture::with_timeout(
         stream,
         Box::new(sender),

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -64,6 +64,7 @@ smallvec = "^0.6"
 socket2 = { version = "^0.3.4", features = ["reuseport"] }
 tokio-core = "^0.1"
 tokio-io = "^0.1"
+tokio-timer = "^0.2"
 untrusted = { version = "^0.5", optional = true }
 url = "1.6.0"
 

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -21,6 +21,8 @@ use ring::error::Unspecified;
 #[cfg(not(feature = "ring"))]
 use self::not_ring::Unspecified;
 
+use tokio_timer::Error as TimerError;
+
 error_chain! {
     // The type defined for this error. These are the conventional
     // and recommended names, but they can be arbitrarily chosen.
@@ -56,6 +58,7 @@ error_chain! {
       SslErrorStack, SSL, "ssl error";
       Unspecified, Ring, "ring error";
       ::url::ParseError, UrlParsingError, "url parsing error";
+      TimerError, Timer, "timer error";
     }
 
     // Define additional `ErrorKind` variants. The syntax here is
@@ -265,6 +268,7 @@ impl Clone for ProtoErrorKind {
             ProtoErrorKind::MaxBufferSizeExceeded(ref max) => {
                 ProtoErrorKind::MaxBufferSizeExceeded(*max)
             }
+            ProtoErrorKind::Timer => ProtoErrorKind:: Timer,
         }
     }
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -35,6 +35,7 @@ extern crate socket2;
 #[macro_use]
 extern crate tokio_core;
 extern crate tokio_io;
+extern crate tokio_timer;
 #[cfg(feature = "ring")]
 extern crate untrusted;
 extern crate url;

--- a/proto/src/multicast/mdns_stream.rs
+++ b/proto/src/multicast/mdns_stream.rs
@@ -468,8 +468,9 @@ pub mod tests {
     //   as there are probably unexpected responses coming on the standard addresses
     fn one_shot_mdns_test(mdns_addr: SocketAddr) {
         use std;
-        use std::time::Duration;
-        use tokio_core::reactor::{Core, Timeout};
+        use std::time::{Duration, Instant};
+        use tokio_core::reactor::Core;
+        use tokio_timer::Delay;
 
         let client_done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
@@ -483,8 +484,7 @@ pub mod tests {
             .spawn(move || {
                 let mut server_loop = Core::new().unwrap();
                 let loop_handle = server_loop.handle();
-                let mut timeout = Timeout::new(Duration::from_millis(100), &loop_handle)
-                    .expect("failed to register timeout");
+                let mut timeout = Delay::new(Instant::now() + Duration::from_millis(100));
 
                 // TTLs are 0 so that multicast test packets never leave the test host...
                 // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
@@ -530,8 +530,7 @@ pub mod tests {
                         }
                         Either::B(((), buffer_and_addr_stream_tmp)) => {
                             server_stream = buffer_and_addr_stream_tmp;
-                            timeout = Timeout::new(Duration::from_millis(100), &loop_handle)
-                                .expect("failed to register timeout");
+                            timeout = Delay::new(Instant::now() + Duration::from_millis(100));
                         }
                     }
 
@@ -554,8 +553,7 @@ pub mod tests {
             &loop_handle,
         );
         let mut stream = io_loop.run(stream).ok().unwrap().into_future();
-        let mut timeout = Timeout::new(Duration::from_millis(100), &io_loop.handle())
-            .expect("failed to register timeout");
+        let mut timeout = Delay::new(Instant::now() + Duration::from_millis(100));
         let mut successes = 0;
 
         for _ in 0..send_recv_times {
@@ -592,8 +590,7 @@ pub mod tests {
                 }
                 Either::B(((), buffer_and_addr_stream_tmp)) => {
                     stream = buffer_and_addr_stream_tmp;
-                    timeout = Timeout::new(Duration::from_millis(100), &loop_handle)
-                        .expect("failed to register timeout");
+                    timeout = Delay::new(Instant::now() + Duration::from_millis(100));
                 }
             }
         }
@@ -623,8 +620,9 @@ pub mod tests {
     //   as there are probably unexpected responses coming on the standard addresses
     fn passive_mdns_test(mdns_query_type: MdnsQueryType, mdns_addr: SocketAddr) {
         use std;
-        use std::time::Duration;
-        use tokio_core::reactor::{Core, Timeout};
+        use std::time::{Duration, Instant};
+        use tokio_core::reactor::Core;
+        use tokio_timer::Delay;
 
         let server_got_packet = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
@@ -638,8 +636,7 @@ pub mod tests {
             .spawn(move || {
                 let mut server_loop = Core::new().unwrap();
                 let loop_handle = server_loop.handle();
-                let mut timeout = Timeout::new(Duration::from_millis(100), &loop_handle)
-                    .expect("failed to register timeout");
+                let mut timeout = Delay::new(Instant::now() + Duration::from_millis(100));
 
                 // TTLs are 0 so that multicast test packets never leave the test host...
                 // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
@@ -681,8 +678,7 @@ pub mod tests {
                         }
                         Either::B(((), buffer_and_addr_stream_tmp)) => {
                             server_stream = buffer_and_addr_stream_tmp;
-                            timeout = Timeout::new(Duration::from_millis(100), &loop_handle)
-                                .expect("failed to register timeout");
+                            timeout = Delay::new(Instant::now() + Duration::from_millis(100));
                         }
                     }
 
@@ -705,8 +701,7 @@ pub mod tests {
             &loop_handle,
         );
         let mut stream = io_loop.run(stream).ok().unwrap().into_future();
-        let mut timeout = Timeout::new(Duration::from_millis(100), &io_loop.handle())
-            .expect("failed to register timeout");
+        let mut timeout = Delay::new(Instant::now() + Duration::from_millis(100));
 
         for _ in 0..send_recv_times {
             // test once
@@ -740,8 +735,7 @@ pub mod tests {
                 }
                 Either::B(((), buffer_and_addr_stream_tmp)) => {
                     stream = buffer_and_addr_stream_tmp;
-                    timeout = Timeout::new(Duration::from_millis(100), &loop_handle)
-                        .expect("failed to register timeout");
+                    timeout = Delay::new(Instant::now() + Duration::from_millis(100));
                 }
             }
         }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -82,6 +82,7 @@ serde = "^1.0"
 serde_derive = "^1.0"
 time = "^0.1"
 tokio-core = "^0.1"
+tokio-timer = "^0.2"
 toml = "^0.4"
 trust-dns = { version = "^0.13", path = "../client" }
 trust-dns-proto = { version = "^0.3", path = "../proto" }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -31,7 +31,6 @@ extern crate chrono;
 extern crate env_logger;
 #[macro_use]
 extern crate error_chain;
-#[macro_use]
 extern crate futures;
 #[macro_use]
 extern crate log;
@@ -41,6 +40,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate time;
 extern crate tokio_core;
+extern crate tokio_timer;
 extern crate toml;
 extern crate trust_dns;
 extern crate trust_dns_proto;

--- a/server/src/server/server_future.rs
+++ b/server/src/server/server_future.rs
@@ -106,7 +106,7 @@ impl<T: RequestHandler> ServerFuture<T> {
                     debug!("accepted request from: {}", src_addr);
                     // take the created stream...
                     let (buf_stream, stream_handle) = TcpStream::from_stream(tcp_stream, src_addr);
-                    let timeout_stream = TimeoutStream::new(buf_stream, timeout, &handle)?;
+                    let timeout_stream = TimeoutStream::new(buf_stream, timeout);
                     //let request_stream = RequestStream::new(timeout_stream, stream_handle);
                     let handler = handler.clone();
 
@@ -188,7 +188,7 @@ impl<T: RequestHandler> ServerFuture<T> {
                         .and_then(move |tls_stream| {
                             let (buf_stream, stream_handle) =
                                 TlsStream::from_stream(tls_stream, src_addr);
-                            let timeout_stream = TimeoutStream::new(buf_stream, timeout, &handle)?;
+                            let timeout_stream = TimeoutStream::new(buf_stream, timeout);
                             //let request_stream = RequestStream::new(timeout_stream, stream_handle);
                             let handler = handler.clone();
 

--- a/server/src/server/timeout_stream.rs
+++ b/server/src/server/timeout_stream.rs
@@ -1,18 +1,17 @@
 use std::io;
 use std::mem;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures::{Async, Future, Poll, Stream};
-use tokio_core::reactor::{Handle, Timeout};
+use tokio_timer::Delay;
 
 /// This wraps the underlying Stream in a timeout.
 ///
 /// Any `Ok(Async::Ready(_))` from the underlying Stream will reset the timeout.
 pub struct TimeoutStream<S> {
     stream: S,
-    reactor_handle: Handle,
     timeout_duration: Duration,
-    timeout: Option<Timeout>,
+    timeout: Option<Delay>,
 }
 
 impl<S> TimeoutStream<S> {
@@ -23,24 +22,22 @@ impl<S> TimeoutStream<S> {
     /// * `stream` - stream to wrap
     /// * `timeout_duration` - timeout between each request, once exceed the connection is killed
     /// * `reactor_handle` - reactor used for registering new timeouts
-    pub fn new(stream: S, timeout_duration: Duration, reactor_handle: &Handle) -> io::Result<Self> {
+    pub fn new(stream: S, timeout_duration: Duration) -> Self {
         // store a Timeout for this message before sending
+        let timeout = Self::timeout(timeout_duration);
 
-        let timeout = Self::timeout(timeout_duration, reactor_handle)?;
-
-        Ok(TimeoutStream {
+        TimeoutStream {
             stream: stream,
-            reactor_handle: reactor_handle.clone(),
             timeout_duration: timeout_duration,
             timeout: timeout,
-        })
+        }
     }
 
-    fn timeout(timeout_duration: Duration, reactor_handle: &Handle) -> io::Result<Option<Timeout>> {
+    fn timeout(timeout_duration: Duration) -> Option<Delay> {
         if timeout_duration > Duration::from_millis(0) {
-            Ok(Some(Timeout::new(timeout_duration, reactor_handle)?))
+            Some(Delay::new(Instant::now() + timeout_duration))
         } else {
-            Ok(None)
+            None
         }
     }
 }
@@ -57,7 +54,7 @@ where
         match self.stream.poll() {
             r @ Ok(Async::Ready(_)) | r @ Err(_) => {
                 // reset the timeout to wait for the next request...
-                let mut timeout = Self::timeout(self.timeout_duration, &self.reactor_handle)?;
+                let mut timeout = Self::timeout(self.timeout_duration);
 
                 // ensure that interest in the Timeout is registered
                 match timeout.poll() {
@@ -83,19 +80,22 @@ where
                 r
             }
             Ok(Async::NotReady) => {
-                if self.timeout.is_none() {
-                    return Ok(Async::NotReady);
-                }
-
-                // otherwise check if the timeout has expired.
-                match try_ready!(self.timeout.as_mut().unwrap().poll()) {
-                    () => {
-                        debug!("timeout on stream");
-                        Err(io::Error::new(
-                            io::ErrorKind::TimedOut,
-                            format!("nothing ready in {:?}", self.timeout_duration),
-                        ))
+                if let Some(ref mut timeout) = self.timeout {
+                    match timeout.poll() {
+                        Ok(Async::NotReady) => return Ok(Async::NotReady),
+                        Ok(Async::Ready(())) => {
+                            debug!("timeout on stream");
+                            return Err(io::Error::new(
+                                io::ErrorKind::TimedOut,
+                                format!("nothing ready in {:?}", self.timeout_duration),
+                            ));
+                        }
+                        Err(_) => {
+                            return Err(io::Error::new(io::ErrorKind::Other, "timer internal error"));
+                        }
                     }
+                } else {
+                    return Ok(Async::NotReady);
                 }
             }
         }

--- a/server/tests/timeout_stream_tests.rs
+++ b/server/tests/timeout_stream_tests.rs
@@ -19,8 +19,7 @@ fn test_no_timeout() {
         iter(vec![Ok(1), Err("error"), Ok(2)]).map_err(|e| io::Error::new(io::ErrorKind::Other, e));
     let mut core = Core::new().expect("could not get core");
 
-    let timeout_stream = TimeoutStream::new(sequence, Duration::from_secs(360), &core.handle())
-        .expect("could not create timeout_stream");
+    let timeout_stream = TimeoutStream::new(sequence, Duration::from_secs(360));
 
     let (val, timeout_stream) = core.run(timeout_stream.into_future())
         .ok()
@@ -58,9 +57,7 @@ impl Stream for NeverStream {
 #[test]
 fn test_timeout() {
     let mut core = Core::new().expect("could not get core");
-    let timeout_stream =
-        TimeoutStream::new(NeverStream {}, Duration::from_millis(1), &core.handle())
-            .expect("could not create timeout_stream");
+    let timeout_stream = TimeoutStream::new(NeverStream {}, Duration::from_millis(1));
 
     assert!(core.run(timeout_stream.into_future()).is_err());
 }


### PR DESCRIPTION
Part of #385, Port to tokio.

The methodology to port to tokio is that library crates need to move to depending on the new sub-crates under the tokio umbrella crate, and applications should depend on the tokio crate.

I've started by migrating all usages of `tokio_core::reactor::Timeout` to direct usages of `tokio_timer::Delay` (or straight to `tokio_timer::Deadline` where it was obvious)

(If you'd rather receive a PR that includes all of the sub-crate migrations at once, I can work on that instead)

