### PR TITLE
resolver: Add config in ResolverOpts to set an optional minimum TTL for cached records

### DIFF
--- a/resolver/src/config.rs
+++ b/resolver/src/config.rs
@@ -439,7 +439,7 @@ pub struct ResolverOpts {
     ///
     /// If this is set, any responses with a TTL lower than this value will have a TTL of
     /// `min_ttl` instead.
-    pub min_ttl: Option<Duration>,
+    pub cache_min_ttl: Option<Duration>,
 }
 
 impl Default for ResolverOpts {
@@ -458,7 +458,7 @@ impl Default for ResolverOpts {
             ip_strategy: LookupIpStrategy::default(),
             cache_size: 32,
             use_hosts_file: true,
-            min_ttl: None,
+            cache_min_ttl: None,
         }
     }
 }

--- a/resolver/src/config.rs
+++ b/resolver/src/config.rs
@@ -435,6 +435,11 @@ pub struct ResolverOpts {
     pub cache_size: usize,
     /// Check /ect/hosts file before dns requery (only works for unix like OS)
     pub use_hosts_file: bool,
+    /// Optional minimum TTL for cached responses.
+    ///
+    /// If this is set, any responses with a TTL lower than this value will have a TTL of
+    /// `min_ttl` instead.
+    pub min_ttl: Option<Duration>,
 }
 
 impl Default for ResolverOpts {
@@ -453,6 +458,7 @@ impl Default for ResolverOpts {
             ip_strategy: LookupIpStrategy::default(),
             cache_size: 32,
             use_hosts_file: true,
+            min_ttl: None,
         }
     }
 }

--- a/resolver/src/config.rs
+++ b/resolver/src/config.rs
@@ -435,11 +435,16 @@ pub struct ResolverOpts {
     pub cache_size: usize,
     /// Check /ect/hosts file before dns requery (only works for unix like OS)
     pub use_hosts_file: bool,
-    /// Optional minimum TTL for cached responses.
+    /// Optional minimum TTL for positive responses.
     ///
-    /// If this is set, any responses with a TTL lower than this value will have a TTL of
-    /// `min_ttl` instead.
-    pub cache_min_ttl: Option<Duration>,
+    /// If this is set, any positive responses with a TTL lower than this value will have a TTL of
+    /// `min_positive_ttl` instead.
+    pub min_positive_ttl: Option<Duration>,
+    /// Optional minimum TTL for negative (`NXDOMAIN`) responses.
+    ///
+    /// If this is set, any positive responses with a TTL lower than this value will have a TTL of
+    /// `min_negative_ttl` instead.
+    pub min_negative_ttl: Option<Duration>,
 }
 
 impl Default for ResolverOpts {
@@ -458,7 +463,8 @@ impl Default for ResolverOpts {
             ip_strategy: LookupIpStrategy::default(),
             cache_size: 32,
             use_hosts_file: true,
-            cache_min_ttl: None,
+            min_negative_ttl: None,
+            min_positive_ttl: None,
         }
     }
 }

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -64,13 +64,9 @@ pub(crate) struct TtlConfig {
 }
 
 impl DnsLru {
-    pub(crate) fn new(capacity: usize) -> Self {
-        Self::with_ttls(capacity, TtlConfig::default())
-    }
-
-    pub(crate) fn with_ttls(capacity: usize, ttl_cfg: TtlConfig) -> Self {
+    pub(crate) fn new(capacity: usize, ttl_cfg: TtlConfig) -> Self {
         let TtlConfig { min_positive_ttl, min_negative_ttl } = ttl_cfg;
-        let cache = LruCache::with_capacity(capacity);
+        let cache = LruCache::new(capacity);
         Self {
             cache,
             min_positive_ttl: min_positive_ttl.unwrap_or_else(|| Duration::from_secs(0)),
@@ -227,9 +223,9 @@ mod tests {
         // configure the cache with a minimum TTL of 2 seconds.
         let ttls = TtlConfig {
             min_positive_ttl: Some(Duration::from_secs(2)),
-            ..Default::default
+            ..Default::default()
         };
-        let mut lru = DnsLru::with_ttls(1, ttls);
+        let mut lru = DnsLru::new(1, ttls);
 
         let rc_ips = lru.insert(name.clone(), ips_ttl, now);
         assert_eq!(*rc_ips.iter().next().unwrap(), ips[0]);
@@ -253,7 +249,7 @@ mod tests {
         let name = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         let ips_ttl = vec![(RData::A(Ipv4Addr::new(127, 0, 0, 1)), 1)];
         let ips = vec![RData::A(Ipv4Addr::new(127, 0, 0, 1))];
-        let mut lru = DnsLru::new(1);
+        let mut lru = DnsLru::new(1, TtlConfig::default());
 
         let rc_ips = lru.insert(name.clone(), ips_ttl, now);
         assert_eq!(*rc_ips.iter().next().unwrap(), ips[0]);
@@ -275,7 +271,7 @@ mod tests {
             RData::A(Ipv4Addr::new(127, 0, 0, 1)),
             RData::A(Ipv4Addr::new(127, 0, 0, 2)),
         ];
-        let mut lru = DnsLru::new(1);
+        let mut lru = DnsLru::new(1, TtlConfig::default());
 
         lru.insert(name.clone(), ips_ttl, now);
 
@@ -306,9 +302,9 @@ mod tests {
         // minimum TTL of 3 seconds.
         let ttls = TtlConfig {
             min_positive_ttl: Some(Duration::from_secs(3)),
-            ..Default::default
+            ..Default::default()
         };
-        let mut lru = DnsLru::with_ttls(1, ttls);
+        let mut lru = DnsLru::new(1, ttls);
         lru.insert(name.clone(), ips_ttl, now);
 
         // still valid

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -78,13 +78,10 @@ impl Resolver {
     ///
     /// A new Resolver or an error if there was an error with the configuration.
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> io::Result<Self> {
-        let mut lru = DnsLru::new(options.cache_size);
-        if let Some(min) = options.min_positive_ttl {
-            lru = lru.with_min_positive_ttl(min);
-        }
-        if let Some(min) = options.min_negative_ttl {
-            lru = lru.with_min_negative_ttl(min);
-        }
+        let lru = DnsLru::builder()
+            .with_min_negative_ttl(options.min_negative_ttl)
+            .with_min_positive_ttl(options.min_positive_ttl)
+            .build(options.cache_size);
 
         let lru = Arc::new(Mutex::new(lru));
 

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -78,7 +78,10 @@ impl Resolver {
     ///
     /// A new Resolver or an error if there was an error with the configuration.
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> io::Result<Self> {
-        let lru = Arc::new(Mutex::new(DnsLru::new(options.cache_size)));
+        let lru = Arc::new(Mutex::new(DnsLru::with_min_ttl(
+            options.cache_size,
+            options.cache_min_ttl,
+        )));
         Ok(Resolver {
             config,
             options,

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -83,7 +83,7 @@ impl Resolver {
             min_negative_ttl: options.min_negative_ttl,
         };
 
-        let lru = DnsLru::with_ttls(options.cache_size, ttls);
+        let lru = DnsLru::new(options.cache_size, ttls);
         let lru = Arc::new(Mutex::new(lru));
 
         Ok(Resolver {

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -78,10 +78,16 @@ impl Resolver {
     ///
     /// A new Resolver or an error if there was an error with the configuration.
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> io::Result<Self> {
-        let lru = Arc::new(Mutex::new(DnsLru::with_min_ttl(
-            options.cache_size,
-            options.cache_min_ttl,
-        )));
+        let mut lru = DnsLru::new(options.cache_size);
+        if let Some(min) = options.min_positive_ttl {
+            lru = lru.with_min_positive_ttl(min);
+        }
+        if let Some(min) = options.min_negative_ttl {
+            lru = lru.with_min_negative_ttl(min);
+        }
+
+        let lru = Arc::new(Mutex::new(lru));
+
         Ok(Resolver {
             config,
             options,

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -19,7 +19,7 @@ use trust_dns_proto::xfer::{
 use trust_dns_proto::SecureDnsHandle;
 
 use config::{ResolverConfig, ResolverOpts};
-use dns_lru::DnsLru;
+use dns_lru::{self, DnsLru};
 use error::*;
 use hosts::Hosts;
 use lookup::{self, Lookup, LookupEither, LookupFuture};
@@ -116,7 +116,7 @@ impl ResolverFuture {
             min_negative_ttl: options.min_negative_ttl,
         };
 
-        let lru = DnsLru::with_ttls(options.cache_size, ttls);
+        let lru = DnsLru::new(options.cache_size, ttls);
         let lru = Arc::new(Mutex::new(lru));
 
         Self::with_cache(config, options, lru)

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -111,7 +111,10 @@ impl ResolverFuture {
         config: ResolverConfig,
         options: ResolverOpts,
     ) -> Box<Future<Item = Self, Error = ResolveError> + Send> {
-        let lru = Arc::new(Mutex::new(DnsLru::new(options.cache_size)));
+        let lru = Arc::new(Mutex::new(DnsLru::with_min_ttl(
+            options.cache_size,
+            options.cache_min_ttl,
+        )));
 
         Self::with_cache(config, options, lru)
     }

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -111,13 +111,10 @@ impl ResolverFuture {
         config: ResolverConfig,
         options: ResolverOpts,
     ) -> Box<Future<Item = Self, Error = ResolveError> + Send> {
-        let mut lru = DnsLru::new(options.cache_size);
-        if let Some(min) = options.min_positive_ttl {
-            lru = lru.with_min_positive_ttl(min);
-        }
-        if let Some(min) = options.min_negative_ttl {
-            lru = lru.with_min_negative_ttl(min);
-        }
+        let lru = DnsLru::builder()
+            .with_min_negative_ttl(options.min_negative_ttl)
+            .with_min_positive_ttl(options.min_positive_ttl)
+            .build(options.cache_size);
 
         let lru = Arc::new(Mutex::new(lru));
 

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -111,11 +111,12 @@ impl ResolverFuture {
         config: ResolverConfig,
         options: ResolverOpts,
     ) -> Box<Future<Item = Self, Error = ResolveError> + Send> {
-        let lru = DnsLru::builder()
-            .with_min_negative_ttl(options.min_negative_ttl)
-            .with_min_positive_ttl(options.min_positive_ttl)
-            .build(options.cache_size);
+        let ttls = dns_lru::TtlConfig {
+            min_positive_ttl: options.min_positive_ttl,
+            min_negative_ttl: options.min_negative_ttl,
+        };
 
+        let lru = DnsLru::with_ttls(options.cache_size, ttls);
         let lru = Arc::new(Mutex::new(lru));
 
         Self::with_cache(config, options, lru)

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -111,10 +111,15 @@ impl ResolverFuture {
         config: ResolverConfig,
         options: ResolverOpts,
     ) -> Box<Future<Item = Self, Error = ResolveError> + Send> {
-        let lru = Arc::new(Mutex::new(DnsLru::with_min_ttl(
-            options.cache_size,
-            options.cache_min_ttl,
-        )));
+        let mut lru = DnsLru::new(options.cache_size);
+        if let Some(min) = options.min_positive_ttl {
+            lru = lru.with_min_positive_ttl(min);
+        }
+        if let Some(min) = options.min_negative_ttl {
+            lru = lru.with_min_negative_ttl(min);
+        }
+
+        let lru = Arc::new(Mutex::new(lru));
 
         Self::with_cache(config, options, lru)
     }


### PR DESCRIPTION
This PR adds an optional `cache_min_ttl` field to `ResolverOpts`, which, if 
set, will cause the underlying `DnsLru` cache to limit all TTLs to that minimum
value. Queries with records whose TTL is under the minimum will have their TTL
set to the minimum value instead. 

We want the ability to set a minimum TTL for DNS responses in Conduit so as to
limit the rate at which the Conduit proxy queries DNS in development mode
(see runconduit/conduit#711). I originally implemented this functionality in the
Conduit proxy, but @briansmith [suggested](https://github.com/runconduit/conduit/pull/974#pullrequestreview-122330772) that it should be implemented in 
Trust-DNS, instead.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>