### PR TITLE
tokio related cleanups and preparations

### DIFF
--- a/native-tls/Cargo.toml
+++ b/native-tls/Cargo.toml
@@ -46,11 +46,13 @@ path = "src/lib.rs"
 [dependencies]
 futures = "^0.1.17"
 native-tls = "^0.1"
-tokio-core = "^0.1"
 tokio-tcp = "^0.1"
 tokio-tls = "^0.1"
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "^0.3", path = "../proto", default-features = false }
+
+[dev-dependencies]
+tokio-core = "^0.1"
 
 ## Commented out until MTLS support is complete
 # [target.'cfg(target_os = "linux")'.dependencies]

--- a/native-tls/src/lib.rs
+++ b/native-tls/src/lib.rs
@@ -20,6 +20,7 @@
 
 extern crate futures;
 extern crate native_tls;
+#[cfg(test)]
 extern crate tokio_core;
 extern crate tokio_tcp;
 extern crate tokio_tls;

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -44,10 +44,10 @@ path = "src/lib.rs"
 [dependencies]
 futures = "^0.1.17"
 openssl = { version = "^0.10", features = ["v102", "v110"] }
-tokio-core = "^0.1"
 tokio-openssl = "^0.2"
 tokio-tcp = "^0.1"
 trust-dns-proto = { version = "^0.3", path = "../proto" }
 
 [dev-dependencies]
 openssl = { version = "^0.10", features = ["v102", "v110"] }
+tokio-core = "^0.1"

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -18,7 +18,6 @@
 
 extern crate futures;
 extern crate openssl;
-extern crate tokio_core;
 extern crate tokio_openssl;
 extern crate tokio_tcp;
 extern crate trust_dns_proto;

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -63,7 +63,6 @@ ring = { version = "^0.12", optional = true }
 smallvec = "^0.6"
 socket2 = { version = "^0.3.4", features = ["reuseport"] }
 tokio = "^0.1"
-tokio-core = "^0.1"
 tokio-io = "^0.1"
 tokio-reactor = "^0.1"
 tokio-tcp = "^0.1"
@@ -74,3 +73,4 @@ url = "1.6.0"
 
 [dev-dependencies]
 env_logger = "^0.5"
+tokio-core = "^0.1"

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -33,8 +33,9 @@ extern crate ring;
 extern crate smallvec;
 extern crate socket2;
 extern crate tokio;
-#[macro_use]
+#[cfg(test)]
 extern crate tokio_core;
+#[macro_use]
 extern crate tokio_io;
 extern crate tokio_reactor;
 extern crate tokio_tcp;

--- a/proto/src/tcp/tcp_client_stream.rs
+++ b/proto/src/tcp/tcp_client_stream.rs
@@ -34,7 +34,6 @@ impl TcpClientStream<TokioTcpStream> {
     /// # Arguments
     ///
     /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `loop_handle` - reference to the takio_core::Core for future based IO
     pub fn new<E>(
         name_server: SocketAddr,
     ) -> (
@@ -52,7 +51,6 @@ impl TcpClientStream<TokioTcpStream> {
     /// # Arguments
     ///
     /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `loop_handle` - reference to the takio_core::Core for future based IO
     /// * `timeout` - connection timeout
     pub fn with_timeout<E>(
         name_server: SocketAddr,

--- a/proto/src/tcp/tcp_stream.rs
+++ b/proto/src/tcp/tcp_stream.rs
@@ -87,7 +87,6 @@ impl TcpStream<TokioTcpStream> {
     /// # Arguments
     ///
     /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `loop_handle` - reference to the takio_core::Core for future based IO
     pub fn new<E>(
         name_server: SocketAddr,
     ) -> (
@@ -105,7 +104,6 @@ impl TcpStream<TokioTcpStream> {
     /// # Arguments
     ///
     /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `loop_handle` - reference to the takio_core::Core for future based IO
     /// * `timeout` - connection timeout
     pub fn with_timeout<E>(
         name_server: SocketAddr,

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -46,7 +46,6 @@ path = "src/lib.rs"
 [dependencies]
 futures = "^0.1.17"
 rustls = "^0.11"
-tokio-core = "^0.1"
 tokio-rustls = "^0.4"
 tokio-tcp = "^0.1"
 # disables default features, i.e. openssl...
@@ -54,3 +53,4 @@ trust-dns-proto = { version = "^0.3", path = "../proto", default-features = fals
 
 [dev-dependencies]
 openssl = { version = "^0.10", features = ["v102", "v110"] }
+tokio-core = "^0.1"

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -18,6 +18,7 @@
 
 extern crate futures;
 extern crate rustls;
+#[cfg(test)]
 extern crate tokio_core;
 extern crate tokio_rustls;
 extern crate tokio_tcp;


### PR DESCRIPTION
Move tokio-core dependency to dev-dependencies for modules that now only use it in tests.
The remaining tokio_core::reactor::Core usage cannot be ported to tokio yet as there is no alternative to run() yet, tokio::run can only run `Future<(), ()>`, no return value or error. Some alternative should come in next release.
Prepare server_future for tokio-executor porting. With this, code compiles fine when porting to tokio-executor but we have the same execution context initialization we had for dns_future and I don't thing we want to introduce even more threading + tokio::run here.