### PR TITLE
Expose TTLs on lookups

### DIFF
--- a/integration-tests/tests/lookup_tests.rs
+++ b/integration-tests/tests/lookup_tests.rs
@@ -64,7 +64,7 @@ fn test_lookup_hosts() {
     hosts.insert(
         Name::from_str("www.example.com.").unwrap(),
         RecordType::A,
-        Lookup::new(Arc::new(vec![RData::A(Ipv4Addr::new(10, 0, 1, 104))])),
+        Lookup::new_with_max_ttl(Arc::new(vec![RData::A(Ipv4Addr::new(10, 0, 1, 104))])),
     );
 
     let lookup = InnerLookupIpFuture::lookup(

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -63,7 +63,7 @@ impl DnsLru {
         let ttl_until = now + ttl;
 
         // insert into the LRU
-        let lookup = Lookup::new_with_ttl(Arc::new(rdatas), ttl);
+        let lookup = Lookup::new_with_ttl(Arc::new(rdatas), ttl_until);
         self.0.insert(
             query,
             LruValue {

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -24,13 +24,13 @@ pub const MAX_TTL: u32 = 2147483647_u32;
 struct LruValue {
     // In the None case, this represents an NXDomain
     lookup: Option<Lookup>,
-    ttl_until: Instant,
+    valid_until: Instant,
 }
 
 impl LruValue {
     /// Returns true if this set of ips is still valid
     fn is_current(&self, now: Instant) -> bool {
-        now <= self.ttl_until
+        now <= self.valid_until
     }
 }
 
@@ -60,15 +60,15 @@ impl DnsLru {
         );
 
         let ttl = Duration::from_secs(ttl as u64);
-        let ttl_until = now + ttl;
+        let valid_until = now + ttl;
 
         // insert into the LRU
-        let lookup = Lookup::new_with_deadline(Arc::new(rdatas), ttl_until);
+        let lookup = Lookup::new_with_deadline(Arc::new(rdatas), valid_until);
         self.0.insert(
             query,
             LruValue {
                 lookup: Some(lookup.clone()),
-                ttl_until,
+                valid_until,
             },
         );
 
@@ -84,13 +84,13 @@ impl DnsLru {
         now: Instant,
     ) -> Lookup {
         let ttl = Duration::from_secs(ttl as u64);
-        let ttl_until = now + ttl;
+        let valid_until = now + ttl;
 
         self.0.insert(
             query,
             LruValue {
                 lookup: Some(lookup.clone()),
-                ttl_until,
+                valid_until,
             },
         );
 
@@ -106,13 +106,13 @@ impl DnsLru {
         //   this would cache indefinitely, probably not correct
 
         let ttl = Duration::from_secs(ttl as u64);
-        let ttl_until = now + ttl;
+        let valid_until = now + ttl;
 
         self.0.insert(
             query.clone(),
             LruValue {
                 lookup: None,
-                ttl_until,
+                valid_until,
             },
         );
 
@@ -164,7 +164,7 @@ mod tests {
 
         let value = LruValue {
             lookup: None,
-            ttl_until: future,
+            valid_until: future,
         };
 
         assert!(value.is_current(now));

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -63,7 +63,7 @@ impl DnsLru {
         let ttl_until = now + ttl;
 
         // insert into the LRU
-        let lookup = Lookup::new(Arc::new(rdatas));
+        let lookup = Lookup::new_with_ttl(Arc::new(rdatas), ttl);
         self.0.insert(
             query,
             LruValue {
@@ -154,7 +154,7 @@ mod tests {
     use trust_dns_proto::rr::{Name, RecordType};
 
     use super::*;
- 
+
     #[test]
     fn test_is_current() {
         let now = Instant::now();

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -63,7 +63,7 @@ impl DnsLru {
         let ttl_until = now + ttl;
 
         // insert into the LRU
-        let lookup = Lookup::new_with_ttl(Arc::new(rdatas), ttl_until);
+        let lookup = Lookup::new_with_deadline(Arc::new(rdatas), ttl_until);
         self.0.insert(
             query,
             LruValue {

--- a/resolver/src/hosts.rs
+++ b/resolver/src/hosts.rs
@@ -63,10 +63,10 @@ impl Hosts {
             let mut old_lookup = match &record_type {
                 &RecordType::A => lookup_type
                     .a
-                    .get_or_insert_with(|| Lookup::new(Arc::new(vec![]))),
+                    .get_or_insert_with(|| Lookup::new_with_max_ttl(Arc::new(vec![]))),
                 &RecordType::AAAA => lookup_type
                     .aaaa
-                    .get_or_insert_with(|| Lookup::new(Arc::new(vec![]))),
+                    .get_or_insert_with(|| Lookup::new_with_max_ttl(Arc::new(vec![]))),
                 _ => {
                     warn!("unsupported IP type from Hosts file: {:#?}", record_type);
                     return;
@@ -129,7 +129,7 @@ pub fn read_hosts_conf<P: AsRef<Path>>(path: P) -> io::Result<Hosts> {
 
         for domain in fields.iter().skip(1).map(|domain| domain.to_lowercase()) {
             if let Ok(name) = Name::from_str(&domain) {
-                let lookup = Lookup::new(Arc::new(vec![addr.clone()]));
+                let lookup = Lookup::new_with_max_ttl(Arc::new(vec![addr.clone()]));
                 match &addr {
                     &RData::A(..) => hosts.insert(name.clone(), RecordType::A, lookup),
                     &RData::AAAA(..) => hosts.insert(name.clone(), RecordType::AAAA, lookup),

--- a/resolver/src/lookup.rs
+++ b/resolver/src/lookup.rs
@@ -43,7 +43,7 @@ pub struct Lookup {
 
 impl Lookup {
     /// Return new instance with given rdatas and the maximum TTL.
-    pub fn new(rdatas: Arc<Vec<RData>>,) -> Self {
+    pub fn new_with_max_ttl(rdatas: Arc<Vec<RData>>) -> Self {
         let valid_until =
             Instant::now() + Duration::from_secs(MAX_TTL as u64);
         Lookup {
@@ -95,7 +95,7 @@ impl Lookup {
 
 impl From<RData> for Lookup {
     fn from(data: RData) -> Self {
-        Lookup::new(Arc::new(vec![data]))
+        Lookup::new_with_max_ttl(Arc::new(vec![data]))
     }
 }
 

--- a/resolver/src/lookup.rs
+++ b/resolver/src/lookup.rs
@@ -49,11 +49,11 @@ impl Lookup {
         }
     }
 
-    /// Return a new instance with the given rdatas and TTL.
-    pub fn new_with_deadline(rdatas: Arc<Vec<RData>>, ttl: Instant,) -> Self {
+    /// Return a new instance with the given rdatas and deadline.
+    pub fn new_with_deadline(rdatas: Arc<Vec<RData>>, valid_until: Instant,) -> Self {
         Lookup {
             rdatas,
-            valid_until: Some(ttl),
+            valid_until: Some(valid_until),
         }
     }
 

--- a/resolver/src/lookup.rs
+++ b/resolver/src/lookup.rs
@@ -61,6 +61,7 @@ impl Lookup {
         LookupIter(self.rdatas.iter())
     }
 
+    /// Returns the TTL of the lookup.
     pub fn ttl(&self) -> Option<Duration> {
         self.ttl
     }
@@ -464,6 +465,21 @@ pub mod tests {
                 .map(|r| r.to_ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
             vec![Ipv4Addr::new(127, 0, 0, 1)]
+        );
+    }
+
+    #[test]
+    fn test_lookup_ttl() {
+        assert_eq!(
+            InnerLookupFuture::lookup(
+                vec![Name::root()],
+                RecordType::A,
+                DnsRequestOptions::default(),
+                CachingClient::new(0, mock(vec![v4_message()])),
+            ).wait()
+                .unwrap()
+                .ttl(),
+            Some(Duration::from_secs(86400))
         );
     }
 

--- a/resolver/src/lookup.rs
+++ b/resolver/src/lookup.rs
@@ -472,9 +472,8 @@ pub mod tests {
     }
 
     #[test]
-    fn test_lookup_ttl() {
-        use std::time::Duration;
-        assert_eq!(
+    fn test_lookup_deadline() {
+        assert!(
             InnerLookupFuture::lookup(
                 vec![Name::root()],
                 RecordType::A,
@@ -482,8 +481,10 @@ pub mod tests {
                 CachingClient::new(0, mock(vec![v4_message()])),
             ).wait()
                 .unwrap()
-                .valid_until(),
-            Some(Instant::now() + Duration::from_secs(86400))
+                .valid_until()
+                // Since `time::Instant` is opaque, we can't accurately compare
+                // the deadline, so just assert that there is one.
+                .is_some()
         );
     }
 

--- a/resolver/src/lookup_ip.rs
+++ b/resolver/src/lookup_ip.rs
@@ -13,6 +13,7 @@ use std::error::Error;
 use std::mem;
 use std::net::IpAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::{future, task, Async, Future, Poll};
 
@@ -38,6 +39,11 @@ impl LookupIp {
     /// Returns a borrowed iterator of the returned IPs
     pub fn iter(&self) -> LookupIpIter {
         LookupIpIter(self.0.iter())
+    }
+
+    /// Returns the TTL of the lookup.
+    pub fn ttl(&self) -> Option<Duration> {
+        self.0.ttl()
     }
 }
 

--- a/resolver/src/lookup_ip.rs
+++ b/resolver/src/lookup_ip.rs
@@ -13,7 +13,7 @@ use std::error::Error;
 use std::mem;
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::Instant;
 
 use futures::{future, task, Async, Future, Poll};
 
@@ -41,9 +41,9 @@ impl LookupIp {
         LookupIpIter(self.0.iter())
     }
 
-    /// Returns the TTL of the lookup.
-    pub fn ttl(&self) -> Option<Duration> {
-        self.0.ttl()
+    /// Returns the `Instant` at which this lookup is no longer valid.
+    pub fn ttl_until(&self) -> Option<Instant> {
+        self.0.ttl_until()
     }
 }
 

--- a/resolver/src/lookup_ip.rs
+++ b/resolver/src/lookup_ip.rs
@@ -42,8 +42,8 @@ impl LookupIp {
     }
 
     /// Returns the `Instant` at which this lookup is no longer valid.
-    pub fn ttl_until(&self) -> Option<Instant> {
-        self.0.ttl_until()
+    pub fn valid_until(&self) -> Option<Instant> {
+        self.0.valid_until()
     }
 }
 

--- a/resolver/src/lookup_ip.rs
+++ b/resolver/src/lookup_ip.rs
@@ -42,7 +42,7 @@ impl LookupIp {
     }
 
     /// Returns the `Instant` at which this lookup is no longer valid.
-    pub fn valid_until(&self) -> Option<Instant> {
+    pub fn valid_until(&self) -> Instant {
         self.0.valid_until()
     }
 }

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -256,7 +256,7 @@ impl ResolverFuture {
         if let Some(addr) = host.try_parse_ip() {
             return InnerLookupIpFuture::ok(
                 self.client_cache.clone(),
-                Lookup::new(Arc::new(vec![addr])),
+                Lookup::new_with_max_ttl(Arc::new(vec![addr])),
             );
         }
 


### PR DESCRIPTION
This PR changes the `trust-dns-resolver` API to expose the TTLs of DNS 
lookups, which is needed downstream in Conduit (runconduit/conduit#711).

Reviewers should note the following: 

+ In some cases, `Lookup`s were constructed in places where the TTL is not 
  known or there is no TTL (e.g. for `localhost` in `lookup_state.rs`). 
  Therefore, I made the TTL field on `Lookup` optional, and added a new 
  `Lookup::new_with_ttl` constructor, to avoid breaking existing code.
+ When `append`ing two `Lookups`, if both have known TTLs, the returned 
  `Lookup` has the lower of the two TTLs. Thus, the appended `Lookup` 
  should time out when the shorter-lived of either of its constituents 
  does. This _seemed_ like the correct behaviour to me, so that `append`
  doesn't become a way for short-lived `Lookup`s to escape their TTLs, 
  but I wasn't sure about this --- please let me know if this intuition 
  is incorrect! 
+ I've added a simple unit test for the added `TTL` function in `lookup.rs`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
