### PR TITLE
Fix send sync for DnsHandle and Resolver, etc

### DIFF
--- a/client/src/client/rc_future.rs
+++ b/client/src/client/rc_future.rs
@@ -5,38 +5,38 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use futures::{Async, Fuse, Future, IntoFuture, Poll};
 
 pub struct RcFuture<F: Future>
 where
-    F: Future,
-    F::Item: Clone,
+    F: Future + Send,
+    F::Item: Clone + Send,
 {
-    rc_future: Rc<RefCell<Fuse<F>>>,
-    result: Rc<RefCell<Option<Poll<F::Item, F::Error>>>>,
+    rc_future: Arc<Mutex<Fuse<F>>>,
+    result: Arc<Mutex<Option<Poll<F::Item, F::Error>>>>,
 }
 
-pub fn rc_future<I>(future: I) -> RcFuture<I::Future>
+pub fn rc_future<I, F>(future: I) -> RcFuture<I::Future>
 where
     I: IntoFuture,
-    <I as IntoFuture>::Item: Clone,
+    <I as IntoFuture>::Item: Clone + Send,
+    <I as IntoFuture>::Future: Send,
 {
-    let rc_future = Rc::new(RefCell::new(future.into_future().fuse()));
+    let rc_future = Arc::new(Mutex::new(future.into_future().fuse()));
 
     RcFuture {
         rc_future: rc_future,
-        result: Rc::new(RefCell::new(None)),
+        result: Arc::new(Mutex::new(None)),
     }
 }
 
 impl<F> Future for RcFuture<F>
 where
-    F: Future,
-    F::Item: Clone,
-    F::Error: Clone,
+    F: Future + Send,
+    F::Item: Clone + Send,
+    F::Error: Clone + Send,
 {
     type Item = F::Item;
     type Error = F::Error;
@@ -45,16 +45,20 @@ where
         // try and get a mutable refence to execute the future
         // at least one caller should be able to get a mut reference... others will
         //  wait for it to complete.
-        if self.result.borrow().is_some() {
-            return self.result.borrow().as_ref().unwrap().clone();
+        if self.result.lock().expect("poisoned").is_some() {
+            return self.result
+                .lock()
+                .expect("poisoned")
+                .as_ref()
+                .unwrap()
+                .clone();
         }
 
-
         // TODO convert this to try_borrow_mut when that stabilizes...
-        match self.rc_future.borrow_mut().poll() {
+        match self.rc_future.lock().expect("poisoned").poll() {
             result @ Ok(Async::NotReady) => result,
             result => {
-                let mut store = self.result.borrow_mut();
+                let mut store = self.result.lock().expect("poisoned");
                 *store = Some(result.clone());
                 result
             }
@@ -64,13 +68,13 @@ where
 
 impl<F> Clone for RcFuture<F>
 where
-    F: Future,
-    F::Item: Clone,
+    F: Future + Send,
+    F::Item: Clone + Send,
 {
     fn clone(&self) -> Self {
         RcFuture {
-            rc_future: Rc::clone(&self.rc_future),
-            result: Rc::clone(&self.result),
+            rc_future: Arc::clone(&self.rc_future),
+            result: Arc::clone(&self.result),
         }
     }
 }

--- a/client/src/client/rc_future.rs
+++ b/client/src/client/rc_future.rs
@@ -18,7 +18,7 @@ where
     result: Arc<Mutex<Option<Poll<F::Item, F::Error>>>>,
 }
 
-pub fn rc_future<I, F>(future: I) -> RcFuture<I::Future>
+pub fn rc_future<I>(future: I) -> RcFuture<I::Future>
 where
     I: IntoFuture,
     <I as IntoFuture>::Item: Clone + Send,

--- a/integration-tests/src/mock_client.rs
+++ b/integration-tests/src/mock_client.rs
@@ -28,7 +28,7 @@ impl<E: FromProtoError + 'static> DnsHandle for MockClientHandle<E> {
     fn send<R: Into<DnsRequest>>(
         &mut self,
         _: R,
-    ) -> Box<Future<Item = DnsResponse, Error = Self::Error>> {
+    ) -> Box<Future<Item = DnsResponse, Error = Self::Error> + Send> {
         Box::new(future::result(
             self.messages.lock().unwrap().pop().unwrap_or(empty::<E>()),
         ))

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -12,14 +12,14 @@ use std::sync::Arc;
 
 use rr::{Name, RecordType};
 
-#[cfg(feature = "openssl")]
-use openssl::error::ErrorStack as SslErrorStack;
 #[cfg(not(feature = "openssl"))]
 use self::not_openssl::SslErrorStack;
-#[cfg(feature = "ring")]
-use ring::error::Unspecified;
 #[cfg(not(feature = "ring"))]
 use self::not_ring::Unspecified;
+#[cfg(feature = "openssl")]
+use openssl::error::ErrorStack as SslErrorStack;
+#[cfg(feature = "ring")]
+use ring::error::Unspecified;
 
 use tokio_timer::Error as TimerError;
 
@@ -175,7 +175,6 @@ pub mod not_openssl {
         }
     }
 
-
     impl std::error::Error for SslErrorStack {
         fn description(&self) -> &str {
             "openssl feature not enabled"
@@ -195,7 +194,6 @@ pub mod not_ring {
             Ok(())
         }
     }
-
 
     impl std::error::Error for Unspecified {
         fn description(&self) -> &str {
@@ -268,7 +266,7 @@ impl Clone for ProtoErrorKind {
             ProtoErrorKind::MaxBufferSizeExceeded(ref max) => {
                 ProtoErrorKind::MaxBufferSizeExceeded(*max)
             }
-            ProtoErrorKind::Timer => ProtoErrorKind:: Timer,
+            ProtoErrorKind::Timer => ProtoErrorKind::Timer,
         }
     }
 }
@@ -289,10 +287,10 @@ impl Clone for ProtoError {
     }
 }
 
-pub trait FromProtoError: From<ProtoError> + ::std::error::Error + Clone {}
+pub trait FromProtoError: From<ProtoError> + ::std::error::Error + Clone + Send {}
 
 impl<E> FromProtoError for E
 where
-    E: From<ProtoError> + ::std::error::Error + Clone,
+    E: From<ProtoError> + ::std::error::Error + Clone + Send,
 {
 }

--- a/proto/src/rr/mod.rs
+++ b/proto/src/rr/mod.rs
@@ -27,8 +27,8 @@ pub mod record_type;
 pub mod resource;
 mod rr_set;
 
-pub use self::domain::{IntoName, Name};
 pub use self::dns_class::DNSClass;
+pub use self::domain::{IntoName, Name, TryParseIp};
 pub use self::record_data::RData;
 pub use self::record_type::RecordType;
 pub use self::resource::Record;

--- a/proto/src/xfer/dns_handle.rs
+++ b/proto/src/xfer/dns_handle.rs
@@ -9,9 +9,9 @@
 
 use std::marker::PhantomData;
 
-use futures::IntoFuture;
 use futures::sync::mpsc::UnboundedSender;
 use futures::sync::oneshot;
+use futures::IntoFuture;
 use futures::{Complete, Future};
 use rand;
 
@@ -120,7 +120,7 @@ where
 }
 
 /// A trait for implementing high level functions of DNS.
-pub trait DnsHandle: Clone {
+pub trait DnsHandle: Clone + Send {
     /// The associated error type returned by future send operations
     type Error: FromProtoError;
 

--- a/proto/src/xfer/dns_handle.rs
+++ b/proto/src/xfer/dns_handle.rs
@@ -92,7 +92,7 @@ where
     fn send<R: Into<DnsRequest>>(
         &mut self,
         request: R,
-    ) -> Box<Future<Item = DnsResponse, Error = Self::Error>> {
+    ) -> Box<Future<Item = DnsResponse, Error = Self::Error> + Send> {
         let request = request.into();
         let (complete, receiver) = oneshot::channel();
         let message_sender: &mut _ = &mut self.message_sender;
@@ -141,7 +141,7 @@ pub trait DnsHandle: Clone + Send {
     fn send<R: Into<DnsRequest>>(
         &mut self,
         request: R,
-    ) -> Box<Future<Item = DnsResponse, Error = Self::Error>>;
+    ) -> Box<Future<Item = DnsResponse, Error = Self::Error> + Send>;
 
     /// A *classic* DNS query
     ///
@@ -154,7 +154,7 @@ pub trait DnsHandle: Clone + Send {
         &mut self,
         query: Query,
         options: DnsRequestOptions,
-    ) -> Box<Future<Item = DnsResponse, Error = Self::Error>> {
+    ) -> Box<Future<Item = DnsResponse, Error = Self::Error> + Send> {
         debug!("querying: {} {:?}", query.name(), query.query_type());
 
         // build the message

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -70,3 +70,6 @@ webpki-roots = { version = "^0.13", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ipconfig = { version = "^0.1.4" }
+
+[dev-dependencies]
+tokio-io = "^0.1"

--- a/resolver/examples/global_resolver.rs
+++ b/resolver/examples/global_resolver.rs
@@ -1,0 +1,150 @@
+#[macro_use]
+extern crate lazy_static;
+extern crate futures;
+extern crate tokio;
+extern crate tokio_io;
+extern crate trust_dns_resolver;
+
+use std::io;
+use std::net::SocketAddr;
+
+use futures::Future;
+use tokio_io::IoFuture;
+use trust_dns_resolver::{IntoName, ResolverFuture, TryParseIp};
+
+// This is an example of registering a static global resolver into any system.
+//
+// We may want to create a GlobalResolver as part of the Resolver library
+//   in the mean time, this example has the necessary steps to do so.
+//
+// Thank you to @zonyitoo for the original example.
+
+lazy_static! {
+    // First we need to setup the global Resolver
+    static ref GLOBAL_DNS_RESOLVER: ResolverFuture = {
+        use std::sync::{Arc, Mutex, Condvar};
+        use std::thread;
+
+        // We'll be using this condvar to get the Resolver from the thread...
+        let pair = Arc::new((Mutex::new(None::<ResolverFuture>), Condvar::new()));
+        let pair2 = pair.clone();
+
+
+        // Spawn the runtime to a new thread...
+        //
+        // This thread will manage the actual resolution runtime
+        thread::spawn(move || {
+            // A runtime for this new thread
+            let mut runtime = tokio::runtime::current_thread::Runtime::new().expect("failed to launch Runtime");
+
+            // our platform independent future, result, see next blocks
+            let future;
+
+            // To make this independent, if targeting macOS, BSD, Linux, or Windows, we can use the system's configuration:
+            #[cfg(any(unix, windows))]
+            {
+                // use the system resolver configuration
+                future = ResolverFuture::from_system_conf().expect("Failed to create ResolverFuture");
+            }
+
+            // For other operating systems, we can use one of the preconfigured definitions
+            #[cfg(not(any(unix, windows)))]
+            {
+                // Directly reference the config types
+                use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+
+                // Get a new resolver with the google nameservers as the upstream recursive resolvers
+                future = ResolverFuture::new(ResolverConfig::google(), ResolverOpts::default()).expect("Failed to create ResolverFuture");
+            }
+
+            // this will block the thread until the Resolver is constructed with the above configuration
+            let resolver = runtime.block_on(future).expect("Failed to create DNS resolver");
+
+            let &(ref lock, ref cvar) = &*pair2;
+            let mut started = lock.lock().unwrap();
+            *started = Some(resolver);
+            cvar.notify_one();
+            drop(started);
+
+            runtime.run().expect("Resolver Thread shutdown!");
+        });
+
+        // Wait for the thread to start up.
+        let &(ref lock, ref cvar) = &*pair;
+        let mut resolver = lock.lock().unwrap();
+        while resolver.is_none() {
+            resolver = cvar.wait(resolver).unwrap();
+        }
+
+        // take the started resolver
+        let resolver = std::mem::replace(&mut *resolver, None);
+
+        // set the global resolver
+        resolver.expect("resolver should not be none")
+    };
+}
+
+/// Provide a general purpose resolution function.
+///
+/// This looks up the `host` (a &str or String is good), and combines that with the provided port
+///   this mimics the lookup functions of std::net.
+pub fn resolve<N: IntoName + TryParseIp>(host: N, port: u16) -> IoFuture<Vec<SocketAddr>> {
+    // Now we use the global resolver to perform a lookup_ip.
+    let resolve_future = GLOBAL_DNS_RESOLVER.lookup_ip(host).then(move |result| {
+        // map the result into what we want...
+        result
+            .map_err(move |err| {
+                // we transform the error into a standard IO error for convenience
+                io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    format!("dns resolution error: {}", err),
+                )
+            })
+            .map(move |lookup_ip| {
+                // we take all the IPs returned, and then send back the set of IPs
+                lookup_ip
+                    .iter()
+                    .map(|ip| SocketAddr::new(ip, port))
+                    .collect::<Vec<_>>()
+            })
+    });
+
+    // Now return the boxed future
+    Box::new(resolve_future)
+}
+
+fn main() {
+    use std::thread;
+    use std::time::Duration;
+
+    // Let's resolve some names, we should be able to do it across threads
+    let names = &["www.google.com", "www.reddit.com", "www.wikipedia.org"];
+
+    // println!("spawning to runtime");
+    // runtime.spawn(
+    //     resolve("www.google.com", 443)
+    //         .map(|addrs| println!("addrs: {:?}", addrs))
+    //         .map_err(|err| println!("lookup error: {}", err)),
+    // );
+
+    thread::sleep(Duration::from_secs(1));
+
+    // spawn all the threads to do the lookups
+    let threads = names
+        .iter()
+        .map(|name| {
+            let join = thread::spawn(move || {
+                let mut runtime = tokio::runtime::current_thread::Runtime::new()
+                    .expect("failed to launch Runtime");
+                runtime.block_on(resolve(*name, 443))
+            });
+
+            (name, join)
+        })
+        .collect::<Vec<_>>();
+
+    for (name, join) in threads {
+        let result = join.join();
+        println!("{} resolved to {:?}", name, result);
+    }
+}

--- a/resolver/examples/global_resolver.rs
+++ b/resolver/examples/global_resolver.rs
@@ -115,19 +115,9 @@ pub fn resolve<N: IntoName + TryParseIp>(host: N, port: u16) -> IoFuture<Vec<Soc
 
 fn main() {
     use std::thread;
-    use std::time::Duration;
 
     // Let's resolve some names, we should be able to do it across threads
     let names = &["www.google.com", "www.reddit.com", "www.wikipedia.org"];
-
-    // println!("spawning to runtime");
-    // runtime.spawn(
-    //     resolve("www.google.com", 443)
-    //         .map(|addrs| println!("addrs: {:?}", addrs))
-    //         .map_err(|err| println!("lookup error: {}", err)),
-    // );
-
-    thread::sleep(Duration::from_secs(1));
 
     // spawn all the threads to do the lookups
     let threads = names
@@ -143,6 +133,7 @@ fn main() {
         })
         .collect::<Vec<_>>();
 
+    // print the resolved IPs
     for (name, join) in threads {
         let result = join.join();
         println!("{} resolved to {:?}", name, result);

--- a/resolver/src/lib.rs
+++ b/resolver/src/lib.rs
@@ -201,6 +201,9 @@ pub mod system_conf;
 #[cfg(feature = "dns-over-tls")]
 mod tls;
 
+// reexports from proto
+pub use self::trust_dns_proto::rr::{IntoName, Name, TryParseIp};
+
 pub use hosts::Hosts;
 pub use resolver::Resolver;
 pub use resolver_future::ResolverFuture;

--- a/resolver/src/lib.rs
+++ b/resolver/src/lib.rs
@@ -166,6 +166,7 @@
 extern crate cfg_if;
 #[macro_use]
 extern crate error_chain;
+#[macro_use]
 extern crate futures;
 #[cfg(target_os = "windows")]
 extern crate ipconfig;

--- a/resolver/src/lookup_ip.rs
+++ b/resolver/src/lookup_ip.rs
@@ -80,7 +80,7 @@ where
     names: Vec<Name>,
     strategy: LookupIpStrategy,
     options: DnsRequestOptions,
-    future: Box<Future<Item = Lookup, Error = ResolveError>>,
+    future: Box<Future<Item = Lookup, Error = ResolveError> + Send>,
     hosts: Option<Arc<Hosts>>,
 }
 
@@ -103,7 +103,7 @@ impl<C: DnsHandle<Error = ResolveError> + 'static> LookupIpFuture<C> {
             ResolveError::from(ResolveErrorKind::Message("can not lookup IPs for no names"))
         });
 
-        let query: Box<Future<Item = Lookup, Error = ResolveError>> = match name {
+        let query: Box<Future<Item = Lookup, Error = ResolveError> + Send> = match name {
             Ok(name) => strategic_lookup(
                 name,
                 strategy,
@@ -199,7 +199,7 @@ fn strategic_lookup<C: DnsHandle<Error = ResolveError> + 'static>(
     client: CachingClient<C>,
     options: DnsRequestOptions,
     hosts: Option<Arc<Hosts>>,
-) -> Box<Future<Item = Lookup, Error = ResolveError>> {
+) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
     match strategy {
         LookupIpStrategy::Ipv4Only => ipv4_only(name, client, options, hosts),
         LookupIpStrategy::Ipv6Only => ipv6_only(name, client, options, hosts),
@@ -215,7 +215,7 @@ fn hosts_lookup<C: DnsHandle<Error = ResolveError> + 'static>(
     mut client: CachingClient<C>,
     options: DnsRequestOptions,
     hosts: Option<Arc<Hosts>>,
-) -> Box<Future<Item = Lookup, Error = ResolveError>> {
+) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
     if let Some(hosts) = hosts {
         if let Some(lookup) = hosts.lookup_static_host(&query) {
             return Box::new(future::ok(lookup));
@@ -232,7 +232,7 @@ fn ipv4_only<C: DnsHandle<Error = ResolveError> + 'static>(
     client: CachingClient<C>,
     options: DnsRequestOptions,
     hosts: Option<Arc<Hosts>>,
-) -> Box<Future<Item = Lookup, Error = ResolveError>> {
+) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
     hosts_lookup(Query::query(name, RecordType::A), client, options, hosts)
 }
 
@@ -242,7 +242,7 @@ fn ipv6_only<C: DnsHandle<Error = ResolveError> + 'static>(
     client: CachingClient<C>,
     options: DnsRequestOptions,
     hosts: Option<Arc<Hosts>>,
-) -> Box<Future<Item = Lookup, Error = ResolveError>> {
+) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
     hosts_lookup(Query::query(name, RecordType::AAAA), client, options, hosts)
 }
 
@@ -252,7 +252,7 @@ fn ipv4_and_ipv6<C: DnsHandle<Error = ResolveError> + 'static>(
     client: CachingClient<C>,
     options: DnsRequestOptions,
     hosts: Option<Arc<Hosts>>,
-) -> Box<Future<Item = Lookup, Error = ResolveError>> {
+) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
     Box::new(
         hosts_lookup(
             Query::query(name.clone(), RecordType::A),
@@ -280,7 +280,7 @@ fn ipv4_and_ipv6<C: DnsHandle<Error = ResolveError> + 'static>(
                             Err(_) => future::ok(ips),
                         })) as
                             // This cast is to resolve a comilation error, not sure of it's necessity
-                            Box<Future<Item = Lookup, Error = ResolveError>>
+                            Box<Future<Item = Lookup, Error = ResolveError> + Send>
                     }
 
                     // One failed, just return the other
@@ -296,7 +296,7 @@ fn ipv6_then_ipv4<C: DnsHandle<Error = ResolveError> + 'static>(
     client: CachingClient<C>,
     options: DnsRequestOptions,
     hosts: Option<Arc<Hosts>>,
-) -> Box<Future<Item = Lookup, Error = ResolveError>> {
+) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
     rt_then_swap(
         name,
         client,
@@ -313,7 +313,7 @@ fn ipv4_then_ipv6<C: DnsHandle<Error = ResolveError> + 'static>(
     client: CachingClient<C>,
     options: DnsRequestOptions,
     hosts: Option<Arc<Hosts>>,
-) -> Box<Future<Item = Lookup, Error = ResolveError>> {
+) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
     rt_then_swap(
         name,
         client,
@@ -332,7 +332,7 @@ fn rt_then_swap<C: DnsHandle<Error = ResolveError> + 'static>(
     second_type: RecordType,
     options: DnsRequestOptions,
     hosts: Option<Arc<Hosts>>,
-) -> Box<Future<Item = Lookup, Error = ResolveError>> {
+) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
     let or_client = client.clone();
     Box::new(
         hosts_lookup(
@@ -351,10 +351,10 @@ fn rt_then_swap<C: DnsHandle<Error = ResolveError> + 'static>(
                             options,
                             hosts,
                         ))
-                            as Box<Future<Item = Lookup, Error = ResolveError>>
+                            as Box<Future<Item = Lookup, Error = ResolveError> + Send>
                     } else {
                         Box::new(future::ok(ips))
-                            as Box<Future<Item = Lookup, Error = ResolveError>>
+                            as Box<Future<Item = Lookup, Error = ResolveError> + Send>
                     }
                 }
                 Err(_) => Box::new(hosts_lookup(
@@ -393,7 +393,7 @@ pub mod tests {
         fn send<R: Into<DnsRequest>>(
             &mut self,
             _: R,
-        ) -> Box<Future<Item = DnsResponse, Error = Self::Error>> {
+        ) -> Box<Future<Item = DnsResponse, Error = Self::Error> + Send> {
             Box::new(future::result(
                 self.messages.lock().unwrap().pop().unwrap_or(empty()),
             ))

--- a/resolver/src/lookup_state.rs
+++ b/resolver/src/lookup_state.rs
@@ -17,8 +17,10 @@ use std::time::Instant;
 use futures::{future, task, Async, Future, Poll};
 
 use trust_dns_proto::op::{Message, Query, ResponseCode};
-use trust_dns_proto::rr::domain::usage::{IN_ADDR_ARPA_127, IP6_ARPA_1, ResolverUsage, DEFAULT,
-                                         INVALID, LOCAL, LOCALHOST as LOCALHOST_usage};
+use trust_dns_proto::rr::domain::usage::{
+    IN_ADDR_ARPA_127, IP6_ARPA_1, ResolverUsage, DEFAULT, INVALID, LOCAL,
+    LOCALHOST as LOCALHOST_usage,
+};
 use trust_dns_proto::rr::{DNSClass, Name, RData, Record, RecordType};
 use trust_dns_proto::xfer::{DnsHandle, DnsRequestOptions, DnsResponse};
 

--- a/resolver/src/lookup_state.rs
+++ b/resolver/src/lookup_state.rs
@@ -32,9 +32,9 @@ use lookup::Lookup;
 const MAX_QUERY_DEPTH: u8 = 8; // arbitrarily chosen number...
 
 // FIXME: this is wrong, it must be restricted to the Tokio Task,
-thread_local! {
-    static QUERY_DEPTH: RefCell<u8> = RefCell::new(0);
-}
+// thread_local! {
+//     static QUERY_DEPTH: RefCell<u8> = RefCell::new(0);
+// }
 
 lazy_static! {
     static ref LOCALHOST: Lookup = Lookup::from(RData::PTR(Name::from_ascii("localhost.").unwrap()));
@@ -68,7 +68,7 @@ impl<C: DnsHandle<Error = ResolveError> + 'static> CachingClient<C> {
         query: Query,
         options: DnsRequestOptions,
     ) -> Box<Future<Item = Lookup, Error = ResolveError> + Send> {
-        QUERY_DEPTH.with(|c| *c.borrow_mut() += 1);
+        //   QUERY_DEPTH.with(|c| *c.borrow_mut() += 1);
 
         // see https://tools.ietf.org/html/rfc6761
         //
@@ -113,7 +113,7 @@ impl<C: DnsHandle<Error = ResolveError> + 'static> CachingClient<C> {
 
         Box::new(
             QueryState::lookup(query, options, &mut self.client, self.lru.clone()).then(|f| {
-                QUERY_DEPTH.with(|c| *c.borrow_mut() -= 1);
+                // QUERY_DEPTH.with(|c| *c.borrow_mut() -= 1);
                 f
             }),
         )
@@ -176,15 +176,15 @@ enum Records {
 
 impl<C: DnsHandle<Error = ResolveError> + 'static> QueryFuture<C> {
     fn next_query(&mut self, query: Query, cname_ttl: u32, message: DnsResponse) -> Records {
-        if QUERY_DEPTH.with(|c| *c.borrow() >= MAX_QUERY_DEPTH) {
-            // TODO: This should return an error
-            self.handle_nxdomain(message, true)
-        } else {
-            Records::CnameChain {
-                next: self.client.lookup(query, self.options.clone()),
-                min_ttl: cname_ttl,
-            }
+        // if QUERY_DEPTH.with(|c| *c.borrow() >= MAX_QUERY_DEPTH) {
+        //     // TODO: This should return an error
+        //     self.handle_nxdomain(message, true)
+        // } else {
+        Records::CnameChain {
+            next: self.client.lookup(query, self.options.clone()),
+            min_ttl: cname_ttl,
         }
+        // }
     }
 
     fn handle_noerror(&mut self, mut response: DnsResponse) -> Poll<Records, ResolveError> {

--- a/resolver/src/name_server_pool.rs
+++ b/resolver/src/name_server_pool.rs
@@ -165,13 +165,10 @@ impl PartialOrd for NameServerStats {
 }
 
 #[doc(hidden)]
-pub trait ConnectionProvider: Clone {
+pub trait ConnectionProvider: 'static + Clone + Send {
     type ConnHandle;
 
-    fn new_connection(
-        config: &NameServerConfig,
-        options: &ResolverOpts,
-    ) -> Self::ConnHandle;
+    fn new_connection(config: &NameServerConfig, options: &ResolverOpts) -> Self::ConnHandle;
 }
 
 /// Standard connection implements the default mechanism for creating new Connections
@@ -181,10 +178,7 @@ pub struct StandardConnection;
 impl ConnectionProvider for StandardConnection {
     type ConnHandle = BasicResolverHandle;
 
-    fn new_connection(
-        config: &NameServerConfig,
-        options: &ResolverOpts,
-    ) -> Self::ConnHandle {
+    fn new_connection(config: &NameServerConfig, options: &ResolverOpts) -> Self::ConnHandle {
         let dns_handle = match config.protocol {
             Protocol::Udp => {
                 let (stream, handle) = UdpClientStream::new(config.socket_addr);
@@ -444,9 +438,7 @@ impl<C: DnsHandle, P: ConnectionProvider<ConnHandle = C>> Eq for NameServer<C, P
 
 // TODO: once IPv6 is better understood, also make this a binary keep.
 #[cfg(feature = "mdns")]
-fn mdns_nameserver(
-    options: ResolverOpts,
-) -> NameServer<BasicResolverHandle, StandardConnection> {
+fn mdns_nameserver(options: ResolverOpts) -> NameServer<BasicResolverHandle, StandardConnection> {
     let config = NameServerConfig {
         socket_addr: *MDNS_IPV4,
         protocol: Protocol::Mdns,
@@ -480,10 +472,7 @@ impl<C: DnsHandle + 'static, P: ConnectionProvider<ConnHandle = C> + 'static> Na
                 .iter()
                 .filter(|ns_config| ns_config.protocol.is_datagram())
                 .map(|ns_config| {
-                    NameServer::<_, StandardConnection>::new(
-                        ns_config.clone(),
-                        options.clone(),
-                    )
+                    NameServer::<_, StandardConnection>::new(ns_config.clone(), options.clone())
                 })
                 .collect();
 
@@ -492,10 +481,7 @@ impl<C: DnsHandle + 'static, P: ConnectionProvider<ConnHandle = C> + 'static> Na
             .iter()
             .filter(|ns_config| ns_config.protocol.is_stream())
             .map(|ns_config| {
-                NameServer::<_, StandardConnection>::new(
-                    ns_config.clone(),
-                    options.clone(),
-                )
+                NameServer::<_, StandardConnection>::new(ns_config.clone(), options.clone())
             })
             .collect();
 
@@ -841,19 +827,16 @@ mod tests {
             tls_dns_name: None,
         };
         let mut io_loop = Runtime::new().unwrap();
-        let name_server = future::lazy(|| {
-            future::ok(NameServer::<_, StandardConnection>::new(config, options))
-        });
+        let name_server =
+            future::lazy(|| future::ok(NameServer::<_, StandardConnection>::new(config, options)));
 
         let name = Name::parse("www.example.com.", None).unwrap();
         assert!(
             io_loop
-                .block_on(name_server.and_then(|mut name_server| {
-                    name_server.lookup(
-                        Query::query(name.clone(), RecordType::A),
-                        DnsRequestOptions::default()
-                    )
-                }))
+                .block_on(name_server.and_then(|mut name_server| name_server.lookup(
+                    Query::query(name.clone(), RecordType::A),
+                    DnsRequestOptions::default()
+                )))
                 .is_err()
         );
     }

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -50,7 +50,7 @@ impl DnsHandle for BasicResolverHandle {
     fn send<R: Into<DnsRequest>>(
         &mut self,
         request: R,
-    ) -> Box<Future<Item = DnsResponse, Error = Self::Error>> {
+    ) -> Box<Future<Item = DnsResponse, Error = Self::Error> + Send> {
         Box::new(
             self.message_sender
                 .send(request)
@@ -369,6 +369,10 @@ mod tests {
 
         assert!(is_send_t::<ResolverFuture>());
         assert!(is_sync_t::<ResolverFuture>());
+
+        assert!(is_send_t::<DnsRequest>());
+        assert!(is_send_t::<LookupIpFuture>());
+        assert!(is_send_t::<LookupFuture>());
     }
 
     fn lookup_test(config: ResolverConfig) {

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -352,6 +352,25 @@ mod tests {
 
     use super::*;
 
+    fn is_send_t<T: Send>() -> bool {
+        true
+    }
+
+    fn is_sync_t<T: Sync>() -> bool {
+        true
+    }
+
+    #[test]
+    fn test_send_sync() {
+        assert!(is_send_t::<ResolverConfig>());
+        assert!(is_send_t::<ResolverConfig>());
+        assert!(is_send_t::<ResolverOpts>());
+        assert!(is_sync_t::<ResolverOpts>());
+
+        assert!(is_send_t::<ResolverFuture>());
+        assert!(is_sync_t::<ResolverFuture>());
+    }
+
     fn lookup_test(config: ResolverConfig) {
         let mut io_loop = Runtime::new().unwrap();
         let resolver = ResolverFuture::new(config, ResolverOpts::default());

--- a/scripts/test_default_features.sh
+++ b/scripts/test_default_features.sh
@@ -15,3 +15,6 @@ cargo test --manifest-path rustls/Cargo.toml
 cargo test --manifest-path resolver/Cargo.toml
 cargo test --manifest-path server/Cargo.toml
 cargo test --manifest-path integration-tests/Cargo.toml
+
+# All examples should go here
+cargo run --manifest-path resolver/Cargo.toml --example global_resolver

--- a/server/tests/server_harness/mut_message_client.rs
+++ b/server/tests/server_harness/mut_message_client.rs
@@ -33,7 +33,7 @@ impl<C: ClientHandle> DnsHandle for MutMessageHandle<C> {
     fn send<R: Into<DnsRequest>>(
         &mut self,
         request: R,
-    ) -> Box<Future<Item = DnsResponse, Error = Self::Error>> {
+    ) -> Box<Future<Item = DnsResponse, Error = Self::Error> + Send> {
         let mut request = request.into();
         {
             // mutable block


### PR DESCRIPTION
fixes: #456 

edit, issues for the below will be filed so that this can be merged into master ASAP:

- need to clean up the Client library
- need to refactor DnsHandle send return to IntoFuture, to clean up interefaces
- probably other things as well...
- need an example with global Resolver.

