### PR TITLE
fix for ipv4 early return/search

### DIFF
--- a/integration-tests/src/authority.rs
+++ b/integration-tests/src/authority.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 use trust_dns::rr::*;
 
@@ -164,17 +163,6 @@ pub fn create_example() -> Authority {
     // www.example.com.	86400	IN	RRSIG	TXT 8 3 86400 20150914142952 20150824191224 54108 example.com. LvODnPb7NLDZfHPBOrr/qLnOKA670vVYKQSk5Qkz3MPNKDVAFJqsP2Y6 UYcypSJZfcSjfIk2mU9dUiansU2ZL80OZJUsUobqJt5De748ovITYDJ7 afbohQzPg+4E1GIWMkJZ/VQD3B2pmr7J5rPn+vejxSQSoI93AIQaTpCU L5O/Bac=
     // www.example.com.	86400	IN	RRSIG	AAAA 8 3 86400 20150914082216 20150824191224 54108 example.com. kje4FKE+7d/j4OzWQelcKkePq6DxCRY/5btAiUcZNf+zVNlHK+o57h1r Y76ZviWChQB8Np2TjA1DrXGi/kHr2KKE60H5822mFZ2b9O+sgW4q6o3G kO2E1CQxbYe+nI1Z8lVfjdCNm81zfvYqDjo2/tGqagehxG1V9MBZO6br 4KKdoa4=
     // www.example.com.	86400	IN	RRSIG	A 8 3 86400 20150915023456 20150824191224 54108 example.com. cWtw0nMvcXcYNnxejB3Le3KBfoPPQZLmbaJ8ybdmzBDefQOm1ZjZZMOP wHEIxzdjRhG9mLt1mpyo1H7OezKTGX+mDtskcECTl/+jB/YSZyvbwRxj e88Lrg4D+D2MiajQn3XSWf+6LQVe1J67gdbKTXezvux0tRxBNHHqWXRk pxCILes=
-
-    records.upsert(
-        Record::new()
-            .set_name(Name::from_str("1.2.3.4.example.com.").unwrap())
-            .set_ttl(86400)
-            .set_rr_type(RecordType::A)
-            .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(198, 51, 100, 35)))
-            .clone(),
-        0,
-    );
 
     return records;
 }

--- a/integration-tests/src/authority.rs
+++ b/integration-tests/src/authority.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::str::FromStr;
 
 use trust_dns::rr::*;
 
@@ -97,14 +98,7 @@ pub fn create_example() -> Authority {
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
-                0x2606,
-                0x2800,
-                0x220,
-                0x1,
-                0x248,
-                0x1893,
-                0x25c8,
-                0x1946,
+                0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
             )))
             .clone(),
         0,
@@ -159,14 +153,7 @@ pub fn create_example() -> Authority {
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
-                0x2606,
-                0x2800,
-                0x220,
-                0x1,
-                0x248,
-                0x1893,
-                0x25c8,
-                0x1946,
+                0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
             )))
             .clone(),
         0,
@@ -177,6 +164,17 @@ pub fn create_example() -> Authority {
     // www.example.com.	86400	IN	RRSIG	TXT 8 3 86400 20150914142952 20150824191224 54108 example.com. LvODnPb7NLDZfHPBOrr/qLnOKA670vVYKQSk5Qkz3MPNKDVAFJqsP2Y6 UYcypSJZfcSjfIk2mU9dUiansU2ZL80OZJUsUobqJt5De748ovITYDJ7 afbohQzPg+4E1GIWMkJZ/VQD3B2pmr7J5rPn+vejxSQSoI93AIQaTpCU L5O/Bac=
     // www.example.com.	86400	IN	RRSIG	AAAA 8 3 86400 20150914082216 20150824191224 54108 example.com. kje4FKE+7d/j4OzWQelcKkePq6DxCRY/5btAiUcZNf+zVNlHK+o57h1r Y76ZviWChQB8Np2TjA1DrXGi/kHr2KKE60H5822mFZ2b9O+sgW4q6o3G kO2E1CQxbYe+nI1Z8lVfjdCNm81zfvYqDjo2/tGqagehxG1V9MBZO6br 4KKdoa4=
     // www.example.com.	86400	IN	RRSIG	A 8 3 86400 20150915023456 20150824191224 54108 example.com. cWtw0nMvcXcYNnxejB3Le3KBfoPPQZLmbaJ8ybdmzBDefQOm1ZjZZMOP wHEIxzdjRhG9mLt1mpyo1H7OezKTGX+mDtskcECTl/+jB/YSZyvbwRxj e88Lrg4D+D2MiajQn3XSWf+6LQVe1J67gdbKTXezvux0tRxBNHHqWXRk pxCILes=
+
+    records.upsert(
+        Record::new()
+            .set_name(Name::from_str("1.2.3.4.example.com.").unwrap())
+            .set_ttl(86400)
+            .set_rr_type(RecordType::A)
+            .set_dns_class(DNSClass::IN)
+            .set_rdata(RData::A(Ipv4Addr::new(198, 51, 100, 35)))
+            .clone(),
+        0,
+    );
 
     return records;
 }
@@ -191,7 +189,12 @@ pub fn create_secure_example() -> Authority {
     let rsa = Rsa::generate(2048).unwrap();
     let key = KeyPair::from_rsa(rsa).unwrap();
     let dnskey = key.to_dnskey(Algorithm::RSASHA256).unwrap();
-    let signer = Signer::dnssec(dnskey, key, authority.origin().clone().into(), Duration::weeks(1));
+    let signer = Signer::dnssec(
+        dnskey,
+        key,
+        authority.origin().clone().into(),
+        Duration::weeks(1),
+    );
 
     authority.add_secure_key(signer);
     authority.secure_zone();

--- a/integration-tests/tests/lookup_tests.rs
+++ b/integration-tests/tests/lookup_tests.rs
@@ -90,6 +90,7 @@ fn test_lookup_hosts() {
             CachingClient::new(0, client),
             Default::default(),
             Some(Arc::new(hosts)),
+            None,
         )
     });
     let lookup = io_loop.block_on(lookup).unwrap();


### PR DESCRIPTION
If ndots is greater than for, then this skips the early return of the IP address, and delays that until the final result after performing all other queries.

fixes: #431