### PR TITLE
resolver: Propagate TTLs for NXDOMAIN responses

### DIFF
--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -97,8 +97,8 @@ impl DnsLru {
         lookup
     }
 
-    pub(crate) fn nx_error(query: Query) -> ResolveError {
-        ResolveErrorKind::NoRecordsFound(query).into()
+    pub(crate) fn nx_error(query: Query, valid_until: Option<Instant>) -> ResolveError {
+        ResolveErrorKind::NoRecordsFound { query, valid_until }.into()
     }
 
     pub(crate) fn negative(&mut self, query: Query, ttl: u32, now: Instant) -> ResolveError {
@@ -116,7 +116,7 @@ impl DnsLru {
             },
         );
 
-        Self::nx_error(query)
+        Self::nx_error(query, Some(valid_until))
     }
 
     /// This needs to be mut b/c it's an LRU, meaning the ordering of elements will potentially change on retrieval...

--- a/resolver/src/lookup.rs
+++ b/resolver/src/lookup.rs
@@ -491,7 +491,10 @@ pub mod tests {
             ).wait()
                 .unwrap_err()
                 .kind(),
-            ResolveErrorKind::NoRecordsFound(Query::query(Name::root(), RecordType::A))
+            ResolveErrorKind::NoRecordsFound {
+                query: Query::query(Name::root(), RecordType::A),
+                valid_until: None,
+            }
         );
     }
 }


### PR DESCRIPTION
Since 21c666ddb3975508b0bca90224fba6caccf15107, we've exposed the deadlines for successful DNS lookups to users of the `Resolver` API. This PR adds a `valid_until` field to the `ResolveErrorKind::NoRecordsFound` variant as well, so the TTLs for NXDOMAIN responses are also accessible to the user. This is necessary in situations where the user has implemented their own caching separate from `Trust-DNS`' cache.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>