### PR TITLE
fix max query deptch tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Cargo.lock
 
 *.rs.bk
 .rls.toml
+rls/**

--- a/resolver/examples/global_resolver.rs
+++ b/resolver/examples/global_resolver.rs
@@ -135,7 +135,7 @@ fn main() {
 
     // print the resolved IPs
     for (name, join) in threads {
-        let result = join.join();
+        let result = join.join().expect(&format!("error resolving: {}", name));
         println!("{} resolved to {:?}", name, result);
     }
 }


### PR DESCRIPTION
The original patch to this issue was incorrect.
This better, it relies on the task cleanup to remove the QUERY_DEPTH, thus we only need to track the increments.

also fixes the global resolver example to fail if the tests fail.