### PR TITLE
Prepare 0.14 Client/Server and 0.9 Resolver releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated `trust-dns-proto` to `0.3`, which brings in better `Name` and `Label` impls
 - rusqlite updated to 0.13 #331 (@oherrala)
 - Many serialization improvements #317
+- Use tokio-timer (part of tokio upgrade) @justinlatimer #411
+- Backtrace now optional @briansmith #416
+- Use tokio-tcp (part of tokio upgrade) @Keruspe #426
+- Use tokio-udp (part of tokio upgrade) @Keruspe #426
+- Upgrade to tokio-executor (tokio upgrade) @Keruspe and @justinlatimer #438
+- Send (Sync where applicable) enforced on all DnsHandle::send and other interfaces #460
+- ClientHandle api return Send @ariwaranosai #465
 
 ### Added
 
@@ -20,6 +27,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - octal escapes fixed in `Name` parsing #330
 - `NULL` record type incorrectly valued at `0` to proper `10` #329 (@jannic)
+- BinEncoder panic on record sets of extreme sizes #352
+- Panic when oneshot channel receiver goes away #356
+- Hung server on UDP due to bad data #407
+
+### Removed
+
+- usage of tokio-core::Core @Keruspe #446
 
 ## 0.13.0
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -65,7 +65,7 @@ rand = "^0.4"
 ring = { version = "^0.12", optional = true }
 tokio = "^0.1.6"
 tokio-tcp = "^0.1"
-trust-dns-proto = {version = "^0.3", path = "../proto", features = ["dnssec"] }
+trust-dns-proto = {version = "^0.4", path = "../proto", features = ["dnssec"] }
 untrusted = { version = "^0.5", optional = true }
 
 [dev-dependencies]

--- a/native-tls/Cargo.toml
+++ b/native-tls/Cargo.toml
@@ -49,7 +49,7 @@ native-tls = "^0.1"
 tokio-tcp = "^0.1"
 tokio-tls = "^0.1"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "^0.3", path = "../proto", default-features = false }
+trust-dns-proto = { version = "^0.4", path = "../proto", default-features = false }
 
 [dev-dependencies]
 tokio = "^0.1.6"

--- a/native-tls/Cargo.toml
+++ b/native-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns-native-tls"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -46,7 +46,7 @@ futures = "^0.1.17"
 openssl = { version = "^0.10", features = ["v102", "v110"] }
 tokio-openssl = "^0.2"
 tokio-tcp = "^0.1"
-trust-dns-proto = { version = "^0.3", path = "../proto" }
+trust-dns-proto = { version = "^0.4", path = "../proto" }
 
 [dev-dependencies]
 openssl = { version = "^0.10", features = ["v102", "v110"] }

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns-openssl"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns-proto"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when

--- a/resolver/CHANGELOG.md
+++ b/resolver/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Experimental DNS-SD, service discovery (RFC 6763, `mdns` feature required) #363
 - Experimental mDNS, multicast DNS, known issues persist (RFC 6762, `mdns` feature required) #337
 - Exposed TTLs on `Lookup` objects @hawkw #444
+- Added global resolver example #460
 
 ### Changed
 
@@ -30,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Properly yield on failure to acquire lock #372
 - Correct order of search list with ndots variable #410
 - Send (Sync where applicable) enforced on all DnsHandle::send and other interfaces #460
+- Properly track max query depth as a `task_local` not `thread_local` #460, #469
 
 ### Removed
 

--- a/resolver/CHANGELOG.md
+++ b/resolver/CHANGELOG.md
@@ -7,11 +7,33 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- dns-over-tls configurations (requires one of `dns-over-native-tls` or `dns-over-rustls` features)
+- DNS-over-TLS configurations (requires one of `dns-over-native-tls` or `dns-over-rustls` features) #396
+- Experimental DNS-SD, service discovery (RFC 6763, `mdns` feature required) #363
+- Experimental mDNS, multicast DNS, known issues persist (RFC 6762, `mdns` feature required) #337
+- Exposed TTLs on `Lookup` objects @hawkw #444
 
 ### Changed
 
-- enforced all resolver futures are Sendable
+- Use tokio-timer (part of tokio upgrade) @justinlatimer #411
+- Backtrace now optional @briansmith #416
+- Upgrade to tokio-tcp (tokio upgrade) @Keruspe #426
+- Upgrade to tokio-udp (tokio upgrade) @Keruspe #427
+- Upgrade to tokio-executor (tokio upgrade) @Keruspe and @justinlatimer #438
+- Always reattempt nameserver reconnections regardless of time #457
+- Defaulted type parameter for LookupFuture, removed InnerLookupFuture #459
+
+### Fixed
+
+- BinEncoder panic on record sets of extreme sizes #352
+- Panic when oneshot channel receiver goes away #356
+- Incorrect IPv6 configuration for Google nameservers #358
+- Properly yield on failure to acquire lock #372
+- Correct order of search list with ndots variable #410
+- Send (Sync where applicable) enforced on all DnsHandle::send and other interfaces #460
+
+### Removed
+
+- usage of tokio-core::Core @Keruspe #446
 
 ## 0.8.1
 

--- a/resolver/CHANGELOG.md
+++ b/resolver/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Correct order of search list with ndots variable #410
 - Send (Sync where applicable) enforced on all DnsHandle::send and other interfaces #460
 - Properly track max query depth as a `task_local` not `thread_local` #460, #469
+- IPv4 like name resolution in lookup_ip with search order #467
 
 ### Removed
 

--- a/resolver/CHANGELOG.md
+++ b/resolver/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.9
+
+### Added
+
+- dns-over-tls configurations (requires one of `dns-over-native-tls` or `dns-over-rustls` features)
+
+### Changed
+
+- enforced all resolver futures are Sendable
+
 ## 0.8.1
 
 ### Changed

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -62,10 +62,10 @@ resolv-conf = { version = "0.6.0", features = ["system"] }
 rustls = {version  = "^0.11", optional = true} 
 smallvec = "^0.6"
 tokio = "^0.1.6"
-trust-dns-native-tls = { version = "^0.2", path = "../native-tls", optional = true }
-trust-dns-openssl = { version = "^0.2", path = "../openssl", optional = true }
-trust-dns-proto = { version = "^0.3", path = "../proto" }
-trust-dns-rustls = { version = "^0.2", path = "../rustls", optional = true }
+trust-dns-native-tls = { version = "^0.3", path = "../native-tls", optional = true }
+trust-dns-openssl = { version = "^0.3", path = "../openssl", optional = true }
+trust-dns-proto = { version = "^0.4", path = "../proto" }
+trust-dns-rustls = { version = "^0.3", path = "../rustls", optional = true }
 webpki-roots = { version = "^0.13", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns-resolver"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -49,7 +49,7 @@ rustls = "^0.11"
 tokio-rustls = "^0.4"
 tokio-tcp = "^0.1"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "^0.3", path = "../proto", default-features = false }
+trust-dns-proto = { version = "^0.4", path = "../proto", default-features = false }
 
 [dev-dependencies]
 openssl = { version = "^0.10", features = ["v102", "v110"] }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns-rustls"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -88,11 +88,11 @@ tokio-tcp = "^0.1"
 tokio-timer = "^0.2"
 tokio-udp = "^0.1"
 toml = "^0.4"
-trust-dns = { version = "^0.13", path = "../client" }
-trust-dns-proto = { version = "^0.3", path = "../proto" }
-trust-dns-openssl = { version = "^0.2.0", path = "../openssl", optional = true }
+trust-dns = { version = "^0.14", path = "../client" }
+trust-dns-proto = { version = "^0.4", path = "../proto" }
+trust-dns-openssl = { version = "^0.3", path = "../openssl", optional = true }
 
 [dev-dependencies]
 native-tls = "^0.1"
-trust-dns-native-tls = { version = "^0.2", path = "../native-tls" }
+trust-dns-native-tls = { version = "^0.3", path = "../native-tls" }
 tokio-tls = "^0.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns-server"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -45,7 +45,7 @@ path = "src/pem_to_public_dnskey.rs"
 [dependencies]
 clap = "^2.23.3"
 data-encoding = "2.1.0"
-trust-dns = { version = "0.13.0", features = ["dnssec-openssl"], path = "../client" }
+trust-dns = { version = "0.14", features = ["dnssec-openssl"], path = "../client" }
 env_logger = "0.5"
 log = "^0.4.1"
 openssl = { version = "^0.10", features = ["v102", "v110"] }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns-util"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when


### PR DESCRIPTION
once #467 lands, then these releases are ready to go.