### PR TITLE
resolver: Refactor Future implementation for LookupIpFuture

### DIFF
--- a/resolver/examples/multithreaded_runtime.rs
+++ b/resolver/examples/multithreaded_runtime.rs
@@ -1,0 +1,70 @@
+//! This example shows how to create a resolver that uses the tokio multithreaded runtime. This is how
+//! you might integrate the resolver into a more complex application.
+
+extern crate futures;
+extern crate tokio;
+extern crate trust_dns_resolver;
+
+use futures::Future;
+use futures::sync::oneshot::channel;
+use tokio::runtime::Runtime;
+use trust_dns_resolver::ResolverFuture;
+use trust_dns_resolver::error::ResolveError;
+
+fn main() {
+    // Set up the standard tokio runtime (multithreaded by default).
+    let mut runtime = Runtime::new().expect("Failed to create runtime");
+
+    let future;
+    // To make this independent, if targeting macOS, BSD, Linux, or Windows, we can use the system's configuration:
+    #[cfg(any(unix, windows))]
+    {
+        future = ResolverFuture::from_system_conf().expect("Failed to create ResolverFuture");
+    }
+    // For other operating systems, we can use one of the preconfigured definitions
+    #[cfg(not(any(unix, windows)))]
+    {
+        use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+        future = ResolverFuture::new(ResolverConfig::google(), ResolverOpts::default());
+    }
+
+    // The resolver needs to be created in the runtime so it can connect to the reactor. The tokio multithreaded
+    // runtime doesn't provide a mechanism to return the result of future out of the reactor. Create a oneshot
+    // channel that can be used to send the created resolver out.
+    let (sender, receiver) = channel::<Result<ResolverFuture, ResolveError>>();
+    runtime.spawn(future.then(|result| {
+        sender
+            .send(result)
+            .map_err(|_| println!("Failed to send resolver"))
+    }));
+    // Once the resolver is created, we can ask the runtime to shut down when it's done.
+    let shutdown = runtime.shutdown_on_idle();
+    // Wait unti the resolver has been created and fetch it from the oneshot channel.
+    let resolver = receiver
+        .wait()
+        .expect("Failed to retrieve resolver")
+        .expect("Failed to create resolver");
+
+    // Create some futures representing name lookups.
+    let names = &["www.google.com", "www.reddit.com", "www.wikipedia.org"];
+    let mut futures = names
+        .iter()
+        .map(|name| (name, resolver.lookup_ip(*name)))
+        .collect::<Vec<_>>();
+
+    // Go through the list of resolution operations and wait for them to complete.
+    for (name, lookup) in futures.drain(..) {
+        let ips = lookup
+            .wait()
+            .expect("Failed completing lookup future")
+            .iter()
+            .collect::<Vec<_>>();
+        println!("{} resolved to {:?}", name, ips);
+    }
+
+    // Drop the resolver, which means that the runtime will become idle.
+    drop(resolver);
+
+    // Wait for the runtime to complete shutting down.
+    shutdown.wait().expect("Failed when shutting down runtime");
+}

--- a/resolver/src/lookup_ip.rs
+++ b/resolver/src/lookup_ip.rs
@@ -117,23 +117,26 @@ impl<C: DnsHandle<Error = ResolveError> + 'static> Future for LookupIpFuture<C> 
                         self.options.clone(),
                         self.hosts.clone(),
                     );
+                    // Continue looping with the new query. It will be polled
+                    // on the next iteration of the loop.
                     continue;
                 } else if let Some(ip_addr) = self.finally_ip_addr.take() {
-                    // Otherwise, if there's an IP address to fall back to, we'll
-                    // return it.
+                    // Otherwise, if there's an IP address to fall back to,
+                    // we'll return it.
                     return Ok(Async::Ready(
                         Lookup::new_with_max_ttl(Arc::new(vec![ip_addr])).into(),
                     ));
                 }
             };
 
-            // If we didn't have to retry the query, or we weren't able to retry
-            // because we've exhausted the names to search and have no fallback
-            // IP address, return the current query.
+            // If we didn't have to retry the query, or we weren't able to
+            // retry because we've exhausted the names to search and have no
+            // fallback IP address, return the current query.
             return query.map(|async| async.map(LookupIp::from));
-            // If we skipped retrying the  query, this will return the successful
-            // lookup, otherwise, if the retry failed, this will return the last
-            // query result --- either an empty lookup or the last error we saw.
+            // If we skipped retrying the  query, this will return the
+            // successful lookup, otherwise, if the retry failed, this will
+            // return the last  query result --- either an empty lookup or the
+            // last error we saw.
         }
     }
 }

--- a/scripts/test_default_features.sh
+++ b/scripts/test_default_features.sh
@@ -18,3 +18,4 @@ cargo test --manifest-path integration-tests/Cargo.toml
 
 # All examples should go here
 cargo run --manifest-path resolver/Cargo.toml --example global_resolver
+cargo run --manifest-path resolver/Cargo.toml --example multithreaded_runtime

--- a/scripts/test_windows.bat
+++ b/scripts/test_windows.bat
@@ -13,6 +13,7 @@ if [%DEFAULT_SUITE%] EQU [1] (
     cargo test --manifest-path server\Cargo.toml
     cargo test --manifest-path integration-tests\Cargo.toml
     cargo run --manifest-path resolver\Cargo.toml --example global_resolver
+    cargo run --manifest-path resolver\Cargo.toml --example multithreaded_runtime
 )
 
 if [%ALL_FEATURES_SUITE%] EQU [1] (
@@ -40,7 +41,7 @@ if [%DNSSEC_OPENSSL_SUITE%] EQU [1] (
 )
 
 if [%DNSSEC_RING_SUITE%] EQU [1] (
-    cargo test --manifest-path proto\Cargo.toml --no-default-features --features=dnssec-ring  
+    cargo test --manifest-path proto\Cargo.toml --no-default-features --features=dnssec-ring
     cargo test --manifest-path client\Cargo.toml --no-default-features --features=dnssec-ring
     cargo test --manifest-path resolver\Cargo.toml --no-default-features --features=dnssec-ring
     cargo test --manifest-path server\Cargo.toml --no-default-features --features=dnssec-ring


### PR DESCRIPTION
This PR refactors the implementation of `Future` for `LookupIpFuture` to
remove the need to call `task::current().unpark()`, and (hopefully) simplify
the implementation. Typically, I find that unparking a future manually is often
a source of confusion that makes the `Future` implementation harder to reason
about, and ought to be avoided when possible. Hopefully the resultant code
is simpler and easier to understand, and shouldn't change the semantics of
`LookupIpFuture`.

This came out of work I was doing on issue #430, but I realised it could be
factored out into a separate branch.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>