### PR TITLE
Migrate proto from error-chain to failure

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -55,7 +55,7 @@ path = "src/lib.rs"
 chrono = "^0.4"
 data-encoding = "2.1.0"
 data-encoding-macro = "0.1.1"
-error-chain = { version = "0.1.12", default-features = false }
+failure = "0.1"
 futures = "^0.1.17"
 lazy_static = "^1.0"
 log = "^0.4.1"

--- a/client/src/client/client.rs
+++ b/client/src/client/client.rs
@@ -14,7 +14,9 @@
 
 use std::sync::Arc;
 
-use futures::{future, Future};
+#[cfg(feature = "dnssec")]
+use futures::future;
+use futures::Future;
 use tokio::runtime::current_thread::Runtime;
 
 use trust_dns_proto::xfer::DnsResponse;

--- a/client/src/error/mod.rs
+++ b/client/src/error/mod.rs
@@ -13,31 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(missing_docs)]
 
 //! All defined errors for Trust-DNS
 
-mod dnssec_error;
+#![deny(missing_docs)]
+
 mod client_error;
+mod dnssec_error;
 mod lexer_error;
 mod parse_error;
 
-pub use self::dnssec_error::Error as DnsSecError;
 pub use self::client_error::Error as ClientError;
+pub use self::dnssec_error::Error as DnsSecError;
 pub use self::lexer_error::Error as LexerError;
 pub use self::parse_error::Error as ParseError;
 
-pub use self::dnssec_error::ErrorKind as DnsSecErrorKind;
 pub use self::client_error::ErrorKind as ClientErrorKind;
+pub use self::dnssec_error::ErrorKind as DnsSecErrorKind;
 pub use self::lexer_error::ErrorKind as LexerErrorKind;
 pub use self::parse_error::ErrorKind as ParseErrorKind;
 
-pub use self::dnssec_error::ChainErr as DnsSecChainErr;
-pub use self::client_error::ChainErr as ClientChainErr;
-pub use self::lexer_error::ChainErr as LexerChainErr;
-pub use self::parse_error::ChainErr as ParseChainErr;
-
-pub use self::dnssec_error::Result as DnsSecResult;
 pub use self::client_error::Result as ClientResult;
+pub use self::dnssec_error::Result as DnsSecResult;
 pub use self::lexer_error::Result as LexerResult;
 pub use self::parse_error::Result as ParseResult;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -209,7 +209,7 @@ extern crate data_encoding;
 #[macro_use]
 extern crate data_encoding_macro;
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 extern crate futures;
 #[macro_use]
 extern crate lazy_static;

--- a/client/src/rr/dnssec/mod.rs
+++ b/client/src/rr/dnssec/mod.rs
@@ -41,7 +41,6 @@ pub use self::dnssec::Verifier;
 
 pub use error::DnsSecError;
 pub use error::DnsSecErrorKind;
-pub use error::DnsSecChainErr;
 pub use error::DnsSecResult;
 
 #[cfg(all(not(feature = "ring"), feature = "openssl"))]

--- a/client/src/serialize/txt/master.rs
+++ b/client/src/serialize/txt/master.rs
@@ -392,7 +392,7 @@ impl Parser {
                 '0'...'9' => {
                     collect *= 10;
                     collect += c.to_digit(10)
-                        .ok_or_else(|| ParseErrorKind::CharToIntError(c))?;
+                        .ok_or_else(|| ParseErrorKind::CharToInt(c))?;
                 }
                 'S' | 's' => {
                     value += collect;
@@ -414,7 +414,7 @@ impl Parser {
                     value += collect * 604_800;
                     collect = 0;
                 }
-                _ => return Err(ParseErrorKind::ParseTimeError(ttl_str.to_string()).into()),
+                _ => return Err(ParseErrorKind::ParseTime(ttl_str.to_string()).into()),
             }
         }
 

--- a/client/src/serialize/txt/master_lex.rs
+++ b/client/src/serialize/txt/master_lex.rs
@@ -344,7 +344,7 @@ pub enum State {
 }
 
 /// Tokens emited from each Lexer pass
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum Token {
     /// only if the first part of the line
     Blank,

--- a/integration-tests/src/authority.rs
+++ b/integration-tests/src/authority.rs
@@ -97,7 +97,14 @@ pub fn create_example() -> Authority {
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
-                0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
+                0x2606,
+                0x2800,
+                0x220,
+                0x1,
+                0x248,
+                0x1893,
+                0x25c8,
+                0x1946,
             )))
             .clone(),
         0,
@@ -152,7 +159,14 @@ pub fn create_example() -> Authority {
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
-                0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
+                0x2606,
+                0x2800,
+                0x220,
+                0x1,
+                0x248,
+                0x1893,
+                0x25c8,
+                0x1946,
             )))
             .clone(),
         0,
@@ -177,12 +191,7 @@ pub fn create_secure_example() -> Authority {
     let rsa = Rsa::generate(2048).unwrap();
     let key = KeyPair::from_rsa(rsa).unwrap();
     let dnskey = key.to_dnskey(Algorithm::RSASHA256).unwrap();
-    let signer = Signer::dnssec(
-        dnskey,
-        key,
-        authority.origin().clone().into(),
-        Duration::weeks(1),
-    );
+    let signer = Signer::dnssec(dnskey, key, authority.origin().clone().into(), Duration::weeks(1));
 
     authority.add_secure_key(signer);
     authority.secure_zone();

--- a/integration-tests/tests/client_future_tests.rs
+++ b/integration-tests/tests/client_future_tests.rs
@@ -17,6 +17,7 @@ use openssl::rsa::Rsa;
 use tokio::runtime::current_thread::Runtime;
 
 use trust_dns::client::{BasicClientHandle, ClientFuture, ClientHandle};
+use trust_dns::error::ClientErrorKind;
 use trust_dns::op::ResponseCode;
 use trust_dns::rr::dnssec::{Algorithm, KeyPair, Signer};
 use trust_dns::rr::rdata::{DNSSECRData, DNSSECRecordType};
@@ -785,11 +786,7 @@ fn test_timeout_query(mut client: BasicClientHandle, mut io_loop: Runtime) {
         .block_on(client.query(name.clone(), DNSClass::IN, RecordType::A))
         .unwrap_err();
 
-    let error_str = format!("{}", err);
-    assert!(
-        error_str.contains("timed out"),
-        format!("actual error: {}", error_str)
-    );
+    assert_eq!(err.kind(), &ClientErrorKind::Timeout);
 
     io_loop
         .block_on(client.query(name.clone(), DNSClass::IN, RecordType::AAAA))

--- a/integration-tests/tests/client_tests.rs
+++ b/integration-tests/tests/client_tests.rs
@@ -19,7 +19,7 @@ use openssl::rsa::Rsa;
 
 #[allow(deprecated)]
 use trust_dns::client::{Client, ClientConnection, SecureSyncClient, SyncClient};
-use trust_dns::error::{ClientError, ClientResult};
+use trust_dns::error::{ClientError, ClientErrorKind, ClientResult};
 use trust_dns::op::*;
 use trust_dns::rr::dnssec::{Algorithm, KeyPair, Signer};
 use trust_dns::rr::rdata::*;
@@ -190,11 +190,7 @@ where
 
     let err = response.unwrap_err();
 
-    let error_str = format!("{}", err);
-    assert!(
-        error_str.contains("timed out"),
-        format!("actual error: {}", error_str)
-    );
+    assert_eq!(err.kind(), &ClientErrorKind::Timeout);
 }
 
 #[test]

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -52,7 +52,7 @@ path = "src/lib.rs"
 [dependencies]
 byteorder = "^1.2"
 data-encoding = { version = "2.1.0", optional = true }
-error-chain = { version = "0.1.12", default-features = false }
+failure = "0.1"
 futures = "^0.1.17"
 idna = "^0.1.4"
 lazy_static = "^1.0"

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -17,7 +17,7 @@ extern crate data_encoding;
 #[cfg(test)]
 extern crate env_logger;
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 #[macro_use]
 extern crate futures;
 extern crate idna;

--- a/proto/src/op/message.rs
+++ b/proto/src/op/message.rs
@@ -612,9 +612,7 @@ impl Message {
 
             if !is_additional {
                 if saw_sig0 {
-                    return Err(
-                        ProtoErrorKind::Message("sig0 must be final resource record").into(),
-                    );
+                    return Err("sig0 must be final resource record".into());
                 } // SIG0 must be last
                 records.push(record)
             } else {
@@ -626,31 +624,16 @@ impl Message {
                     }
                     RecordType::OPT => {
                         if saw_sig0 {
-                            return Err(
-                                ProtoErrorKind::Message(
-                                    "sig0 must be final resource \
-                                     record",
-                                ).into(),
-                            );
+                            return Err("sig0 must be final resource record".into());
                         } // SIG0 must be last
                         if edns.is_some() {
-                            return Err(
-                                ProtoErrorKind::Message(
-                                    "more than one edns record \
-                                     present",
-                                ).into(),
-                            );
+                            return Err("more than one edns record present".into());
                         }
                         edns = Some((&record).into());
                     }
                     _ => {
                         if saw_sig0 {
-                            return Err(
-                                ProtoErrorKind::Message(
-                                    "sig0 must be final resource \
-                                     record",
-                                ).into(),
-                            );
+                            return Err("sig0 must be final resource record".into());
                         } // SIG0 must be last
                         records.push(record);
                     }

--- a/proto/src/op/op_code.rs
+++ b/proto/src/op/op_code.rs
@@ -96,7 +96,7 @@ impl OpCode {
             2 => Ok(OpCode::Status),
             4 => Ok(OpCode::Notify),
             5 => Ok(OpCode::Update),
-            _ => Err(ProtoErrorKind::Msg(format!("unknown OpCode: {}", value)).into()),
+            _ => Err(format!("unknown OpCode: {}", value).into()),
         }
     }
 }

--- a/proto/src/rr/dnssec/digest_type.rs
+++ b/proto/src/rr/dnssec/digest_type.rs
@@ -72,9 +72,7 @@ impl DigestType {
             DigestType::SHA256 => Ok(hash::MessageDigest::sha256()),
             DigestType::SHA384 => Ok(hash::MessageDigest::sha384()),
             DigestType::SHA512 => Ok(hash::MessageDigest::sha512()),
-            _ => Err(
-                ProtoErrorKind::Msg(format!("digest not supported by openssl: {:?}", self)).into(),
-            ),
+            _ => Err(format!("digest not supported by openssl: {:?}", self).into()),
         }
     }
 
@@ -86,9 +84,7 @@ impl DigestType {
             DigestType::SHA256 => Ok(&digest::SHA256),
             DigestType::SHA384 => Ok(&digest::SHA384),
             DigestType::SHA512 => Ok(&digest::SHA512),
-            _ => {
-                Err(ProtoErrorKind::Msg(format!("digest not supported by ring: {:?}", self)).into())
-            }
+            _ => Err(format!("digest not supported by ring: {:?}", self).into()),
         }
     }
 
@@ -108,7 +104,7 @@ impl DigestType {
     /// This will always error, enable openssl feature at compile time
     #[cfg(not(any(feature = "openssl", feature = "ring")))]
     pub fn hash(&self, _: &[u8]) -> ProtoResult<Vec<u8>> {
-        Err(ProtoErrorKind::Message("The openssl and ring features are both disabled").into())
+        Err("The openssl and ring features are both disabled".into())
     }
 
     /// Digest all the data.

--- a/proto/src/rr/dnssec/public_key.rs
+++ b/proto/src/rr/dnssec/public_key.rs
@@ -80,7 +80,7 @@ fn verify_with_pkey(
             if b {
                 Ok(())
             } else {
-                Err(ProtoErrorKind::Message("could not verify").into())
+                Err("could not verify".into())
             }
         })
 }
@@ -285,13 +285,11 @@ impl<'k> Ed25519<'k> {
     /// ```
     pub fn from_public_bytes(public_key: &'k [u8]) -> ProtoResult<Self> {
         if public_key.len() != ED25519_PUBLIC_KEY_LEN {
-            return Err(
-                ProtoErrorKind::Msg(format!(
-                    "expected {} byte public_key: {}",
-                    ED25519_PUBLIC_KEY_LEN,
-                    public_key.len()
-                )).into(),
-            );
+            return Err(format!(
+                "expected {} byte public_key: {}",
+                ED25519_PUBLIC_KEY_LEN,
+                public_key.len()
+            ).into());
         }
 
         Ok(Ed25519 { raw: public_key })

--- a/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -226,7 +226,7 @@ impl DNSKEY {
                 .and_then(|_| emit(&mut encoder, self))
             {
                 warn!("error serializing dnskey: {}", e);
-                return Err(ProtoErrorKind::Msg(format!("error serializing dnskey: {}", e)).into());
+                return Err(format!("error serializing dnskey: {}", e).into());
             }
         }
 
@@ -236,7 +236,7 @@ impl DNSKEY {
     /// This will always return an error unless the Ring or OpenSSL features are enabled
     #[cfg(not(any(feature = "openssl", feature = "ring")))]
     pub fn to_digest(&self, _: &Name, _: DigestType) -> ProtoResult<Digest> {
-        Err(ProtoErrorKind::Message("Ring or OpenSSL must be enabled for this feature").into())
+        Err("Ring or OpenSSL must be enabled for this feature".into())
     }
 }
 

--- a/proto/src/rr/dnssec/rdata/ds.rs
+++ b/proto/src/rr/dnssec/rdata/ds.rs
@@ -180,7 +180,7 @@ impl DS {
     /// This will always return an error unless the Ring or OpenSSL features are enabled
     #[cfg(not(any(feature = "openssl", feature = "ring")))]
     pub fn covers(&self, _: &Name, _: &DNSKEY) -> ProtoResult<bool> {
-        Err(ProtoErrorKind::Message("Ring or OpenSSL must be enabled for this feature").into())
+        Err("Ring or OpenSSL must be enabled for this feature".into())
     }
 }
 

--- a/proto/src/rr/dnssec/rdata/key.rs
+++ b/proto/src/rr/dnssec/rdata/key.rs
@@ -757,7 +757,7 @@ impl KEY {
     //         if let Err(e) = name.emit(&mut encoder)
     //                .and_then(|_| emit(&mut encoder, self)) {
     //             warn!("error serializing KEY: {}", e);
-    //             return Err(ProtoErrorKind::Msg(format!("error serializing KEY: {}", e)).into());
+    //             return Err(format!("error serializing KEY: {}", e).into());
     //         }
     //     }
 

--- a/proto/src/rr/dnssec/rsa_public_key.rs
+++ b/proto/src/rr/dnssec/rsa_public_key.rs
@@ -20,12 +20,12 @@ impl<'a> RSAPublicKey<'a> {
             }
             Some(e_len) if *e_len != 0 => (1, usize::from(*e_len)),
             _ => {
-                return Err(ProtoErrorKind::Message("bad public key").into());
+                return Err("bad public key".into());
             }
         };
 
         if encoded.len() < e_len_len + e_len {
-            return Err(ProtoErrorKind::Message("bad public key").into());
+            return Err("bad public key".into());
         };
 
         let (e, n) = encoded[e_len_len..].split_at(e_len);

--- a/proto/src/rr/dnssec/tbs.rs
+++ b/proto/src/rr/dnssec/tbs.rs
@@ -106,7 +106,7 @@ pub fn rrset_tbs(
     let name: Name = if let Some(name) = determine_name(name, num_labels) {
         name
     } else {
-        return Err(ProtoErrorKind::Msg(format!("could not determine name from {}", name)).into());
+        return Err(format!("could not determine name from {}", name).into());
     };
 
     // TODO: rather than buffering here, use the Signer/Verifier? might mean fewer allocations...
@@ -190,9 +190,7 @@ pub fn rrset_tbs_with_rrsig(rrsig: &Record, records: &[Record]) -> ProtoResult<T
     if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *rrsig.rdata() {
         rrset_tbs_with_sig(rrsig.name(), rrsig.dns_class(), sig, records)
     } else {
-        return Err(
-            ProtoErrorKind::Msg(format!("could not determine name from {}", rrsig.name())).into(),
-        );
+        return Err(format!("could not determine name from {}", rrsig.name()).into());
     }
 }
 
@@ -229,7 +227,6 @@ pub fn rrset_tbs_with_sig(
         records,
     )
 }
-
 
 /// [RFC 4035](https://tools.ietf.org/html/rfc4035), DNSSEC Protocol Modifications, March 2005
 ///

--- a/proto/src/rr/domain/label.rs
+++ b/proto/src/rr/domain/label.rs
@@ -36,10 +36,7 @@ impl Label {
     /// Generally users should use `from_str` or `from_ascii`
     pub fn from_raw_bytes(bytes: &[u8]) -> ProtoResult<Self> {
         if bytes.len() > 63 {
-            return Err(ProtoErrorKind::Msg(format!(
-                "Label exceeds maximum length 63: {}",
-                bytes.len()
-            )).into());
+            return Err(format!("Label exceeds maximum length 63: {}", bytes.len()).into());
         };
         Ok(Label(Rc::from(bytes)))
     }
@@ -64,10 +61,7 @@ impl Label {
             },
         ) {
             Ok(puny) => Self::from_ascii(&puny),
-            Err(e) => Err(ProtoErrorKind::Msg(format!(
-                "Label contains invalid characters: {:?}",
-                e
-            )).into()),
+            Err(e) => Err(format!("Label contains invalid characters: {:?}", e).into()),
         }
     }
 
@@ -84,7 +78,7 @@ impl Label {
         {
             Label::from_raw_bytes(s.as_bytes())
         } else {
-            Err(ProtoErrorKind::Msg(format!("Malformed label: {}", s)).into())
+            Err(format!("Malformed label: {}", s).into())
         }
     }
 

--- a/proto/src/rr/rdata/caa.rs
+++ b/proto/src/rr/rdata/caa.rs
@@ -505,12 +505,7 @@ pub fn read_issuer(bytes: &[u8]) -> ProtoResult<(Option<Name>, Vec<KeyValue>)> {
 
                         state = ParseNameKeyPairState::Key { key, key_values }
                     }
-                    ch => {
-                        return Err(
-                            ProtoErrorKind::Msg(format!("bad character in CAA issuer key: {}", ch))
-                                .into(),
-                        )
-                    }
+                    ch => return Err(format!("bad character in CAA issuer key: {}", ch).into()),
                 }
             }
             ParseNameKeyPairState::Key {
@@ -533,12 +528,7 @@ pub fn read_issuer(bytes: &[u8]) -> ProtoResult<(Option<Name>, Vec<KeyValue>)> {
 
                         state = ParseNameKeyPairState::Key { key, key_values }
                     }
-                    ch => {
-                        return Err(
-                            ProtoErrorKind::Msg(format!("bad character in CAA issuer key: {}", ch))
-                                .into(),
-                        )
-                    }
+                    ch => return Err(format!("bad character in CAA issuer key: {}", ch).into()),
                 }
             }
             ParseNameKeyPairState::Value {
@@ -562,13 +552,7 @@ pub fn read_issuer(bytes: &[u8]) -> ProtoResult<(Option<Name>, Vec<KeyValue>)> {
                             key_values,
                         }
                     }
-                    ch => {
-                        return Err(
-                            ProtoErrorKind::Msg(
-                                format!("bad character in CAA issuer value: {}", ch),
-                            ).into(),
-                        )
-                    }
+                    ch => return Err(format!("bad character in CAA issuer value: {}", ch).into()),
                 }
             }
         }
@@ -587,7 +571,7 @@ pub fn read_issuer(bytes: &[u8]) -> ProtoResult<(Option<Name>, Vec<KeyValue>)> {
             key_values
         }
         ParseNameKeyPairState::Key { key, .. } => {
-            return Err(ProtoErrorKind::Msg(format!("key missing value: {}", key)).into())
+            return Err(format!("key missing value: {}", key).into())
         }
     };
 
@@ -745,7 +729,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<CAA> {
 // TODO: change this to return &str
 fn read_tag(decoder: &mut BinDecoder, len: u8) -> ProtoResult<String> {
     if len == 0 || len > 15 {
-        return Err(ProtoErrorKind::Message("CAA tag length out of bounds, 1-15").into());
+        return Err("CAA tag length out of bounds, 1-15".into());
     }
     let mut tag = String::with_capacity(len as usize);
 
@@ -756,7 +740,7 @@ fn read_tag(decoder: &mut BinDecoder, len: u8) -> ProtoResult<String> {
             ch @ 'a'...'z' | ch @ 'A'...'Z' | ch @ '0'...'9' => {
                 tag.push(ch);
             }
-            _ => return Err(ProtoErrorKind::Message("CAA tag character(s) out of bounds").into()),
+            _ => return Err("CAA tag character(s) out of bounds".into()),
         }
     }
 
@@ -770,16 +754,14 @@ fn emit_tag(buf: &mut [u8], tag: &Property) -> ProtoResult<u8> {
 
     let len = property.len();
     if len > ::std::u8::MAX as usize {
-        return Err(ProtoErrorKind::Msg(format!("CAA property too long: {}", len)).into());
+        return Err(format!("CAA property too long: {}", len).into());
     }
     if buf.len() < len {
-        return Err(
-            ProtoErrorKind::Msg(format!(
-                "insufficient capacity in CAA buffer: {} for tag: {}",
-                buf.len(),
-                len
-            )).into(),
-        );
+        return Err(format!(
+            "insufficient capacity in CAA buffer: {} for tag: {}",
+            buf.len(),
+            len
+        ).into());
     }
 
     // copy into the buffer

--- a/proto/src/rr/rdata/null.rs
+++ b/proto/src/rr/rdata/null.rs
@@ -68,7 +68,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<NULL> {
             if let Ok(byte) = decoder.pop() {
                 anything.push(byte);
             } else {
-                return Err(ProtoErrorKind::Message("unexpected end of input reached").into());
+                return Err("unexpected end of input reached".into());
             }
         }
 

--- a/proto/src/rr/record_data.rs
+++ b/proto/src/rr/record_data.rs
@@ -491,9 +491,10 @@ impl RData {
         // we should have read rdata_length, but we did not
         let read = decoder.index() - start_idx;
         if read != rdata_length as usize {
-            return Err(
-                ProtoErrorKind::IncorrectRDataLengthRead(read, rdata_length as usize).into(),
-            );
+            return Err(ProtoErrorKind::IncorrectRDataLengthRead {
+                read,
+                len: rdata_length as usize,
+            }.into());
         }
 
         result

--- a/proto/src/serialize/binary/decoder.rs
+++ b/proto/src/serialize/binary/decoder.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-use error::{ProtoErrorKind, ProtoResult};
 use byteorder::{ByteOrder, NetworkEndian};
+use error::ProtoResult;
 
 /// This is non-destructive to the inner buffer, b/c for pointer types we need to perform a reverse
 ///  seek to lookup names
@@ -49,7 +49,7 @@ impl<'a> BinDecoder<'a> {
             self.index += 1;
             Ok(byte)
         } else {
-            Err(ProtoErrorKind::Message("unexpected end of input reached").into())
+            Err("unexpected end of input reached".into())
         }
     }
 
@@ -135,7 +135,7 @@ impl<'a> BinDecoder<'a> {
     pub fn read_slice(&mut self, len: usize) -> ProtoResult<&'a [u8]> {
         let end = self.index + len;
         if end > self.buffer.len() {
-            return Err(ProtoErrorKind::Message("buffer exhausted").into());
+            return Err("buffer exhausted".into());
         }
         let slice: &'a [u8] = &self.buffer[self.index..end];
         self.index += len;
@@ -145,7 +145,7 @@ impl<'a> BinDecoder<'a> {
     /// Reads a slice from a previous index to the current
     pub fn slice_from(&self, index: usize) -> ProtoResult<&'a [u8]> {
         if index > self.index {
-            return Err(ProtoErrorKind::Message("index antecedes upper bound").into());
+            return Err("index antecedes upper bound".into());
         }
 
         Ok(&self.buffer[index..self.index])

--- a/proto/src/serialize/binary/encoder.rs
+++ b/proto/src/serialize/binary/encoder.rs
@@ -524,7 +524,7 @@ mod tests {
         encoder.emit(4).expect("failed to write");
         let error = encoder.emit(5).unwrap_err();
 
-        match error.into_kind() {
+        match *error.kind() {
             ProtoErrorKind::MaxBufferSizeExceeded(_) => (),
             _ => assert!(false),
         }
@@ -538,7 +538,7 @@ mod tests {
         encoder.set_max_size(0);
         let error = encoder.emit(0).unwrap_err();
 
-        match error.into_kind() {
+        match *error.kind() {
             ProtoErrorKind::MaxBufferSizeExceeded(_) => (),
             _ => assert!(false),
         }
@@ -555,7 +555,7 @@ mod tests {
 
         let error = encoder.place::<u16>().unwrap_err();
 
-        match error.into_kind() {
+        match *error.kind() {
             ProtoErrorKind::MaxBufferSizeExceeded(_) => (),
             _ => assert!(false),
         }

--- a/proto/src/xfer/dns_handle.rs
+++ b/proto/src/xfer/dns_handle.rs
@@ -61,7 +61,7 @@ where
 
     fn send(&mut self, buffer: Vec<u8>) -> Result<(), Self::Error> {
         UnboundedSender::unbounded_send(&self.sender, buffer)
-            .map_err(|e| E::from(ProtoErrorKind::Msg(format!("mpsc::SendError {}", e)).into()))
+            .map_err(|e| E::from(format!("mpsc::SendError {}", e).into()))
     }
 }
 
@@ -103,7 +103,7 @@ where
             Err(e) => {
                 let (complete, receiver) = oneshot::channel();
                 ignore_send(complete.send(Err(E::from(
-                    ProtoErrorKind::Msg(format!("error sending to channel: {}", e)).into(),
+                    format!("error sending to channel: {}", e).into(),
                 ))));
                 receiver
             }

--- a/proto/src/xfer/mod.rs
+++ b/proto/src/xfer/mod.rs
@@ -108,6 +108,6 @@ where
         sender
             .sender
             .unbounded_send((buffer, name_server))
-            .map_err(|e| E::from(ProtoErrorKind::Msg(format!("mpsc::SendError {}", e)).into()))
+            .map_err(|e| E::from(format!("mpsc::SendError {}", e).into()))
     }
 }

--- a/proto/src/xfer/retry_dns_handle.rs
+++ b/proto/src/xfer/retry_dns_handle.rs
@@ -139,9 +139,7 @@ mod test {
             }
 
             self.attempts.set(i + 1);
-            return Box::new(failed(
-                ProtoErrorKind::Message("last retry set to fail").into(),
-            ));
+            return Box::new(failed(ProtoError::from("last retry set to fail").into()));
         }
     }
 

--- a/proto/src/xfer/secure_dns_handle.rs
+++ b/proto/src/xfer/secure_dns_handle.rs
@@ -118,9 +118,7 @@ where
 
         // backstop, this might need to be configurable at some point
         if self.request_depth > 20 {
-            return Box::new(failed(E::from(
-                ProtoErrorKind::Message("exceeded max validation depth").into(),
-            )));
+            return Box::new(failed(E::from("exceeded max validation depth".into())));
         }
 
         // dnssec only matters on queries.
@@ -187,12 +185,7 @@ where
 
                             if !verify_nsec(&query, nsecs.as_slice()) {
                                 // TODO change this to remove the NSECs, like we do for the others?
-                                return Err(E::from(
-                                    ProtoErrorKind::Message(
-                                        "could not validate nxdomain \
-                                         with NSEC",
-                                    ).into(),
-                                ));
+                                return Err(E::from("could not validate nxdomain with NSEC".into()));
                             }
                         }
 
@@ -746,7 +739,10 @@ where
     // if there are no available verifications, then we are in a failed state.
     if verifications.is_empty() {
         return Box::new(failed(E::from(
-            ProtoErrorKind::RrsigsNotPresent(rrset.name.clone(), rrset.record_type).into(),
+            ProtoErrorKind::RrsigsNotPresent {
+                name: rrset.name.clone(),
+                record_type: rrset.record_type,
+            }.into(),
         )));
     }
 

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -53,7 +53,7 @@ path = "src/lib.rs"
 
 [dependencies]
 cfg-if = "0.1"
-error-chain = { version = "0.1.12", default-features = false }
+failure = "0.1"
 futures = "^0.1.17"
 lazy_static = "^1.0"
 log = "^0.4.1"

--- a/resolver/src/lib.rs
+++ b/resolver/src/lib.rs
@@ -165,7 +165,7 @@
 #[macro_use]
 extern crate cfg_if;
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 #[macro_use]
 extern crate futures;
 #[cfg(target_os = "windows")]

--- a/resolver/src/lookup_ip.rs
+++ b/resolver/src/lookup_ip.rs
@@ -9,11 +9,12 @@
 //!
 //! At it's heart LookupIp uses Lookup for performing all lookups. It is unlike other standard lookups in that there are customizations around A and AAAA resolutions.
 
-use std::error::Error;
 use std::mem;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Instant;
+
+use failure::Fail;
 
 use futures::{future, task, Async, Future, Poll};
 
@@ -154,7 +155,7 @@ impl<C: DnsHandle<Error = ResolveError> + 'static> LookupIpFuture<C> {
         }
     }
 
-    pub(crate) fn error<E: Error>(client_cache: CachingClient<C>, error: E) -> Self {
+    pub(crate) fn error<E: Fail>(client_cache: CachingClient<C>, error: E) -> Self {
         return LookupIpFuture {
             // errors on names don't need to be cheap... i.e. this clone is unfortunate in this case.
             client_cache,

--- a/resolver/src/lookup_state.rs
+++ b/resolver/src/lookup_state.rs
@@ -656,11 +656,11 @@ mod tests {
         let mut client = mock(vec![empty()]);
 
         assert_eq!(
-            QueryState::lookup(Query::new(), Default::default(), &mut client, cache)
+            *QueryState::lookup(Query::new(), Default::default(), &mut client, cache)
                 .wait()
                 .unwrap_err()
                 .kind(),
-            &ResolveErrorKind::NoRecordsFound(Query::new())
+            ResolveErrorKind::NoRecordsFound(Query::new())
         );
     }
 

--- a/resolver/src/system_conf/windows.rs
+++ b/resolver/src/system_conf/windows.rs
@@ -19,14 +19,8 @@ use config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
 use error::*;
 
 macro_rules! map_ipconfig_error {
-    // TODO: this should use error_chains chain facility
     ($result:expr) => {
-        $result.map_err(|e| {
-            ResolveError::from(ResolveErrorKind::Msg(format!(
-                "failed to read from registry: {}",
-                e
-            )))
-        })
+        $result.map_err(|e| e.context(ResolveErrorKind::from("failed to read from registry")))
     };
 }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -72,7 +72,7 @@ backtrace = "^0.3"
 chrono = "^0.4"
 clap = "^2.27"
 env_logger = "^0.5"
-error-chain = { version = "0.1.12", default-features = false }
+failure = "0.1"
 futures = "^0.1.17"
 lazy_static = "^1.0"
 log = "^0.4.1"

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -123,7 +123,7 @@ impl Authority {
             if record.rr_type() == RecordType::AXFR {
                 self.records.clear();
             } else if let Err(error) = self.update_records(&[record], false) {
-                return Err(PersistenceErrorKind::RecoveryError(error.to_str()).into());
+                return Err(PersistenceErrorKind::Recovery(error.to_str()).into());
             }
         }
 

--- a/server/src/authority/persistence.rs
+++ b/server/src/authority/persistence.rs
@@ -101,7 +101,10 @@ impl Journal {
         )?;
         //
         if count != 1 {
-            return Err(PersistenceErrorKind::WrongInsertCount(count, 1).into());
+            return Err(PersistenceErrorKind::WrongInsertCount {
+                got: count,
+                expect: 1,
+            }.into());
         };
 
         Ok(())
@@ -152,9 +155,10 @@ impl Journal {
                 // todo add location to this...
                 match Record::read(&mut decoder) {
                     Ok(record) => Ok((row_id, record)),
-                    Err(decode_error) => Err(rusqlite::Error::InvalidParameterName(
-                        format!("could not decode: {}", decode_error),
-                    )),
+                    Err(decode_error) => Err(rusqlite::Error::InvalidParameterName(format!(
+                        "could not decode: {}",
+                        decode_error
+                    ))),
                 }
             },
         )?

--- a/server/src/error/mod.rs
+++ b/server/src/error/mod.rs
@@ -16,9 +16,6 @@
 
 //! All defined errors for Trust-DNS
 
-// TODO figure out how to doc error_chain!
-#![allow(missing_docs)]
-
 mod config_error;
 mod persistence_error;
 
@@ -27,9 +24,6 @@ pub use self::persistence_error::Error as PersistenceError;
 
 pub use self::config_error::ErrorKind as ConfigErrorKind;
 pub use self::persistence_error::ErrorKind as PersistenceErrorKind;
-
-pub use self::config_error::ChainErr as ConfigChainErr;
-pub use self::persistence_error::ChainErr as PersistenceChainErr;
 
 pub use self::config_error::Result as ConfigResult;
 pub use self::persistence_error::Result as PersistenceResult;

--- a/server/src/error/persistence_error.rs
+++ b/server/src/error/persistence_error.rs
@@ -6,50 +6,98 @@
 // copied, modified, or distributed except according to those terms.
 use rusqlite;
 
-use trust_dns::error::*;
+use failure::{Backtrace, Context, Fail};
+use std::fmt;
+
 use trust_dns_proto::error::*;
 
-error_chain! {
-  // The type defined for this error. These are the conventional
-  // and recommended names, but they can be arbitrarily chosen.
-  types {
-    Error, ErrorKind, ChainErr, Result;
-  }
+/// An alias for results returned by functions of this crate
+pub type Result<T> = ::std::result::Result<T, Error>;
 
-  // Automatic conversions between this error chain and other
-  // error chains. In this case, it will e.g. generate an
-  // `ErrorKind` variant called `Dist` which in turn contains
-  // the `rustup_dist::ErrorKind`, with conversions from
-  // `rustup_dist::Error`.
-  //
-  // This section can be empty.
-  links {
-    DnsSecError, DnsSecErrorKind, DnsSec;
-    ProtoError, ProtoErrorKind, ProtoError;
-  }
+/// The error kind for errors that get returned in the crate
+#[derive(Clone, Eq, PartialEq, Debug, Fail)]
+pub enum ErrorKind {
+    /// An error that occurred when recovering from journal
+    #[fail(display = "error recovering from journal: {}", _0)]
+    Recovery(&'static str),
 
-  // Automatic conversions between this error chain and other
-  // error types not defined by the `error_chain!`. These will be
-  // boxed as the error cause and wrapped in a new error with,
-  // in this case, the `ErrorKind::Temp` variant.
-  //
-  // This section can be empty.
-  foreign_links {
-    rusqlite::Error, Sqlite, "sqlite error";
-  }
+    /// The number of inserted records didn't match the expected amount
+    #[fail(display = "wrong insert count: {} expect: {}", got, expect)]
+    WrongInsertCount {
+        /// The number of inserted records
+        got: i32,
+        /// The number of records expected to be inserted
+        expect: i32,
+    },
 
-  // Define additional `ErrorKind` variants. The syntax here is
-  // the same as `quick_error!`, but the `from()` and `cause()`
-  // syntax is not supported.
-  errors {
-    WrongInsertCount(got: i32, expect: i32) {
-      description("wrong insert count")
-      display("wrong insert count: {} expect: {}", got, expect)
+    // foreign
+    /// An error got returned by the trust-dns-proto crate
+    #[fail(display = "proto error")]
+    Proto,
+
+    /// An error got returned from the rusqlite crate
+    #[fail(display = "sqlite error")]
+    Sqlite,
+
+    /// A request timed out
+    #[fail(display = "request timed out")]
+    Timeout,
+}
+
+/// The error type for errors that get returned in the crate
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
+
+impl Error {
+    /// Get the kind of the error
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&Fail> {
+        self.inner.cause()
     }
 
-    RecoveryError(msg: &'static str) {
-      description("error recovering from journal")
-      display("error recovering from journal: {}", msg)
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
     }
-  }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(kind),
+        }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner }
+    }
+}
+
+impl From<ProtoError> for Error {
+    fn from(e: ProtoError) -> Error {
+        match *e.kind() {
+            ProtoErrorKind::Timeout => e.context(ErrorKind::Timeout).into(),
+            _ => e.context(ErrorKind::Proto).into(),
+        }
+    }
+}
+
+impl From<rusqlite::Error> for Error {
+    fn from(e: rusqlite::Error) -> Error {
+        e.context(ErrorKind::Sqlite).into()
+    }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -30,7 +30,7 @@
 extern crate chrono;
 extern crate env_logger;
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 extern crate futures;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Closes: #326 

I finished the migration to failure. All tests pass on my Linux machines, but I have no other machines to test with.

My implementation tries to imitate what was available in the error-chain implementation as far as the available error kinds are affected. I did however throw some errors away that seemed to be no longer used, but were present in the error-chain implementation, either because they were needed in the past, or because they were copied over from one error implementation to another.

One significant difference is, that I added a `Timeout` error kind wherever appropriate, which gets mapped whenever possible (from `std::io::Error` to trust-dns error types, as well as from one trust-dns error type to another). From the user perspective, it seems to me that it make sense to always be able to easily check on the occurrence of timeouts.

I did implement the errors as heavy-weight as it seemed appropriate for the functionality, so maybe extra work needs to be done for #318 in a separate commit.

I stumbled upon one occurrence of a test affected by this change that has an `#[ignore]` flag attached, so I did my best to test what I would expect to work, but I couldn't test. This is in ` resolver/src/resolver_future.rs:519`.

I hope my commit lives up to the expected format and quality, and would be happy about feedback if you find any problems with my changes, so I can update them accordingly. I would love to see this migration done in one of the upcoming releases.