### PR TITLE
Remove backtrace dependency.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -55,7 +55,7 @@ path = "src/lib.rs"
 chrono = "^0.4"
 data-encoding = "2.1.0"
 data-encoding-macro = "0.1.1"
-error-chain = "0.1.12"
+error-chain = { version = "0.1.12", default-features = false }
 futures = "^0.1.17"
 lazy_static = "^1.0"
 log = "^0.4.1"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -52,7 +52,7 @@ path = "src/lib.rs"
 [dependencies]
 byteorder = "^1.2"
 data-encoding = { version = "2.1.0", optional = true }
-error-chain = "0.1.12"
+error-chain = { version = "0.1.12", default-features = false }
 futures = "^0.1.17"
 idna = "^0.1.4"
 lazy_static = "^1.0"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -53,7 +53,7 @@ path = "src/lib.rs"
 
 [dependencies]
 cfg-if = "0.1"
-error-chain = "0.1.12"
+error-chain = { version = "0.1.12", default-features = false }
 futures = "^0.1.17"
 lazy_static = "^1.0"
 log = "^0.4.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -72,7 +72,7 @@ backtrace = "^0.3.5"
 chrono = "^0.4"
 clap = "^2.27"
 env_logger = "^0.5"
-error-chain = "0.1.12"
+error-chain = { version = "0.1.12", default-features = false }
 futures = "^0.1.17"
 lazy_static = "^1.0"
 log = "^0.4.1"


### PR DESCRIPTION
Disable the default "backtrace" feature of error-chain to remove the
dependency on "backtrace". The replacement for error-chain, the
failure crate, will disable backtraces by default.

Contributed on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>