### PR TITLE
resolver: Add maximum TTL config option

### DIFF
--- a/resolver/src/config.rs
+++ b/resolver/src/config.rs
@@ -438,13 +438,27 @@ pub struct ResolverOpts {
     /// Optional minimum TTL for positive responses.
     ///
     /// If this is set, any positive responses with a TTL lower than this value will have a TTL of
-    /// `positive_min_ttl` instead.
+    /// `positive_min_ttl` instead. Otherwise, this will default to 0 seconds.
     pub positive_min_ttl: Option<Duration>,
     /// Optional minimum TTL for negative (`NXDOMAIN`) responses.
     ///
     /// If this is set, any positive responses with a TTL lower than this value will have a TTL of
-    /// `negative_min_ttl` instead.
+    /// `negative_min_ttl` instead. Otherwise, this will default to 0 seconds.
     pub negative_min_ttl: Option<Duration>,
+    /// Optional maximum TTL for positive responses.
+    ///
+    /// If this is set, any positive responses with a TTL higher than this value will have a TTL of
+    /// `positive_max_ttl` instead. Otherwise, this will default to [`MAX_TTL`] seconds.
+    ///
+    /// [`MAX_TTL`]: ../dns_lru/const.MAX_TTL.html
+    pub positive_max_ttl: Option<Duration>,
+    /// Optional maximum TTL for negative (`NXDOMAIN`) responses.
+    ///
+    /// If this is set, any positive responses with a TTL higher than this value will have a TTL of
+    /// `negative_max_ttl` instead. Otherwise, this will default to [`MAX_TTL`] seconds.
+    ///
+    /// [`MAX_TTL`]: ../dns_lru/const.MAX_TTL.html
+    pub negative_max_ttl: Option<Duration>,
 }
 
 impl Default for ResolverOpts {
@@ -463,8 +477,10 @@ impl Default for ResolverOpts {
             ip_strategy: LookupIpStrategy::default(),
             cache_size: 32,
             use_hosts_file: true,
-            negative_min_ttl: None,
             positive_min_ttl: None,
+            negative_min_ttl: None,
+            positive_max_ttl: None,
+            negative_max_ttl: None,
         }
     }
 }

--- a/resolver/src/config.rs
+++ b/resolver/src/config.rs
@@ -438,13 +438,13 @@ pub struct ResolverOpts {
     /// Optional minimum TTL for positive responses.
     ///
     /// If this is set, any positive responses with a TTL lower than this value will have a TTL of
-    /// `min_positive_ttl` instead.
-    pub min_positive_ttl: Option<Duration>,
+    /// `positive_min_ttl` instead.
+    pub positive_min_ttl: Option<Duration>,
     /// Optional minimum TTL for negative (`NXDOMAIN`) responses.
     ///
     /// If this is set, any positive responses with a TTL lower than this value will have a TTL of
-    /// `min_negative_ttl` instead.
-    pub min_negative_ttl: Option<Duration>,
+    /// `negative_min_ttl` instead.
+    pub negative_min_ttl: Option<Duration>,
 }
 
 impl Default for ResolverOpts {
@@ -463,8 +463,8 @@ impl Default for ResolverOpts {
             ip_strategy: LookupIpStrategy::default(),
             cache_size: 32,
             use_hosts_file: true,
-            min_negative_ttl: None,
-            min_positive_ttl: None,
+            negative_min_ttl: None,
+            positive_min_ttl: None,
         }
     }
 }

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -186,10 +186,11 @@ impl DnsLru {
         // TODO: if we are getting a negative response, should we instead fallback to cache?
         //   this would cache indefinitely, probably not correct
 
-        let ttl = Duration::from_secs(ttl as u64);
-        // If the cache was configured with a min TTL for negative responses,
-        // and that TTL is higher than the response's TTL, use it instead.
-        let ttl = self.negative_min_ttl.max(ttl);
+        let ttl = Duration::from_secs(ttl as u64)
+            // Clamp the TTL so that it's between the cache's configured
+            // minimum and maximum TTLs for negative responses.
+            .max(self.negative_min_ttl)
+            .min(self.negative_max_ttl);
         let valid_until = now + ttl;
 
         self.cache.insert(

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -77,6 +77,13 @@ pub(crate) struct DnsLru {
 
 }
 
+/// The time-to-live, TTL, configuration for use by the cache.
+/// 
+/// It should be understood that the TTL in DNS is expressed with a u32.
+///   We use Duration here for tracking this which can express larger values
+///   than the DNS standard. Generally a Duration greater than u32::MAX_VALUE
+///   shouldn't cause any issue as this will never be used in serialization,
+///   but understand that this would be outside the standard range.
 #[derive(Copy, Clone, Debug, Default)]
 pub(crate) struct TtlConfig {
     /// An optional minimum TTL value for positive responses.

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -128,16 +128,16 @@ impl DnsLru {
     ) -> Lookup {
         let len = rdatas_and_ttl.len();
         // collapse the values, we're going to take the Minimum TTL as the correct one
-        let (rdatas, ttl): (Vec<RData>, u32) = rdatas_and_ttl.into_iter().fold(
-            (Vec::with_capacity(len), MAX_TTL),
+        let (rdatas, ttl): (Vec<RData>, Duration) = rdatas_and_ttl.into_iter().fold(
+            (Vec::with_capacity(len), self.positive_max_ttl),
             |(mut rdatas, mut min_ttl), (rdata, ttl)| {
                 rdatas.push(rdata);
+                let ttl = Duration::from_secs(ttl as u64);
                 min_ttl = min_ttl.min(ttl);
                 (rdatas, min_ttl)
             },
         );
 
-        let ttl = Duration::from_secs(ttl as u64);
         // If the cache was configured with a minimum TTL, and that value is higher
         // than the minimum TTL in the values, use it instead.
         let ttl = self.positive_min_ttl.max(ttl);

--- a/resolver/src/dns_lru.rs
+++ b/resolver/src/dns_lru.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 use trust_dns_proto::op::Query;
 use trust_dns_proto::rr::RData;
 
+use config;
 use error::*;
 use lookup::Lookup;
 use lru_cache::LruCache;
@@ -98,6 +99,17 @@ pub(crate) struct TtlConfig {
     /// `NXDOMAIN` responses with TTLs over `negative_max_ttl` will use
     /// `negative_max_ttl` instead.
     pub negative_max_ttl: Option<Duration>,
+}
+
+impl TtlConfig {
+    pub(crate) fn from_opts(opts: &config::ResolverOpts) -> TtlConfig {
+        TtlConfig {
+            positive_min_ttl: opts.positive_min_ttl,
+            negative_min_ttl: opts.negative_min_ttl,
+            positive_max_ttl: opts.positive_max_ttl,
+            negative_max_ttl: opts.negative_max_ttl,
+        }
+    }
 }
 
 impl DnsLru {

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -79,8 +79,9 @@ impl Resolver {
     /// A new Resolver or an error if there was an error with the configuration.
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> io::Result<Self> {
         let ttls = dns_lru::TtlConfig {
-            min_positive_ttl: options.min_positive_ttl,
-            min_negative_ttl: options.min_negative_ttl,
+            positive_min_ttl: options.positive_min_ttl,
+            negative_min_ttl: options.negative_min_ttl,
+            ..Default::default() // for now.
         };
 
         let lru = DnsLru::new(options.cache_size, ttls);

--- a/resolver/src/resolver.rs
+++ b/resolver/src/resolver.rs
@@ -78,13 +78,10 @@ impl Resolver {
     ///
     /// A new Resolver or an error if there was an error with the configuration.
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> io::Result<Self> {
-        let ttls = dns_lru::TtlConfig {
-            positive_min_ttl: options.positive_min_ttl,
-            negative_min_ttl: options.negative_min_ttl,
-            ..Default::default() // for now.
-        };
-
-        let lru = DnsLru::new(options.cache_size, ttls);
+        let lru = DnsLru::new(
+            options.cache_size,
+            dns_lru::TtlConfig::from_opts(&options),
+        );
         let lru = Arc::new(Mutex::new(lru));
 
         Ok(Resolver {

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -111,13 +111,10 @@ impl ResolverFuture {
         config: ResolverConfig,
         options: ResolverOpts,
     ) -> Box<Future<Item = Self, Error = ResolveError> + Send> {
-        let ttls = dns_lru::TtlConfig {
-            positive_min_ttl: options.positive_min_ttl,
-            negative_min_ttl: options.negative_min_ttl,
-            ..Default::default() // for now
-        };
-
-        let lru = DnsLru::new(options.cache_size, ttls);
+        let lru = DnsLru::new(
+            options.cache_size,
+            dns_lru::TtlConfig::from_opts(&options),
+        );
         let lru = Arc::new(Mutex::new(lru));
 
         Self::with_cache(config, options, lru)

--- a/resolver/src/resolver_future.rs
+++ b/resolver/src/resolver_future.rs
@@ -112,8 +112,9 @@ impl ResolverFuture {
         options: ResolverOpts,
     ) -> Box<Future<Item = Self, Error = ResolveError> + Send> {
         let ttls = dns_lru::TtlConfig {
-            min_positive_ttl: options.min_positive_ttl,
-            min_negative_ttl: options.min_negative_ttl,
+            positive_min_ttl: options.positive_min_ttl,
+            negative_min_ttl: options.negative_min_ttl,
+            ..Default::default() // for now
         };
 
         let lru = DnsLru::new(options.cache_size, ttls);


### PR DESCRIPTION
This is a simple follow up from #484. It adds support for setting a maximum TTL for positive and negative responses on `DnsLru`, as well as the minimum TTLs that were previously added. I've also improved the documentation for all the TTL configuration options, and changed the names slightly to (hopefully) make the code a little more readable.

In addition, I've added unit tests for the new configs, as well as for the `negative_min_ttl` that was added previously but not tested.

Closes #489.