### PR TITLE
improve truncation to always return records

### DIFF
--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -17,24 +17,24 @@
 //! signer is a structure for performing many of the signing processes of the DNSSec specification
 #[cfg(any(feature = "openssl", feature = "ring"))]
 use chrono::Duration;
+#[cfg(feature = "dnssec")]
+use rr::rdata::DNSSECRData;
 use trust_dns_proto::error::{ProtoErrorKind, ProtoResult};
 #[cfg(any(feature = "openssl", feature = "ring"))]
 use trust_dns_proto::rr::dnssec::{tbs, TBS};
-#[cfg(feature = "dnssec")]
-use rr::rdata::DNSSECRData;
 
 use op::{Message, MessageFinalizer};
-use rr::Record;
-#[cfg(any(feature = "openssl", feature = "ring"))]
-use rr::{DNSClass, Name, RecordType};
-#[cfg(any(feature = "openssl", feature = "ring"))]
-use rr::RData;
 #[cfg(any(feature = "openssl", feature = "ring"))]
 use rr::dnssec::{Algorithm, KeyPair};
 #[cfg(any(feature = "openssl", feature = "ring"))]
 use rr::rdata::SIG;
 #[cfg(any(feature = "openssl", feature = "ring"))]
 use rr::rdata::{DNSSECRecordType, DNSKEY, KEY};
+#[cfg(any(feature = "openssl", feature = "ring"))]
+use rr::RData;
+use rr::Record;
+#[cfg(any(feature = "openssl", feature = "ring"))]
+use rr::{DNSClass, Name, RecordType};
 #[cfg(any(feature = "openssl", feature = "ring"))]
 use serialize::binary::BinEncoder;
 
@@ -319,7 +319,8 @@ impl Signer {
         is_zone_signing_key: bool,
         _: bool,
     ) -> Self {
-        let dnskey = key.to_dnskey(algorithm)
+        let dnskey = key
+            .to_dnskey(algorithm)
             .expect("something went wrong, use one of the SIG0 or DNSSec constructors");
 
         Signer {
@@ -332,8 +333,6 @@ impl Signer {
         }
     }
 
-
-
     /// Return the key used for validation/signing
     pub fn key(&self) -> &KeyPair<Private> {
         &self.key
@@ -343,8 +342,6 @@ impl Signer {
     pub fn sig_duration(&self) -> Duration {
         self.sig_duration
     }
-
-
 
     /// A hint to the DNSKey associated with this Signer can be used to sign/validate records in the zone
     pub fn is_zone_signing_key(&self) -> bool {
@@ -375,9 +372,9 @@ impl Signer {
     ///
     /// The signature, ready to be stored in an `RData::RRSIG`.
     pub fn sign(&self, tbs: &TBS) -> ProtoResult<Vec<u8>> {
-        self.key.sign(self.algorithm, tbs).map_err(|e| {
-            ProtoErrorKind::Msg(format!("signing error: {}", e)).into()
-        })
+        self.key
+            .sign(self.algorithm, tbs)
+            .map_err(|e| ProtoErrorKind::Msg(format!("signing error: {}", e)).into())
     }
 
     /// Returns the algorithm this Signer will use to either sign or validate a signature
@@ -511,7 +508,9 @@ impl Signer {
     ///
     ///  ---
     pub fn sign_message(&self, message: &Message, pre_sig0: &SIG) -> ProtoResult<Vec<u8>> {
-        tbs::message_tbs(message, pre_sig0).and_then(|tbs| self.sign(&tbs))
+        // TODO: remove this somehow...
+        let mut message = message.clone();
+        tbs::message_tbs(&mut message, pre_sig0).and_then(|tbs| self.sign(&tbs))
     }
 }
 
@@ -577,14 +576,14 @@ impl MessageFinalizer for Signer {
 mod tests {
     extern crate openssl;
     use self::openssl::bn::BigNum;
-    use self::openssl::rsa::Rsa;
     use self::openssl::pkey::Private;
+    use self::openssl::rsa::Rsa;
 
-    use rr::{DNSClass, Name, Record, RecordType};
-    use rr::rdata::{DNSSECRData, SIG};
-    use rr::rdata::key::KeyUsage;
-    use rr::dnssec::*;
     use op::{Message, Query};
+    use rr::dnssec::*;
+    use rr::rdata::key::KeyUsage;
+    use rr::rdata::{DNSSECRData, SIG};
+    use rr::{DNSClass, Name, Record, RecordType};
 
     pub use super::*;
 
@@ -656,7 +655,8 @@ mod tests {
     fn test_sign_and_verify_rrset() {
         let rsa = Rsa::generate(2048).unwrap();
         let key = KeyPair::from_rsa(rsa).unwrap();
-        let sig0key = key.to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
+        let sig0key = key
+            .to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
             .unwrap();
         let signer = Signer::sig0(sig0key, key, Name::root());
 
@@ -747,14 +747,7 @@ mod tests {
             (vec![33, 3, 21, 11, 3, 1, 1, 1], 9739),
             (
                 vec![
-                    0xc2fedb69,
-                    0x10001,
-                    0x6ebb9209,
-                    0xf743,
-                    0xc9e3,
-                    0xd07f,
-                    0x6275,
-                    0x1095,
+                    0xc2fedb69, 0x10001, 0x6ebb9209, 0xf743, 0xc9e3, 0xd07f, 0x6275, 0x1095,
                 ],
                 42354,
             ),
@@ -766,7 +759,8 @@ mod tests {
             println!("pkey:\n{}", String::from_utf8(rsa_pem).unwrap());
 
             let key = KeyPair::from_rsa(rsa).unwrap();
-            let sig0key = key.to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
+            let sig0key = key
+                .to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
                 .unwrap();
             let signer = Signer::sig0(sig0key, key, Name::root());
             let key_tag = signer.calculate_key_tag().unwrap();
@@ -788,7 +782,8 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
         println!("pkey:\n{}", String::from_utf8(rsa_pem).unwrap());
 
         let key = KeyPair::from_rsa(rsa).unwrap();
-        let sig0key = key.to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
+        let sig0key = key
+            .to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
             .unwrap();
         let signer = Signer::sig0(sig0key, key, Name::root());
         let key_tag = signer.calculate_key_tag().unwrap();
@@ -803,10 +798,10 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
         extern crate openssl;
         use self::openssl::rsa::Rsa;
 
-        use rr::*;
-        use rr::rdata::{DNSSECRData, SIG};
-        use rr::dnssec::*;
         use rr::dnssec::tbs::*;
+        use rr::dnssec::*;
+        use rr::rdata::{DNSSECRData, SIG};
+        use rr::*;
 
         #[test]
         fn test_rrset_tbs() {

--- a/client/src/rr/dnssec/signer.rs
+++ b/client/src/rr/dnssec/signer.rs
@@ -508,9 +508,7 @@ impl Signer {
     ///
     ///  ---
     pub fn sign_message(&self, message: &Message, pre_sig0: &SIG) -> ProtoResult<Vec<u8>> {
-        // TODO: remove this somehow...
-        let mut message = message.clone();
-        tbs::message_tbs(&mut message, pre_sig0).and_then(|tbs| self.sign(&tbs))
+        tbs::message_tbs(message, pre_sig0).and_then(|tbs| self.sign(&tbs))
     }
 }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -27,7 +27,6 @@ use trust_dns::error::{ClientError, ClientResult};
 use trust_dns::op::*;
 use trust_dns::serialize::binary::*;
 use trust_dns_proto::error::FromProtoError;
-use trust_dns_proto::op::EncodableMessage;
 use trust_dns_proto::{DnsStreamHandle, StreamHandle};
 
 use trust_dns_server::authority::{Catalog, MessageRequest, MessageResponse};

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -30,7 +30,7 @@ use trust_dns_proto::error::FromProtoError;
 use trust_dns_proto::op::EncodableMessage;
 use trust_dns_proto::{DnsStreamHandle, StreamHandle};
 
-use trust_dns_server::authority::{Catalog, MessageRequest};
+use trust_dns_server::authority::{Catalog, MessageRequest, MessageResponse};
 use trust_dns_server::server::{Request, RequestHandler, ResponseHandler};
 
 pub mod authority;
@@ -86,10 +86,12 @@ impl TestResponseHandler {
 }
 
 impl ResponseHandler for TestResponseHandler {
-    fn send<M: EncodableMessage>(self, response: M) -> io::Result<()> {
+    fn send(self, response: MessageResponse) -> io::Result<()> {
         let buf = &mut self.buf.lock().unwrap();
         let mut encoder = BinEncoder::new(buf);
-        response.emit(&mut encoder).expect("could not encode");
+        response
+            .destructive_emit(&mut encoder)
+            .expect("could not encode");
         Ok(())
     }
 }

--- a/integration-tests/tests/authority_tests.rs
+++ b/integration-tests/tests/authority_tests.rs
@@ -33,10 +33,7 @@ fn test_search() {
         let record = result.next().unwrap();
         assert_eq!(record.rr_type(), RecordType::A);
         assert_eq!(record.dns_class(), DNSClass::IN);
-        assert_eq!(
-            record.rdata(),
-            &RData::A(Ipv4Addr::new(93, 184, 216, 34))
-        );
+        assert_eq!(record.rdata(), &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
     } else {
         panic!("expected a result"); // valid panic, in test
     }
@@ -54,13 +51,10 @@ fn test_search_www() {
 
     let mut result = example.search(&query, false, SupportedAlgorithms::new());
     if !result.is_empty() {
-        let record = result.next().unwrap();        
+        let record = result.next().unwrap();
         assert_eq!(record.rr_type(), RecordType::A);
         assert_eq!(record.dns_class(), DNSClass::IN);
-        assert_eq!(
-            record.rdata(),
-            &RData::A(Ipv4Addr::new(93, 184, 216, 34))
-        );
+        assert_eq!(record.rdata(), &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
     } else {
         panic!("expected a result"); // valid panic, in test
     }
@@ -70,10 +64,7 @@ fn test_search_www() {
 fn test_authority() {
     let authority: Authority = create_example();
 
-    assert_eq!(
-        authority.soa().next().unwrap().dns_class(),
-        DNSClass::IN
-    );
+    assert_eq!(authority.soa().next().unwrap().dns_class(), DNSClass::IN);
 
     assert!(
         !authority
@@ -840,8 +831,7 @@ fn test_zone_signing() {
     );
 
     assert!(
-        results
-            .any(|r| r.rr_type() == RecordType::DNSSEC(DNSSECRecordType::DNSKEY)),
+        results.any(|r| r.rr_type() == RecordType::DNSSEC(DNSSECRecordType::DNSKEY)),
         "must contain a DNSKEY"
     );
 
@@ -861,11 +851,11 @@ fn test_zone_signing() {
         }
 
         let mut inner_results = authority.lookup(
-        &authority.origin(),
-        RecordType::AXFR,
-        true,
-        SupportedAlgorithms::all(),
-    );
+            &authority.origin(),
+            RecordType::AXFR,
+            true,
+            SupportedAlgorithms::all(),
+        );
 
         // validate all records have associated RRSIGs after signing
         assert!(
@@ -890,8 +880,7 @@ fn test_get_nsec() {
     let authority: Authority = create_secure_example();
     let lower_name = LowerName::from(name.clone());
 
-    let results =
-        authority.get_nsec_records(&lower_name, true, SupportedAlgorithms::all());
+    let results = authority.get_nsec_records(&lower_name, true, SupportedAlgorithms::all());
 
     for record in results {
         assert!(record.name() < &name);
@@ -1004,7 +993,12 @@ fn test_recovery() {
         recovered_authority.records().len(),
         authority.records().len()
     );
-    assert!(recovered_authority.soa().zip(authority.soa()).all(|(r1, r2)| r1 == r2));
+    assert!(
+        recovered_authority
+            .soa()
+            .zip(authority.soa())
+            .all(|(r1, r2)| r1 == r2)
+    );
     assert!(
         recovered_authority
             .records()
@@ -1015,8 +1009,8 @@ fn test_recovery() {
                     .get(rr_key)
                     .expect(&format!("key doesn't exist: {:?}", rr_key));
                 rr_set
-                    .iter()
-                    .zip(other_rr_set.iter())
+                    .records_without_rrsigs()
+                    .zip(other_rr_set.records_without_rrsigs())
                     .all(|(record, other_record)| {
                         record.ttl() == other_record.ttl() && record.rdata() == other_record.rdata()
                     })
@@ -1029,8 +1023,8 @@ fn test_recovery() {
             .get(rr_key)
             .expect(&format!("key doesn't exist: {:?}", rr_key));
         rr_set
-            .iter()
-            .zip(other_rr_set.iter())
+            .records_without_rrsigs()
+            .zip(other_rr_set.records_without_rrsigs())
             .all(|(record, other_record)| {
                 record.ttl() == other_record.ttl() && record.rdata() == other_record.rdata()
             })

--- a/integration-tests/tests/catalog_tests.rs
+++ b/integration-tests/tests/catalog_tests.rs
@@ -2,18 +2,18 @@ extern crate trust_dns;
 extern crate trust_dns_integration;
 extern crate trust_dns_server;
 
-use std::net::*;
 use std::collections::*;
+use std::net::*;
 
 use trust_dns::op::*;
-use trust_dns::rr::*;
 use trust_dns::rr::rdata::*;
+use trust_dns::rr::*;
 use trust_dns::serialize::binary::{BinDecodable, BinEncodable};
 
 use trust_dns_server::authority::*;
 
-use trust_dns_integration::*;
 use trust_dns_integration::authority::create_example;
+use trust_dns_integration::*;
 
 pub fn create_test() -> Authority {
     let origin: Name = Name::parse("test.com.", None).unwrap();
@@ -81,14 +81,7 @@ pub fn create_test() -> Authority {
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
-                0x2606,
-                0x2800,
-                0x220,
-                0x1,
-                0x248,
-                0x1893,
-                0x25c8,
-                0x1946,
+                0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
             )))
             .clone(),
         0,
@@ -112,14 +105,7 @@ pub fn create_test() -> Authority {
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
-                0x2606,
-                0x2800,
-                0x220,
-                0x1,
-                0x248,
-                0x1893,
-                0x25c8,
-                0x1946,
+                0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
             )))
             .clone(),
         0,
@@ -349,14 +335,7 @@ fn test_axfr() {
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
-                0x2606,
-                0x2800,
-                0x220,
-                0x1,
-                0x248,
-                0x1893,
-                0x25c8,
-                0x1946,
+                0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
             )))
             .clone(),
         Record::new()
@@ -372,14 +351,7 @@ fn test_axfr() {
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
-                0x2606,
-                0x2800,
-                0x220,
-                0x1,
-                0x248,
-                0x1893,
-                0x25c8,
-                0x1946,
+                0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
             )))
             .clone(),
         Record::new()
@@ -403,3 +375,6 @@ fn test_axfr() {
 
     assert_eq!(expected_set, answers);
 }
+
+#[test]
+fn test_truncated_returns_records() {}

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -80,6 +80,13 @@ pub enum ProtoErrorKind {
     #[fail(display = "no error specified")]
     NoError,
 
+    /// Not all records were able to be written
+    #[fail(display = "not all records could be written, wrote: {}", count)]
+    NotAllRecordsWritten {
+        /// Number of records that were written before the error
+        count: usize,
+    },
+
     /// Missing rrsigs
     #[fail(
         display = "rrsigs are not present for record set name: {} record_type: {}",
@@ -321,6 +328,7 @@ impl Clone for ProtoErrorKind {
             Message(msg) => Message(msg),
             Msg(ref msg) => Msg(msg.clone()),
             NoError => NoError,
+            NotAllRecordsWritten { count } => NotAllRecordsWritten { count },
             RrsigsNotPresent {
                 ref name,
                 ref record_type,

--- a/proto/src/op/header.rs
+++ b/proto/src/op/header.rs
@@ -18,10 +18,10 @@
 
 use std::convert::From;
 
-use serialize::binary::*;
-use error::*;
 use super::op_code::OpCode;
 use super::response_code::ResponseCode;
+use error::*;
+use serialize::binary::*;
 
 /// Metadata for the `Message` struct.
 ///
@@ -371,24 +371,6 @@ impl Header {
     /// This is the additional record section count, this section may include EDNS options.
     pub fn additional_count(&self) -> u16 {
         self.additional_count
-    }
-
-    /// This is a specialized clone which clones all the fields but the counts
-    ///  handy for setting the count fields before sending over the wire.
-    pub fn clone(
-        &self,
-        query_count: u16,
-        answer_count: u16,
-        name_server_count: u16,
-        additional_count: u16,
-    ) -> Self {
-        Header {
-            query_count: query_count,
-            answer_count: answer_count,
-            name_server_count: name_server_count,
-            additional_count: additional_count,
-            ..*self
-        }
     }
 }
 

--- a/proto/src/op/message.rs
+++ b/proto/src/op/message.rs
@@ -158,9 +158,13 @@ pub fn update_header_counts(
 ///
 /// This is only used internally during serialization.
 pub struct HeaderCounts {
+    /// The number of queries in the Message
     pub query_count: usize,
+    /// The number of answers in the Message
     pub answer_count: usize,
+    /// The number of nameservers or authorities in the Message
     pub nameserver_count: usize,
+    /// The number of additional records in the Message
     pub additional_count: usize,
 }
 

--- a/proto/src/op/mod.rs
+++ b/proto/src/op/mod.rs
@@ -27,7 +27,7 @@ pub mod response_code;
 pub use self::edns::Edns;
 pub use self::header::Header;
 pub use self::header::MessageType;
-pub use self::message::{EncodableMessage, Message, MessageFinalizer, NoopMessageFinalizer};
+pub use self::message::{Message, MessageFinalizer, NoopMessageFinalizer};
 pub use self::op_code::OpCode;
 pub use self::query::Query;
 pub use self::response_code::ResponseCode;

--- a/proto/src/rr/dnssec/tbs.rs
+++ b/proto/src/rr/dnssec/tbs.rs
@@ -1,10 +1,10 @@
 //! hash functions for DNSSec operations
 
+use super::rdata::{sig, DNSSECRData, SIG};
 use error::*;
 use op::EncodableMessage;
-use rr::{DNSClass, Name, RData, Record, RecordType};
 use rr::dnssec::Algorithm;
-use super::rdata::{sig, DNSSECRData, SIG};
+use rr::{DNSClass, Name, RData, Record, RecordType};
 use serialize::binary::{BinEncodable, BinEncoder, EncodeMode};
 
 /// Data To Be Signed.
@@ -93,7 +93,8 @@ pub fn rrset_tbs(
 
     // collect only the records for this rrset
     for record in records {
-        if dns_class == record.dns_class() && type_covered == record.rr_type()
+        if dns_class == record.dns_class()
+            && type_covered == record.rr_type()
             && name == record.name()
         {
             rrset.push(record);

--- a/proto/src/rr/dnssec/tbs.rs
+++ b/proto/src/rr/dnssec/tbs.rs
@@ -2,7 +2,6 @@
 
 use super::rdata::{sig, DNSSECRData, SIG};
 use error::*;
-use op::EncodableMessage;
 use rr::dnssec::Algorithm;
 use rr::{DNSClass, Name, RData, Record, RecordType};
 use serialize::binary::{BinEncodable, BinEncoder, EncodeMode};
@@ -23,7 +22,7 @@ impl AsRef<[u8]> for TBS {
 }
 
 /// Returns the to-be-signed serialization of the given message.
-pub fn message_tbs<M: EncodableMessage>(message: &M, pre_sig0: &SIG) -> ProtoResult<TBS> {
+pub fn message_tbs<M: BinEncodable>(message: &M, pre_sig0: &SIG) -> ProtoResult<TBS> {
     // TODO: should perform the serialization and sign block by block to reduce the max memory
     //  usage, though at 4k max, this is probably unnecessary... For AXFR and large zones, it's
     //  more important

--- a/proto/src/rr/dnssec/verifier.rs
+++ b/proto/src/rr/dnssec/verifier.rs
@@ -2,10 +2,10 @@
 
 use error::*;
 use op::EncodableMessage;
-use rr::{DNSClass, Name, Record};
+use rr::dnssec::rdata::{DNSKEY, KEY, SIG};
 use rr::dnssec::Algorithm;
 use rr::dnssec::{tbs, PublicKey, PublicKeyEnum};
-use rr::dnssec::rdata::{DNSKEY, KEY, SIG};
+use rr::{DNSClass, Name, Record};
 
 /// Types which are able to verify DNS based signatures
 pub trait Verifier {

--- a/proto/src/rr/dnssec/verifier.rs
+++ b/proto/src/rr/dnssec/verifier.rs
@@ -1,11 +1,11 @@
 //! Verifier is a structure for performing many of the signing processes of the DNSSec specification
 
 use error::*;
-use op::EncodableMessage;
 use rr::dnssec::rdata::{DNSKEY, KEY, SIG};
 use rr::dnssec::Algorithm;
 use rr::dnssec::{tbs, PublicKey, PublicKeyEnum};
 use rr::{DNSClass, Name, Record};
+use serialize::binary::BinEncodable;
 
 /// Types which are able to verify DNS based signatures
 pub trait Verifier {
@@ -41,7 +41,7 @@ pub trait Verifier {
     /// # Return value
     ///
     /// `true` if the message could be validated against the signature, `false` otherwise
-    fn verify_message<M: EncodableMessage>(
+    fn verify_message<M: BinEncodable>(
         &self,
         message: &M,
         signature: &[u8],

--- a/proto/src/rr/mod.rs
+++ b/proto/src/rr/mod.rs
@@ -34,3 +34,4 @@ pub use self::record_type::RecordType;
 pub use self::resource::Record;
 pub use self::rr_set::IntoRecordSet;
 pub use self::rr_set::RecordSet;
+pub use self::rr_set::RrsetRecords;

--- a/proto/src/rr/resource.rs
+++ b/proto/src/rr/resource.rs
@@ -140,7 +140,7 @@ impl Record {
     ///                 field specifies the meaning of the data in the RDATA
     ///                 field.
     /// ```
-    #[deprecated(note = "use `Record::set_record_type`")]
+    // #[deprecated(note = "use `Record::set_record_type`")]
     pub fn set_rr_type(&mut self, rr_type: RecordType) -> &mut Self {
         self.rr_type = rr_type;
         self
@@ -195,7 +195,7 @@ impl Record {
     }
 
     /// Returns the type of the RData in the record
-    #[deprecated(note = "use `Record::record_type`")]
+    // #[deprecated(note = "use `Record::record_type`")]
     pub fn rr_type(&self) -> RecordType {
         self.rr_type
     }

--- a/proto/src/rr/resource.rs
+++ b/proto/src/rr/resource.rs
@@ -18,15 +18,15 @@
 
 use std::cmp::Ordering;
 
-use serialize::binary::*;
 use error::*;
 use rr::dns_class::DNSClass;
-use rr::Name;
-use rr::IntoRecordSet;
 use rr::rdata::NULL;
+use rr::IntoRecordSet;
+use rr::Name;
 use rr::RData;
-use rr::RecordType;
 use rr::RecordSet;
+use rr::RecordType;
+use serialize::binary::*;
 
 /// Resource records are storage value in DNS, into which all key/value pair data is stored.
 ///
@@ -117,12 +117,7 @@ impl Record {
     /// * `rr_type` - the record type
     /// * `ttl` - time-to-live is the amount of time this record should be cached before refreshing
     /// * `rdata` - record data to associate with the Record
-    pub fn from_rdata(
-        name: Name,
-        ttl: u32,
-        record_type: RecordType,
-        rdata: RData,
-    ) -> Record {
+    pub fn from_rdata(name: Name, ttl: u32, record_type: RecordType, rdata: RData) -> Record {
         Record {
             name_labels: name,
             rr_type: record_type,
@@ -145,7 +140,18 @@ impl Record {
     ///                 field specifies the meaning of the data in the RDATA
     ///                 field.
     /// ```
+    #[deprecated(note = "use `Record::set_record_type`")]
     pub fn set_rr_type(&mut self, rr_type: RecordType) -> &mut Self {
+        self.rr_type = rr_type;
+        self
+    }
+
+    /// ```text
+    /// TYPE            two octets containing one of the RR type codes.  This
+    ///                 field specifies the meaning of the data in the RDATA
+    ///                 field.
+    /// ```
+    pub fn set_record_type(&mut self, rr_type: RecordType) -> &mut Self {
         self.rr_type = rr_type;
         self
     }
@@ -189,7 +195,13 @@ impl Record {
     }
 
     /// Returns the type of the RData in the record
+    #[deprecated(note = "use `Record::record_type`")]
     pub fn rr_type(&self) -> RecordType {
+        self.rr_type
+    }
+
+    /// Returns the type of the RecordData in the record
+    pub fn record_type(&self) -> RecordType {
         self.rr_type
     }
 
@@ -323,20 +335,22 @@ impl PartialEq for Record {
     /// ```
     fn eq(&self, other: &Self) -> bool {
         // self == other && // the same pointer
-        self.name_labels == other.name_labels && self.rr_type == other.rr_type
-            && self.dns_class == other.dns_class && self.rdata == other.rdata
+        self.name_labels == other.name_labels
+            && self.rr_type == other.rr_type
+            && self.dns_class == other.dns_class
+            && self.rdata == other.rdata
     }
 }
 
 /// returns the value of the compare if the items are greater or lesser, but coninues on equal
 macro_rules! compare_or_equal {
-  ( $x:ident, $y:ident, $z:ident ) => (
-    match $x.$z.partial_cmp(&$y.$z) {
-      o @ Some(Ordering::Less) | o @ Some(Ordering::Greater) => return o,
-      None => return None,
-      Some(Ordering::Equal) => (),
-    }
-  );
+    ($x:ident, $y:ident, $z:ident) => {
+        match $x.$z.partial_cmp(&$y.$z) {
+            o @ Some(Ordering::Less) | o @ Some(Ordering::Greater) => return o,
+            None => return None,
+            Some(Ordering::Equal) => (),
+        }
+    };
 }
 
 impl PartialOrd<Record> for Record {
@@ -386,7 +400,6 @@ impl PartialOrd<Record> for Record {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use std::cmp::Ordering;
@@ -394,13 +407,12 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    #[allow(unused)]
-    use serialize::binary::*;
+    use rr::dns_class::DNSClass;
     use rr::record_data::RData;
     use rr::record_type::RecordType;
-    use rr::dns_class::DNSClass;
     use rr::Name;
-
+    #[allow(unused)]
+    use serialize::binary::*;
 
     #[test]
     fn test_emit_and_read() {

--- a/proto/src/rr/rr_set.rs
+++ b/proto/src/rr/rr_set.rs
@@ -199,7 +199,7 @@ impl RecordSet {
     }
 
     /// Returns an iterator over the records in the set
-    #[deprecated]
+    #[deprecated(note = "see `records_without_rrsigs`")]
     pub fn iter<'s>(&'s self) -> Iter<'s, Record> {
         self.records.iter()
     }
@@ -497,6 +497,7 @@ impl<'r> Iterator for RrsigsByAlgorithms<'r> {
     }
 }
 
+/// An iterator over the RecordSet data
 #[derive(Debug)]
 pub enum RrsetRecords<'r> {
     /// There are no records in the record set

--- a/proto/src/rr/rr_set.rs
+++ b/proto/src/rr/rr_set.rs
@@ -155,11 +155,11 @@ impl RecordSet {
     /// * `supported_algorithms` - the RRSIGs will be filtered by the set of supported_algorithms,
     ///                            and then only the maximal RRSIG algorithm will be returned.
     #[cfg(feature = "dnssec")]
-    pub fn records(
-        &self,
+    pub fn records<'s>(
+        &'s self,
         and_rrsigs: bool,
         supported_algorithms: SupportedAlgorithms,
-    ) -> Vec<&Record> {
+    ) -> RrsetRecords<'s> {
         if and_rrsigs {
             self.records_with_rrsigs(supported_algorithms)
         } else {
@@ -174,42 +174,32 @@ impl RecordSet {
     /// * `supported_algorithms` - the RRSIGs will be filtered by the set of supported_algorithms,
     ///                            and then only the maximal RRSIG algorithm will be returned.
     #[cfg(feature = "dnssec")]
-    pub fn records_with_rrsigs(&self, supported_algorithms: SupportedAlgorithms) -> Vec<&Record> {
-        use rr::dnssec::Algorithm;
-        use rr::dnssec::rdata::DNSSECRData;
-
-        // disable rfc 6975 when no supported_algorithms specified
-        if supported_algorithms.is_empty() {
-            return self.records.iter().chain(self.rrsigs.iter()).collect();
+    pub fn records_with_rrsigs<'s>(
+        &'s self,
+        supported_algorithms: SupportedAlgorithms,
+    ) -> RrsetRecords<'s> {
+        if self.records.is_empty() {
+            RrsetRecords::Empty
+        } else {
+            let rrsigs = RrsigsByAlgorithms {
+                rrsigs: self.rrsigs.iter(),
+                supported_algorithms,
+            };
+            RrsetRecords::RecordsAndRrsigs(RecordsAndRrsigsIter(self.records.iter().chain(rrsigs)))
         }
-
-        let rrsigs = self.rrsigs
-            .iter()
-            .filter(|record| {
-                if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *record.rdata() {
-                    supported_algorithms.has(rrsig.algorithm())
-                } else {
-                    false
-                }
-            })
-            .max_by_key(|record| {
-                if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *record.rdata() {
-                    rrsig.algorithm()
-                } else {
-                    Algorithm::RSASHA1
-                }
-            });
-
-        self.records.iter().chain(rrsigs).collect()
     }
 
-
     /// Returns a Vec of all records in the set, without any RRSIGs.
-    pub fn records_without_rrsigs(&self) -> Vec<&Record> {
-        self.records.iter().collect()
+    pub fn records_without_rrsigs<'s>(&'s self) -> RrsetRecords<'s> {
+        if self.records.is_empty() {
+            RrsetRecords::Empty
+        } else {
+            RrsetRecords::RecordsOnly(self.records.iter())
+        }
     }
 
     /// Returns an iterator over the records in the set
+    #[deprecated]
     pub fn iter<'s>(&'s self) -> Iter<'s, Record> {
         self.records.iter()
     }
@@ -320,8 +310,7 @@ impl RecordSet {
                                 if new_soa.serial() <= existing_soa.serial() {
                                     info!(
                                         "update ignored serial out of data: {:?} <= {:?}",
-                                        new_soa,
-                                        existing_soa
+                                        new_soa, existing_soa
                                     );
                                     return false;
                                 }
@@ -349,7 +338,8 @@ impl RecordSet {
         }
 
         // collect any records to update based on rdata
-        let to_replace: Vec<usize> = self.records
+        let to_replace: Vec<usize> = self
+            .records
             .iter()
             .enumerate()
             .filter(|&(_, rr)| rr.rdata() == record.rdata())
@@ -413,7 +403,8 @@ impl RecordSet {
         }
 
         // remove the records, first collect all the indexes, then remove the records
-        let to_remove: Vec<usize> = self.records
+        let to_remove: Vec<usize> = self
+            .records
             .iter()
             .enumerate()
             .filter(|&(_, rr)| rr.rdata() == record.rdata())
@@ -452,13 +443,101 @@ impl IntoIterator for RecordSet {
     }
 }
 
+#[cfg(feature = "dnssec")]
+#[derive(Debug)]
+pub struct RecordsAndRrsigsIter<'r>(Chain<Iter<'r, Record>, RrsigsByAlgorithms<'r>>);
+
+#[cfg(feature = "dnssec")]
+impl<'r> Iterator for RecordsAndRrsigsIter<'r> {
+    type Item = &'r Record;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+#[cfg(feature = "dnssec")]
+#[derive(Debug)]
+pub struct RrsigsByAlgorithms<'r> {
+    rrsigs: Iter<'r, Record>,
+    supported_algorithms: SupportedAlgorithms,
+}
+
+#[cfg(feature = "dnssec")]
+impl<'r> Iterator for RrsigsByAlgorithms<'r> {
+    type Item = &'r Record;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use rr::dnssec::rdata::DNSSECRData;
+        use rr::dnssec::Algorithm;
+
+        let supported_algorithms = self.supported_algorithms;
+
+        // disable rfc 6975 when no supported_algorithms specified
+        if supported_algorithms.is_empty() {
+            self.rrsigs.next()
+        } else {
+            self.rrsigs
+                .by_ref()
+                .filter(|record| {
+                    if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *record.rdata() {
+                        supported_algorithms.has(rrsig.algorithm())
+                    } else {
+                        false
+                    }
+                })
+                .max_by_key(|record| {
+                    if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *record.rdata() {
+                        rrsig.algorithm()
+                    } else {
+                        Algorithm::RSASHA1
+                    }
+                })
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum RrsetRecords<'r> {
+    /// There are no records in the record set
+    Empty,
+    /// The records associated with the record set
+    RecordsOnly(Iter<'r, Record>),
+    /// The records along with their signatures in the record set
+    #[cfg(feature = "dnssec")]
+    RecordsAndRrsigs(RecordsAndRrsigsIter<'r>),
+}
+
+impl<'r> RrsetRecords<'r> {
+    /// This is a best effort emptyness check
+    pub fn is_empty(&self) -> bool {
+        match *self {
+            RrsetRecords::Empty => true,
+            _ => false,
+        }
+    }
+}
+
+impl<'r> Iterator for RrsetRecords<'r> {
+    type Item = &'r Record;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            RrsetRecords::Empty => None,
+            RrsetRecords::RecordsOnly(i) => i.next(),
+            #[cfg(feature = "dnssec")]
+            RrsetRecords::RecordsAndRrsigs(i) => i.next(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
     use std::net::Ipv4Addr;
+    use std::str::FromStr;
 
-    use rr::*;
     use rr::rdata::SOA;
+    use rr::*;
 
     #[test]
     fn test_insert() {
@@ -475,13 +554,23 @@ mod test {
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
-        assert_eq!(rr_set.records_without_rrsigs().len(), 1);
-        assert!(rr_set.records_without_rrsigs().contains(&&insert));
+        assert_eq!(rr_set.records_without_rrsigs().count(), 1);
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
 
         // dups ignored
         assert!(!rr_set.insert(insert.clone(), 0));
-        assert_eq!(rr_set.records_without_rrsigs().len(), 1);
-        assert!(rr_set.records_without_rrsigs().contains(&&insert));
+        assert_eq!(rr_set.records_without_rrsigs().count(), 1);
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
 
         // add one
         let insert1 = Record::new()
@@ -492,9 +581,19 @@ mod test {
             .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 25)))
             .clone();
         assert!(rr_set.insert(insert1.clone(), 0));
-        assert_eq!(rr_set.records_without_rrsigs().len(), 2);
-        assert!(rr_set.records_without_rrsigs().contains(&&insert));
-        assert!(rr_set.records_without_rrsigs().contains(&&insert1));
+        assert_eq!(rr_set.records_without_rrsigs().count(), 2);
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert1)
+        );
     }
 
     #[test]
@@ -550,19 +649,49 @@ mod test {
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
-        assert!(rr_set.records_without_rrsigs().contains(&&insert));
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
         // same serial number
         assert!(!rr_set.insert(same_serial.clone(), 0));
-        assert!(rr_set.records_without_rrsigs().contains(&&insert));
-        assert!(!rr_set.records_without_rrsigs().contains(&&same_serial,));
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
+        assert!(
+            !rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&same_serial,)
+        );
 
         assert!(rr_set.insert(new_serial.clone(), 0));
         assert!(!rr_set.insert(same_serial.clone(), 0));
         assert!(!rr_set.insert(insert.clone(), 0));
 
-        assert!(rr_set.records_without_rrsigs().contains(&&new_serial));
-        assert!(!rr_set.records_without_rrsigs().contains(&&insert));
-        assert!(!rr_set.records_without_rrsigs().contains(&&same_serial));
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&new_serial)
+        );
+        assert!(
+            !rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
+        assert!(
+            !rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&same_serial)
+        );
     }
 
     #[test]
@@ -590,12 +719,27 @@ mod test {
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
-        assert!(rr_set.records_without_rrsigs().contains(&&insert));
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
 
         // update the record
         assert!(rr_set.insert(new_record.clone(), 0));
-        assert!(!rr_set.records_without_rrsigs().contains(&&insert));
-        assert!(rr_set.records_without_rrsigs().contains(&&new_record));
+        assert!(
+            !rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&new_record)
+        );
     }
 
     #[test]
@@ -652,7 +796,12 @@ mod test {
 
         assert!(rr_set.insert(insert.clone(), 0));
         assert!(!rr_set.remove(&insert, 0));
-        assert!(rr_set.records_without_rrsigs().contains(&&insert));
+        assert!(
+            rr_set
+                .records_without_rrsigs()
+                .collect::<Vec<_>>()
+                .contains(&&insert)
+        );
     }
 
     #[test]
@@ -694,8 +843,8 @@ mod test {
     #[cfg(feature = "dnssec")] // This tests RFC 6975, a DNSSEC-specific feature.
     fn test_get_filter() {
         use rr::dnssec::rdata::SIG;
-        use rr::dnssec::{Algorithm, SupportedAlgorithms};
         use rr::dnssec::rdata::{DNSSECRData, DNSSECRecordType};
+        use rr::dnssec::{Algorithm, SupportedAlgorithms};
 
         let name = Name::root();
         let rsasha256 = SIG::new(
@@ -789,38 +938,33 @@ mod test {
         assert!(
             rrset
                 .records_with_rrsigs(SupportedAlgorithms::all(),)
-                .iter()
-                .any(|r| {
-                    if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
+                .any(
+                    |r| if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
                         sig.algorithm() == Algorithm::ED25519
                     } else {
                         false
-                    }
-                },)
+                    },
+                )
         );
 
         let mut supported_algorithms = SupportedAlgorithms::new();
         supported_algorithms.set(Algorithm::ECDSAP384SHA384);
-        assert!(rrset.records_with_rrsigs(supported_algorithms).iter().any(
-            |r| {
-                if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
-                    sig.algorithm() == Algorithm::ECDSAP384SHA384
-                } else {
-                    false
-                }
+        assert!(rrset.records_with_rrsigs(supported_algorithms).any(|r| {
+            if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
+                sig.algorithm() == Algorithm::ECDSAP384SHA384
+            } else {
+                false
             }
-        ));
+        }));
 
         let mut supported_algorithms = SupportedAlgorithms::new();
         supported_algorithms.set(Algorithm::ED25519);
-        assert!(rrset.records_with_rrsigs(supported_algorithms).iter().any(
-            |r| {
-                if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
-                    sig.algorithm() == Algorithm::ED25519
-                } else {
-                    false
-                }
+        assert!(rrset.records_with_rrsigs(supported_algorithms).any(|r| {
+            if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
+                sig.algorithm() == Algorithm::ED25519
+            } else {
+                false
             }
-        ));
+        }));
     }
 }

--- a/proto/src/rr/rr_set.rs
+++ b/proto/src/rr/rr_set.rs
@@ -443,6 +443,7 @@ impl IntoIterator for RecordSet {
     }
 }
 
+/// An iterator over all the records and their signatures
 #[cfg(feature = "dnssec")]
 #[derive(Debug)]
 pub struct RecordsAndRrsigsIter<'r>(Chain<Iter<'r, Record>, RrsigsByAlgorithms<'r>>);
@@ -456,6 +457,7 @@ impl<'r> Iterator for RecordsAndRrsigsIter<'r> {
     }
 }
 
+/// An iterator that limits the record signatures by SupportedAlgorithms
 #[cfg(feature = "dnssec")]
 #[derive(Debug)]
 pub struct RrsigsByAlgorithms<'r> {

--- a/proto/src/serialize/binary/encoder.rs
+++ b/proto/src/serialize/binary/encoder.rs
@@ -493,6 +493,7 @@ impl<T: EncodedSize> Place<T> {
     }
 }
 
+/// A type representing a rollback point in a stream
 pub struct Rollback {
     rollback_index: usize,
 }

--- a/proto/src/serialize/binary/encoder.rs
+++ b/proto/src/serialize/binary/encoder.rs
@@ -365,21 +365,8 @@ impl<'a> BinEncoder<'a> {
         I: Iterator<Item = &'r &'e E>,
         E: 'r + 'e + BinEncodable,
     {
-        let mut count = 0;
-        for i in iter {
-            let rollback = self.set_rollback();
-            i.emit(self).map_err(|e| {
-                if let ProtoErrorKind::MaxBufferSizeExceeded(_) = e.kind() {
-                    rollback.rollback(self);
-                    return ProtoErrorKind::NotAllRecordsWritten { count }.into();
-                } else {
-                    return e;
-                }
-            })?;
-            count += 1;
-        }
-
-        Ok(count)
+        let mut iter = iter.map(|i| *i);
+        self.emit_iter(&mut iter)
     }
 
     /// emits all items in the iterator, return the number emited

--- a/proto/src/serialize/binary/encoder.rs
+++ b/proto/src/serialize/binary/encoder.rs
@@ -20,6 +20,7 @@ use byteorder::{ByteOrder, NetworkEndian};
 use error::{ProtoErrorKind, ProtoResult};
 
 use super::BinEncodable;
+use op::Header;
 
 // this is private to make sure there is no accidental access to the inner buffer.
 mod private {
@@ -28,15 +29,15 @@ mod private {
     /// A wrapper for a buffer that guarantees writes never exceed a defined set of bytes
     pub struct MaximalBuf<'a> {
         max_size: usize,
-        buffer: &'a mut Vec<u8>
+        buffer: &'a mut Vec<u8>,
     }
 
     impl<'a> MaximalBuf<'a> {
         pub fn new(max_size: u16, buffer: &'a mut Vec<u8>) -> Self {
-           MaximalBuf {
-               max_size: max_size as usize,
-               buffer,
-           }
+            MaximalBuf {
+                max_size: max_size as usize,
+                buffer,
+            }
         }
 
         /// Sets the maximum size to enforce
@@ -48,7 +49,8 @@ mod private {
         ///
         /// and reserves the additional space in the buffer
         pub fn enforced_write<F>(&mut self, additional: usize, writer: F) -> ProtoResult<()>
-        where F: FnOnce(&mut Vec<u8>) -> ()
+        where
+            F: FnOnce(&mut Vec<u8>) -> (),
         {
             let expected_len = self.buffer.len() + additional;
 
@@ -67,7 +69,7 @@ mod private {
         pub fn truncate(&mut self, len: usize) {
             self.buffer.truncate(len)
         }
- 
+
         /// returns the length of the underlying buffer
         pub fn len(&self) -> usize {
             self.buffer.len()
@@ -90,7 +92,7 @@ pub struct BinEncoder<'a> {
     offset: usize,
     buffer: private::MaximalBuf<'a>,
     /// start and end of label pointers, smallvec here?
-    name_pointers: Vec<(usize, usize)>, 
+    name_pointers: Vec<(usize, usize)>,
     mode: EncodeMode,
     canonical_names: bool,
 }
@@ -195,7 +197,8 @@ impl<'a> BinEncoder<'a> {
     pub fn trim(&mut self) {
         let offset = self.offset;
         self.buffer.truncate(offset);
-        self.name_pointers.retain(|&(start, end)| start < offset && end <= offset);
+        self.name_pointers
+            .retain(|&(start, end)| start < offset && end <= offset);
     }
 
     // /// returns an error if the maximum buffer size would be exceeded with the addition number of elements
@@ -237,11 +240,11 @@ impl<'a> BinEncoder<'a> {
         for &(match_start, match_end) in &self.name_pointers {
             let matcher = self.slice_of(match_start as usize, match_end as usize);
             if matcher == search {
-                assert!(match_start <= (u16::max_value() as usize)); 
-                return Some(match_start as u16)
+                assert!(match_start <= (u16::max_value() as usize));
+                return Some(match_start as u16);
             }
         }
-        
+
         None
     }
 
@@ -249,10 +252,11 @@ impl<'a> BinEncoder<'a> {
     pub fn emit(&mut self, b: u8) -> ProtoResult<()> {
         if self.offset < self.buffer.len() {
             let offset = self.offset;
-            self.buffer.enforced_write(0, |buffer|
-            *buffer
-                .get_mut(offset)
-                .expect("could not get index at offset") = b)?;
+            self.buffer.enforced_write(0, |buffer| {
+                *buffer
+                    .get_mut(offset)
+                    .expect("could not get index at offset") = b
+            })?;
         } else {
             self.buffer.enforced_write(1, |buffer| buffer.push(b))?;
         }
@@ -319,20 +323,21 @@ impl<'a> BinEncoder<'a> {
         // replacement case, the necessary space should have been reserved already...
         if self.offset < self.buffer.len() {
             let offset = self.offset;
-        
+
             self.buffer.enforced_write(0, |buffer| {
                 let mut offset = offset;
-            for b in data {
+                for b in data {
                     *buffer
                         .get_mut(offset)
-                  .expect("could not get index at offset for slice") = *b;
+                        .expect("could not get index at offset for slice") = *b;
                     offset += 1;
-            }
+                }
             })?;
 
             self.offset += data.len();
         } else {
-            self.buffer.enforced_write(data.len(), |buffer| buffer.extend_from_slice(data))?;
+            self.buffer
+                .enforced_write(data.len(), |buffer| buffer.extend_from_slice(data))?;
             self.offset += data.len();
         }
 
@@ -348,33 +353,56 @@ impl<'a> BinEncoder<'a> {
     pub fn emit_all<'e, I: Iterator<Item = &'e E>, E: 'e + BinEncodable>(
         &mut self,
         iter: I,
-    ) -> ProtoResult<()> {
+    ) -> ProtoResult<usize> {
+        let mut count = 0;
         for i in iter {
-            i.emit(self)?
+            let rollback = self.set_rollback();
+            i.emit(self).map_err(|e| {
+                if let ProtoErrorKind::MaxBufferSizeExceeded(_) = e.kind() {
+                    rollback.rollback(self);
+                    return ProtoErrorKind::NotAllRecordsWritten { count }.into();
+                } else {
+                    return e;
+                }
+            })?;
+            count += 1;
         }
-        Ok(())
+        Ok(count)
     }
 
+    // TODO: dedup with above emit_all
     /// Emits all the elements of an Iterator to the encoder
-    pub fn emit_all_refs<'r, 'e, I, E>(&mut self, iter: I) -> ProtoResult<()>
+    pub fn emit_all_refs<'r, 'e, I, E>(&mut self, iter: I) -> ProtoResult<usize>
     where
         'e: 'r,
         I: Iterator<Item = &'r &'e E>,
         E: 'r + 'e + BinEncodable,
     {
+        let mut count = 0;
         for i in iter {
-            i.emit(self)?
+            let rollback = self.set_rollback();
+            i.emit(self).map_err(|e| {
+                if let ProtoErrorKind::MaxBufferSizeExceeded(_) = e.kind() {
+                    rollback.rollback(self);
+                    return ProtoErrorKind::NotAllRecordsWritten { count }.into();
+                } else {
+                    return e;
+                }
+            })?;
+            count += 1;
         }
-        Ok(())
+
+        Ok(count)
     }
 
     /// capture a location to write back to
     pub fn place<T: EncodedSize>(&mut self) -> ProtoResult<Place<T>> {
         let index = self.offset;
         let len = T::size_of();
- 
+
         // resize the buffer
-        self.buffer.enforced_write(len, |buffer| buffer.resize(index + len, 0))?;
+        self.buffer
+            .enforced_write(len, |buffer| buffer.resize(index + len, 0))?;
 
         // update the offset
         self.offset += len;
@@ -412,18 +440,31 @@ impl<'a> BinEncoder<'a> {
 
         emit_result
     }
+
+    fn set_rollback(&self) -> Rollback {
+        Rollback {
+            rollback_index: self.offset(),
+        }
+    }
 }
 
 /// A trait to return the size of a type as it will be encoded in DNS
 ///
 /// it does not necessarily equal `std::mem::size_of`, though it might, especially for primitives
 pub trait EncodedSize: BinEncodable {
+    /// Return the size in bytes of the
     fn size_of() -> usize;
 }
 
 impl EncodedSize for u16 {
     fn size_of() -> usize {
         2
+    }
+}
+
+impl EncodedSize for Header {
+    fn size_of() -> usize {
+        Header::len()
     }
 }
 
@@ -444,6 +485,16 @@ impl<T: EncodedSize> Place<T> {
     }
 }
 
+pub struct Rollback {
+    rollback_index: usize,
+}
+
+impl Rollback {
+    pub fn rollback(self, encoder: &mut BinEncoder) {
+        encoder.set_offset(self.rollback_index)
+    }
+}
+
 /// In the Verify mode there maybe some things which are encoded differently, e.g. SIG0 records
 ///  should not be included in the additional count and not in the encoded data when in Verify
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -454,12 +505,11 @@ pub enum EncodeMode {
     Normal,
 }
 
-
 #[cfg(test)]
 mod tests {
+    use super::*;
     use op::Message;
     use serialize::binary::BinDecoder;
-    use super::*;
 
     #[test]
     fn test_label_compression_regression() {
@@ -471,7 +521,14 @@ mod tests {
         ;; AUTHORITY SECTION:
         gds.alibabadns.com.     1799    IN      SOA     gdsns1.alibabadns.com. none. 2015080610 1800 600 3600 360
         */
-        let data: Vec<u8> = vec![154, 50, 129, 128, 0, 1, 0, 0, 0, 1, 0, 1, 7, 98, 108, 117, 101, 100, 111, 116, 2, 105, 115, 8, 97, 117, 116, 111, 110, 97, 118, 105, 3, 99, 111, 109, 3, 103, 100, 115, 10, 97, 108, 105, 98, 97, 98, 97, 100, 110, 115, 3, 99, 111, 109, 0, 0, 28, 0, 1, 192, 36, 0, 6, 0, 1, 0, 0, 7, 7, 0, 35, 6, 103, 100, 115, 110, 115, 49, 192, 40, 4, 110, 111, 110, 101, 0, 120, 27, 176, 162, 0, 0, 7, 8, 0, 0, 2, 88, 0, 0, 14, 16, 0, 0, 1, 104, 0, 0, 41, 2, 0, 0, 0, 0, 0, 0, 0];
+        let data: Vec<u8> = vec![
+            154, 50, 129, 128, 0, 1, 0, 0, 0, 1, 0, 1, 7, 98, 108, 117, 101, 100, 111, 116, 2, 105,
+            115, 8, 97, 117, 116, 111, 110, 97, 118, 105, 3, 99, 111, 109, 3, 103, 100, 115, 10,
+            97, 108, 105, 98, 97, 98, 97, 100, 110, 115, 3, 99, 111, 109, 0, 0, 28, 0, 1, 192, 36,
+            0, 6, 0, 1, 0, 0, 7, 7, 0, 35, 6, 103, 100, 115, 110, 115, 49, 192, 40, 4, 110, 111,
+            110, 101, 0, 120, 27, 176, 162, 0, 0, 7, 8, 0, 0, 2, 88, 0, 0, 14, 16, 0, 0, 1, 104, 0,
+            0, 41, 2, 0, 0, 0, 0, 0, 0, 0,
+        ];
 
         let msg = Message::from_vec(&data).unwrap();
         msg.to_bytes().unwrap();

--- a/proto/src/xfer/dns_future.rs
+++ b/proto/src/xfer/dns_future.rs
@@ -35,8 +35,6 @@ struct ActiveRequest<E: FromProtoError> {
     completion: Complete<Result<DnsResponse, E>>,
     request_id: u16,
     request_options: DnsRequestOptions,
-    // the original request and associated options
-    //request: DnsRequest,
     // most requests pass a single Message response directly through to the completion
     //  this small vec will have no allocations, unless the requests is a DNS-SD request
     //  expecting more than one response
@@ -49,7 +47,6 @@ impl<E: FromProtoError> ActiveRequest<E> {
         completion: Complete<Result<DnsResponse, E>>,
         request_id: u16,
         request_options: DnsRequestOptions,
-        // request: DnsRequest,
         timeout: Delay,
     ) -> Self {
         ActiveRequest {
@@ -77,17 +74,15 @@ impl<E: FromProtoError> ActiveRequest<E> {
         self.responses.push(message);
     }
 
+    /// the request id of the message that was sent
     fn request_id(&self) -> u16 {
         self.request_id
     }
 
+    /// the request options from the message that was sent
     fn request_options(&self) -> &DnsRequestOptions {
         &self.request_options
     }
-
-    // fn request(&mut self) -> &mut DnsRequest {
-    //     &mut self.request
-    // }
 
     /// Sends an error
     fn complete_with_error(self, error: ProtoError) {

--- a/proto/src/xfer/dns_request.rs
+++ b/proto/src/xfer/dns_request.rs
@@ -42,6 +42,11 @@ impl DnsRequest {
     pub fn options(&self) -> &DnsRequestOptions {
         &self.options
     }
+
+    /// Unwraps the raw message
+    pub fn unwrap(self) -> Message {
+        self.message
+    }
 }
 
 impl Deref for DnsRequest {

--- a/server/src/authority/auth_lookup.rs
+++ b/server/src/authority/auth_lookup.rs
@@ -5,60 +5,100 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::iter::Chain;
 use std::slice::Iter;
 
 use trust_dns::rr::Record;
 
+use authority::authority::LookupRecords;
+
 /// The result of a lookup on an Authority
-#[derive(Debug, Eq, PartialEq)]
-pub enum AuthLookup<'r> {
-    /// There are other record types with the specified name
-    NameExists,
+///
+/// # Lifetimes
+///
+/// * `'c` - the catalogue lifetime
+/// * `'r` - the recordset lifetime, subset of 'c
+/// * `'q` - the queries lifetime
+#[derive(Debug)]
+pub enum AuthLookup<'r, 'q> {
     /// There is no matching name for the query
-    NoName,
+    NxDomain,
+    /// There are no matching records for the query, but there are others associated to the name
+    NameExists,
     // TODO: change the result of a lookup to a set of chained iterators...
     /// Records
-    Records(Vec<&'r Record>),
+    Records(LookupRecords<'r, 'q>),
+    /// Soa only differs from Records in that the lifetime on the name is from the authority, and not the query
+    SOA(LookupRecords<'r, 'r>),
+    /// An axfr starts with soa, chained to all the records, then another soa...
+    AXFR(Chain<Chain<LookupRecords<'r, 'r>, LookupRecords<'r, 'q>>, LookupRecords<'r, 'r>>),
 }
 
-impl<'r> AuthLookup<'r> {
-    /// Returns true if either the associated Records are empty, or this is a NameExists or NoName
+impl<'r, 'q> AuthLookup<'r, 'q> {
+    /// Returns true if either the associated Records are empty, or this is a NameExists or NxDomain
     pub fn is_empty(&self) -> bool {
         match *self {
-            AuthLookup::NameExists | AuthLookup::NoName => true,
-            AuthLookup::Records(ref records) => records.is_empty(),
+            AuthLookup::NameExists | AuthLookup::NxDomain => true,
+            _ => false,
         }
     }
 
-    /// Returns an iterator over the records
-    pub fn iter(&'r self) -> AuthLookupIter<'r> {
+    /// This is a non-existant domain name
+    pub fn is_nx_domain(&self) -> bool {
         match *self {
-            AuthLookup::NameExists | AuthLookup::NoName => AuthLookupIter(None),
-            AuthLookup::Records(ref records) => AuthLookupIter(Some(records.iter())),
+            AuthLookup::NxDomain => true,
+            _ => false,
         }
     }
 
-    /// Unwraps the associated records, or panics if this is a NameExists or NoNmae
-    pub fn unwrap(self) -> Vec<&'r Record> {
-        if let AuthLookup::Records(records) = self {
-            records
-        } else {
-            panic!("AuthLookup was not Records: {:?}", self)
-        }
-    }
+    // /// Returns an iterator over the records
+    // pub fn iter(&'r self) -> AuthLookupIter<'r> {
+    //     match *self {
+    //         AuthLookup::NameExists | AuthLookup::NoName => AuthLookupIter(None),
+    //         AuthLookup::Records(ref records) => AuthLookupIter(Some(records.iter())),
+    //     }
+    // }
+
+    // /// Unwraps the associated records, or panics if this is a NameExists or NoNmae
+    // pub fn unwrap(self) -> Vec<&'r Record> {
+    //     if let AuthLookup::Records(records) = self {
+    //         records
+    //     } else {
+    //         panic!("AuthLookup was not Records: {:?}", self)
+    //     }
+    // }
 }
 
-/// An Iterator for AuthLookup
-pub struct AuthLookupIter<'r>(Option<Iter<'r, &'r Record>>);
+// /// An Iterator for AuthLookup
+// pub struct AuthLookupIter<'r>(Option<Iter<'r, &'r Record>>);
 
-impl<'r> Iterator for AuthLookupIter<'r> {
+// impl<'r> Iterator for AuthLookupIter<'r> {
+//     type Item = &'r Record;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if let Some(ref mut iter) = self.0 {
+//             iter.next().map(|r| *r)
+//         } else {
+//             None
+//         }
+//     }
+// }
+
+impl<'r, 'q> Iterator for AuthLookup<'r, 'q> {
     type Item = &'r Record;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(ref mut iter) = self.0 {
-            iter.next().map(|r| *r)
-        } else {
-            None
+        match self {
+            AuthLookup::NxDomain | AuthLookup::NameExists => None,
+            AuthLookup::Records(ref mut i) => i.next(),
+            AuthLookup::SOA(ref mut i) => i.next(),
+            AuthLookup::AXFR(ref mut i) => i.next(),
         }
+    }
+}
+
+impl<'r, 'q> Default for AuthLookup<'r, 'q> {
+    fn default() -> Self {
+        AuthLookup::NxDomain
     }
 }

--- a/server/src/authority/auth_lookup.rs
+++ b/server/src/authority/auth_lookup.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use std::iter::Chain;
-use std::slice::Iter;
 
 use trust_dns::rr::Record;
 
@@ -50,39 +49,7 @@ impl<'r, 'q> AuthLookup<'r, 'q> {
             _ => false,
         }
     }
-
-    // /// Returns an iterator over the records
-    // pub fn iter(&'r self) -> AuthLookupIter<'r> {
-    //     match *self {
-    //         AuthLookup::NameExists | AuthLookup::NoName => AuthLookupIter(None),
-    //         AuthLookup::Records(ref records) => AuthLookupIter(Some(records.iter())),
-    //     }
-    // }
-
-    // /// Unwraps the associated records, or panics if this is a NameExists or NoNmae
-    // pub fn unwrap(self) -> Vec<&'r Record> {
-    //     if let AuthLookup::Records(records) = self {
-    //         records
-    //     } else {
-    //         panic!("AuthLookup was not Records: {:?}", self)
-    //     }
-    // }
 }
-
-// /// An Iterator for AuthLookup
-// pub struct AuthLookupIter<'r>(Option<Iter<'r, &'r Record>>);
-
-// impl<'r> Iterator for AuthLookupIter<'r> {
-//     type Item = &'r Record;
-
-//     fn next(&mut self) -> Option<Self::Item> {
-//         if let Some(ref mut iter) = self.0 {
-//             iter.next().map(|r| *r)
-//         } else {
-//             None
-//         }
-//     }
-// }
 
 impl<'r, 'q> Iterator for AuthLookup<'r, 'q> {
     type Item = &'r Record;

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -1288,6 +1288,10 @@ impl Authority {
     }
 }
 
+/// An iterator over an ANY query for Records.
+///
+/// The length of this result cannot be known without consuming the iterator.
+///
 /// # Lifetimes
 ///
 /// * `'r` - the record_set's lifetime, from the catalog

--- a/server/src/authority/message_request.rs
+++ b/server/src/authority/message_request.rs
@@ -247,11 +247,7 @@ impl<'r> Queries<'r> {
 }
 
 macro_rules! section {
-    ($s:ident, $l:ident, $e:ident) => {
-        fn $l(&self) -> usize {
-            self.$s.len()
-        }
-
+    ($s:ident, $e:ident) => {
         fn $e(&self, encoder: &mut BinEncoder) -> ProtoResult<usize> {
             encoder.emit_all(self.$s.iter())
         }
@@ -263,19 +259,15 @@ impl<'r> EncodableMessage for MessageRequest<'r> {
         &self.header
     }
 
-    fn queries_len(&self) -> usize {
-        self.queries.len()
-    }
-
     fn emit_queries(&self, encoder: &mut BinEncoder) -> ProtoResult<usize> {
         // we emit the queries, in order to guarantee canonical form
         //   in cases where that's necessary, like SIG0 validation
         encoder.emit_all(self.queries.queries.iter())
     }
 
-    section!(answers, answers_len, emit_answers);
-    section!(name_servers, name_servers_len, emit_name_servers);
-    section!(additionals, additionals_len, emit_additionals);
+    section!(answers, emit_answers);
+    section!(name_servers, emit_name_servers);
+    section!(additionals, emit_additionals);
 
     fn edns(&self) -> Option<&Edns> {
         MessageRequest::edns(self)

--- a/server/src/authority/message_response.rs
+++ b/server/src/authority/message_response.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use trust_dns_proto::error::*;
-use trust_dns_proto::op::EncodableMessage;
 use trust_dns::op::{Edns, Header, MessageType, OpCode, ResponseCode};
 use trust_dns::rr::Record;
 use trust_dns::serialize::binary::BinEncoder;
+use trust_dns_proto::error::*;
+use trust_dns_proto::op::EncodableMessage;
 
 use authority::Queries;
 
@@ -55,7 +55,7 @@ macro_rules! section {
             self.$s.len()
         }
 
-        fn $e(&self, encoder: &mut BinEncoder) -> ProtoResult<()> {
+        fn $e(&self, encoder: &mut BinEncoder) -> ProtoResult<usize> {
             encoder.emit_all_refs(self.$s.iter())
         }
     }
@@ -70,11 +70,13 @@ impl<'q, 'a> EncodableMessage for MessageResponse<'q, 'a> {
         self.queries.map(|s| s.len()).unwrap_or(0)
     }
 
-    fn emit_queries(&self, encoder: &mut BinEncoder) -> ProtoResult<()> {
+    fn emit_queries(&self, encoder: &mut BinEncoder) -> ProtoResult<usize> {
         if let Some(queries) = self.queries {
-            encoder.emit_vec(queries.as_bytes())
+            encoder
+                .emit_vec(queries.as_bytes())
+                .map(|()| self.queries_len())
         } else {
-            Ok(())
+            Ok(0)
         }
     }
 

--- a/server/src/authority/message_response.rs
+++ b/server/src/authority/message_response.rs
@@ -6,13 +6,11 @@
 // copied, modified, or distributed except according to those terms.
 
 use std::iter::Chain;
-use std::ops::Deref;
 
 use trust_dns::rr::Record;
 use trust_dns::serialize::binary::{BinEncodable, BinEncoder, EncodeMode};
 use trust_dns_proto::error::*;
-use trust_dns_proto::op::EncodableMessage;
-use trust_dns_proto::op::{message, Edns, Header, Message, MessageType, OpCode, ResponseCode};
+use trust_dns_proto::op::{message, Edns, Header, MessageType, OpCode, ResponseCode};
 
 use authority::{AuthLookup, LookupRecords, Queries};
 

--- a/server/src/authority/message_response.rs
+++ b/server/src/authority/message_response.rs
@@ -5,10 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::iter::Chain;
+use std::iter::{self, Chain};
 
 use trust_dns::rr::Record;
-use trust_dns::serialize::binary::{BinEncodable, BinEncoder, EncodeMode};
+use trust_dns::serialize::binary::{BinEncoder, EncodeMode};
 use trust_dns_proto::error::*;
 use trust_dns_proto::op::{message, Edns, Header, MessageType, OpCode, ResponseCode};
 
@@ -16,33 +16,29 @@ use authority::{AuthLookup, LookupRecords, Queries};
 
 /// A EncodableMessage with borrowed data for Responses in the Server
 #[derive(Debug)]
-pub struct MessageResponse<'q, 'a> {
+pub struct MessageResponse<
+    'q,
+    'a,
+    A = AuthLookup<'a, 'q>,
+    N = Chain<LookupRecords<'q, 'a>, LookupRecords<'q, 'a>>,
+> where
+    A: 'q + 'a + Iterator<Item = &'a Record>,
+    N: 'q + 'a + Iterator<Item = &'a Record>,
+{
     header: Header,
     queries: Option<&'q Queries<'q>>,
-    answers: AuthLookup<'a, 'q>,
-    name_servers: Chain<LookupRecords<'q, 'a>, LookupRecords<'q, 'a>>,
+    answers: A,
+    name_servers: N,
     additionals: Vec<&'a Record>,
     sig0: Vec<Record>,
     edns: Option<Edns>,
 }
 
-impl<'q, 'a> MessageResponse<'q, 'a> {
-    /// Constructs a new Response
-    ///
-    /// # Arguments
-    ///
-    /// * `queries` - any optional set of Queries to associate with the Response
-    pub fn new(queries: Option<&'q Queries<'q>>) -> MessageResponseBuilder<'q, 'a> {
-        MessageResponseBuilder {
-            queries,
-            answers: None,
-            name_servers: None,
-            additionals: None,
-            sig0: None,
-            edns: None,
-        }
-    }
-
+impl<'q, 'a, A, N> MessageResponse<'q, 'a, A, N>
+where
+    A: 'q + 'a + Iterator<Item = &'a Record>,
+    N: 'q + 'a + Iterator<Item = &'a Record>,
+{
     /// Returns the header of the message
     pub fn header(&self) -> &Header {
         &self.header
@@ -93,8 +89,10 @@ impl<'q, 'a> MessageResponse<'q, 'a> {
 
         if let Some(edns) = self.edns() {
             // need to commit the error code
-            Record::from(edns).emit(encoder)?;
-            additional_count.0 += 1;
+            let count =
+                message::count_was_truncated(encoder.emit_all(iter::once(&Record::from(edns))))?;
+            additional_count.0 += count.0;
+            additional_count.1 |= count.1;
         }
 
         // FIXME: because this is destructive, we need to move message signing here... maybe it will work?
@@ -103,7 +101,9 @@ impl<'q, 'a> MessageResponse<'q, 'a> {
         //  then the SIG0 records should not be encoded and the edns record (if it exists) is already
         //  part of the additionals section.
         if include_sig0 {
-            additional_count.0 += encoder.emit_all(self.sig0().iter())?;
+            let count = message::count_was_truncated(encoder.emit_all(self.sig0().iter()))?;
+            additional_count.0 += count.0;
+            additional_count.1 |= count.1;
         }
 
         let counts = message::HeaderCounts {
@@ -133,6 +133,22 @@ pub struct MessageResponseBuilder<'q, 'a> {
 }
 
 impl<'q, 'a> MessageResponseBuilder<'q, 'a> {
+    /// Constructs a new Response
+    ///
+    /// # Arguments
+    ///
+    /// * `queries` - any optional set of Queries to associate with the Response
+    pub fn new(queries: Option<&'q Queries<'q>>) -> MessageResponseBuilder<'q, 'a> {
+        MessageResponseBuilder {
+            queries,
+            answers: None,
+            name_servers: None,
+            additionals: None,
+            sig0: None,
+            edns: None,
+        }
+    }
+
     /// Associate a set of answers with the response, generally owned by either a cache or [`trust_dns_server::authorith::Authority`]
     pub fn answers(&mut self, records: AuthLookup<'a, 'q>) -> &mut Self {
         self.answers = Some(records);
@@ -203,5 +219,87 @@ impl<'q, 'a> MessageResponseBuilder<'q, 'a> {
             sig0: self.sig0.unwrap_or_default(),
             edns: self.edns,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+    use std::net::Ipv4Addr;
+    use std::str::FromStr;
+
+    use trust_dns_proto::op::{EncodableMessage, Header, Message};
+    use trust_dns_proto::rr::{DNSClass, Name, RData, Record};
+    use trust_dns_proto::serialize::binary::BinEncoder;
+
+    use super::*;
+
+    #[test]
+    fn test_truncation_ridiculous_number_answers() {
+        let mut buf = Vec::with_capacity(512);
+        {
+            let mut encoder = BinEncoder::new(&mut buf);
+            encoder.set_max_size(512);
+
+            let answer = Record::new()
+                .set_name(Name::from_str("www.example.com.").unwrap())
+                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                .set_dns_class(DNSClass::NONE)
+                .clone();
+
+            let message = MessageResponse {
+                header: Header::new(),
+                queries: None,
+                answers: iter::repeat(&answer),
+                name_servers: iter::once(&answer),
+                additionals: vec![],
+                sig0: vec![],
+                edns: None,
+            };
+
+            message
+                .destructive_emit(&mut encoder)
+                .expect("failed to encode");
+        }
+
+        let response = Message::from_vec(&buf).expect("failed to decode");
+        assert!(response.header().truncated());
+        assert!(response.answer_count() > 1);
+        // should never have written the name server field...
+        assert_eq!(response.name_server_count(), 0);
+    }
+
+    #[test]
+    fn test_truncation_ridiculous_number_nameservers() {
+        let mut buf = Vec::with_capacity(512);
+        {
+            let mut encoder = BinEncoder::new(&mut buf);
+            encoder.set_max_size(512);
+
+            let answer = Record::new()
+                .set_name(Name::from_str("www.example.com.").unwrap())
+                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                .set_dns_class(DNSClass::NONE)
+                .clone();
+
+            let message = MessageResponse {
+                header: Header::new(),
+                queries: None,
+                answers: iter::empty(),
+                name_servers: iter::repeat(&answer),
+                additionals: vec![],
+                sig0: vec![],
+                edns: None,
+            };
+
+            message
+                .destructive_emit(&mut encoder)
+                .expect("failed to encode");
+        }
+
+        let response = Message::from_vec(&buf).expect("failed to decode");
+        assert!(response.header().truncated());
+        assert_eq!(response.answer_count(), 0);
+        assert!(response.name_server_count() > 1);
     }
 }

--- a/server/src/authority/message_response.rs
+++ b/server/src/authority/message_response.rs
@@ -1,25 +1,28 @@
-// Copyright 2015-2017 Benjamin Fry <benjaminfry@me.com>
+// Copyright 2015-2018 Benjamin Fry <benjaminfry@me.com>
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use trust_dns::op::{Edns, Header, MessageType, OpCode, ResponseCode};
+use std::iter::Chain;
+use std::ops::Deref;
+
 use trust_dns::rr::Record;
-use trust_dns::serialize::binary::BinEncoder;
+use trust_dns::serialize::binary::{BinEncodable, BinEncoder, EncodeMode};
 use trust_dns_proto::error::*;
 use trust_dns_proto::op::EncodableMessage;
+use trust_dns_proto::op::{message, Edns, Header, Message, MessageType, OpCode, ResponseCode};
 
-use authority::Queries;
+use authority::{AuthLookup, LookupRecords, Queries};
 
 /// A EncodableMessage with borrowed data for Responses in the Server
 #[derive(Debug)]
 pub struct MessageResponse<'q, 'a> {
     header: Header,
     queries: Option<&'q Queries<'q>>,
-    answers: Vec<&'a Record>,
-    name_servers: Vec<&'a Record>,
+    answers: AuthLookup<'a, 'q>,
+    name_servers: Chain<LookupRecords<'q, 'a>, LookupRecords<'q, 'a>>,
     additionals: Vec<&'a Record>,
     sig0: Vec<Record>,
     edns: Option<Edns>,
@@ -42,47 +45,26 @@ impl<'q, 'a> MessageResponse<'q, 'a> {
         }
     }
 
+    /// Returns the header of the message
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
     /// Set the EDNS options for the Response
     pub fn set_edns(&mut self, edns: Edns) -> &mut Self {
         self.edns = Some(edns);
         self
-    }
-}
-
-macro_rules! section {
-    ($s:ident, $l:ident, $e:ident) => {
-        fn $l(&self) -> usize {
-            self.$s.len()
-        }
-
-        fn $e(&self, encoder: &mut BinEncoder) -> ProtoResult<usize> {
-            encoder.emit_all_refs(self.$s.iter())
-        }
-    }
-}
-
-impl<'q, 'a> EncodableMessage for MessageResponse<'q, 'a> {
-    fn header(&self) -> &Header {
-        &self.header
-    }
-
-    fn queries_len(&self) -> usize {
-        self.queries.map(|s| s.len()).unwrap_or(0)
     }
 
     fn emit_queries(&self, encoder: &mut BinEncoder) -> ProtoResult<usize> {
         if let Some(queries) = self.queries {
             encoder
                 .emit_vec(queries.as_bytes())
-                .map(|()| self.queries_len())
+                .map(|()| self.queries.map(|s| s.len()).unwrap_or(0))
         } else {
             Ok(0)
         }
     }
-
-    section!(answers, answers_len, emit_answers);
-    section!(name_servers, name_servers_len, emit_name_servers);
-    section!(additionals, additionals_len, emit_additionals);
 
     fn edns(&self) -> Option<&Edns> {
         self.edns.as_ref()
@@ -91,13 +73,62 @@ impl<'q, 'a> EncodableMessage for MessageResponse<'q, 'a> {
     fn sig0(&self) -> &[Record] {
         &self.sig0
     }
+
+    /// Consumes self, and emits to the encoder.
+    pub fn destructive_emit(mut self, encoder: &mut BinEncoder) -> ProtoResult<()> {
+        // clone the header to set the counts lazily
+        // TODO: what should we do about sig0 on the server side? It should be deprecated in favor of TLS...
+        let include_sig0: bool = encoder.mode() != EncodeMode::Signing;
+        let place = encoder.place::<Header>()?;
+
+        // TODO: this feels like the right place to verify the max packet size of the message,
+        //  will need to update the header for trucation and the lengths if we send less than the
+        //  full response.
+        let query_count = self.emit_queries(encoder)?;
+        // FIXME: need to do some on max records
+        //  return offset of last emitted record.
+        let answer_count = message::count_was_truncated(encoder.emit_iter(&mut self.answers))?;
+        let nameserver_count =
+            message::count_was_truncated(encoder.emit_iter(&mut self.name_servers))?;
+        let mut additional_count =
+            message::count_was_truncated(encoder.emit_all_refs(self.additionals.iter()))?;
+
+        if let Some(edns) = self.edns() {
+            // need to commit the error code
+            Record::from(edns).emit(encoder)?;
+            additional_count.0 += 1;
+        }
+
+        // FIXME: because this is destructive, we need to move message signing here... maybe it will work?
+
+        // this is a little hacky, but if we are Verifying a signature, i.e. the original Message
+        //  then the SIG0 records should not be encoded and the edns record (if it exists) is already
+        //  part of the additionals section.
+        if include_sig0 {
+            additional_count.0 += encoder.emit_all(self.sig0().iter())?;
+        }
+
+        let counts = message::HeaderCounts {
+            query_count,
+            answer_count: answer_count.0,
+            nameserver_count: nameserver_count.0,
+            additional_count: additional_count.0,
+        };
+        let was_truncated = answer_count.1 || nameserver_count.1 || additional_count.1;
+
+        place.replace(
+            encoder,
+            message::update_header_counts(&self.header, was_truncated, counts),
+        )?;
+        Ok(())
+    }
 }
 
 /// A builder for MessageResponses
 pub struct MessageResponseBuilder<'q, 'a> {
     queries: Option<&'q Queries<'q>>,
-    answers: Option<Vec<&'a Record>>,
-    name_servers: Option<Vec<&'a Record>>,
+    answers: Option<AuthLookup<'a, 'q>>,
+    name_servers: Option<Chain<LookupRecords<'q, 'a>, LookupRecords<'q, 'a>>>,
     additionals: Option<Vec<&'a Record>>,
     sig0: Option<Vec<Record>>,
     edns: Option<Edns>,
@@ -105,13 +136,16 @@ pub struct MessageResponseBuilder<'q, 'a> {
 
 impl<'q, 'a> MessageResponseBuilder<'q, 'a> {
     /// Associate a set of answers with the response, generally owned by either a cache or [`trust_dns_server::authorith::Authority`]
-    pub fn answers(&mut self, records: Vec<&'a Record>) -> &mut Self {
+    pub fn answers(&mut self, records: AuthLookup<'a, 'q>) -> &mut Self {
         self.answers = Some(records);
         self
     }
 
     /// Associate a set of name_servers with the response, generally owned by either a cache or [`trust_dns_server::authorith::Authority`]
-    pub fn name_servers(&mut self, records: Vec<&'a Record>) -> &mut Self {
+    pub fn name_servers(
+        &mut self,
+        records: Chain<LookupRecords<'q, 'a>, LookupRecords<'q, 'a>>,
+    ) -> &mut Self {
         self.name_servers = Some(records);
         self
     }
@@ -132,7 +166,9 @@ impl<'q, 'a> MessageResponseBuilder<'q, 'a> {
             header,
             queries: self.queries,
             answers: self.answers.unwrap_or_default(),
-            name_servers: self.name_servers.unwrap_or_default(),
+            name_servers: self
+                .name_servers
+                .unwrap_or_else(|| LookupRecords::NxDomain.chain(LookupRecords::NxDomain)),
             additionals: self.additionals.unwrap_or_default(),
             sig0: self.sig0.unwrap_or_default(),
             edns: self.edns,
@@ -162,7 +198,9 @@ impl<'q, 'a> MessageResponseBuilder<'q, 'a> {
             header,
             queries: self.queries,
             answers: self.answers.unwrap_or_default(),
-            name_servers: self.name_servers.unwrap_or_default(),
+            name_servers: self
+                .name_servers
+                .unwrap_or_else(|| LookupRecords::NxDomain.chain(LookupRecords::NxDomain)),
             additionals: self.additionals.unwrap_or_default(),
             sig0: self.sig0.unwrap_or_default(),
             edns: self.edns,

--- a/server/src/authority/mod.rs
+++ b/server/src/authority/mod.rs
@@ -37,7 +37,7 @@ pub enum ZoneType {
 mod auth_lookup;
 pub mod authority;
 mod catalog;
-mod message_request;
+pub(crate) mod message_request;
 mod message_response;
 pub mod persistence;
 

--- a/server/src/authority/mod.rs
+++ b/server/src/authority/mod.rs
@@ -43,6 +43,7 @@ pub mod persistence;
 
 pub use self::auth_lookup::AuthLookup;
 pub use self::authority::Authority;
+pub use self::authority::LookupRecords;
 pub use self::catalog::Catalog;
 pub use self::message_request::{MessageRequest, Queries, UpdateRequest};
 pub use self::message_response::{MessageResponse, MessageResponseBuilder};

--- a/server/src/server/response_handler.rs
+++ b/server/src/server/response_handler.rs
@@ -9,9 +9,8 @@ use std::io;
 use std::net::SocketAddr;
 
 use trust_dns::error::ClientError;
-use trust_dns::serialize::binary::{BinEncodable, BinEncoder};
+use trust_dns::serialize::binary::BinEncoder;
 use trust_dns::BufStreamHandle;
-use trust_dns_proto::op::EncodableMessage;
 
 use authority::MessageResponse;
 

--- a/server/src/server/response_handler.rs
+++ b/server/src/server/response_handler.rs
@@ -8,17 +8,19 @@
 use std::io;
 use std::net::SocketAddr;
 
-use trust_dns::BufStreamHandle;
 use trust_dns::error::ClientError;
-use trust_dns_proto::op::EncodableMessage;
 use trust_dns::serialize::binary::{BinEncodable, BinEncoder};
+use trust_dns::BufStreamHandle;
+use trust_dns_proto::op::EncodableMessage;
+
+use authority::MessageResponse;
 
 /// A handler for send a response to a client
 pub trait ResponseHandler {
     /// Serializes and sends a message to to the wrapped handle
     ///
     /// self is consumed as only one message should ever be sent in response to a Request
-    fn send<M: EncodableMessage>(self, response: M) -> io::Result<()>;
+    fn send(self, response: MessageResponse) -> io::Result<()>;
 }
 
 /// A handler for wraping a BufStreamHandle, which will properly serialize the message and add the
@@ -39,19 +41,16 @@ impl ResponseHandler for ResponseHandle {
     /// Serializes and sends a message to to the wrapped handle
     ///
     /// self is consumed as only one message should ever be sent in response to a Request
-    fn send<M: EncodableMessage>(self, response: M) -> io::Result<()> {
+    fn send(self, response: MessageResponse) -> io::Result<()> {
         info!(
-            "response: {} response_code: {} answers: {} name_servers: {} additionals: {}",
+            "response: {} response_code: {}",
             response.header().id(),
             response.header().response_code(),
-            response.answers_len(),
-            response.name_servers_len(),
-            response.additionals_len(),
         );
         let mut buffer = Vec::with_capacity(512);
         let encode_result = {
             let mut encoder: BinEncoder = BinEncoder::new(&mut buffer);
-            response.emit(&mut encoder)
+            response.destructive_emit(&mut encoder)
         };
 
         encode_result.map_err(|e| {

--- a/server/src/server/server_future.rs
+++ b/server/src/server/server_future.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use futures::{Future, future, Stream};
+use futures::{Future, Stream};
 
 use tokio_executor;
 use tokio_reactor::Handle;
@@ -75,7 +75,9 @@ impl<T: RequestHandler + Send> ServerFuture<T> {
 
     /// Register a UDP socket. Should be bound before calling this function.
     pub fn register_socket_std(&self, socket: std::net::UdpSocket) {
-        self.register_socket(tokio_udp::UdpSocket::from_std(socket, &Handle::current()).expect("bad handle?"))
+        self.register_socket(
+            tokio_udp::UdpSocket::from_std(socket, &Handle::current()).expect("bad handle?"),
+        )
     }
 
     /// Register a TcpListener to the Server. This should already be bound to either an IPv6 or an
@@ -155,7 +157,10 @@ impl<T: RequestHandler + Send> ServerFuture<T> {
         listener: std::net::TcpListener,
         timeout: Duration,
     ) -> io::Result<()> {
-        self.register_listener(tokio_tcp::TcpListener::from_std(listener, &Handle::current())?, timeout)
+        self.register_listener(
+            tokio_tcp::TcpListener::from_std(listener, &Handle::current())?,
+            timeout,
+        )
     }
 
     /// Register a TlsListener to the Server. The TlsListener should already be bound to either an
@@ -178,6 +183,8 @@ impl<T: RequestHandler + Send> ServerFuture<T> {
         timeout: Duration,
         pkcs12: ParsedPkcs12,
     ) -> io::Result<()> {
+        use futures::future;
+
         let handler = self.handler.clone();
         debug!("registered tcp: {:?}", listener);
 
@@ -257,7 +264,11 @@ impl<T: RequestHandler + Send> ServerFuture<T> {
         timeout: Duration,
         pkcs12: ParsedPkcs12,
     ) -> io::Result<()> {
-        self.register_tls_listener(tokio_tcp::TcpListener::from_std(listener, &Handle::current())?, timeout, pkcs12)
+        self.register_tls_listener(
+            tokio_tcp::TcpListener::from_std(listener, &Handle::current())?,
+            timeout,
+            pkcs12,
+        )
     }
 
     fn handle_request(
@@ -297,6 +308,9 @@ impl<T: RequestHandler + Send> ServerFuture<T> {
                 .unwrap_or_else(|| "empty_queries".to_string()),
         );
 
-        handler.lock().unwrap().handle_request(&request, response_handle)
+        handler
+            .lock()
+            .unwrap()
+            .handle_request(&request, response_handle)
     }
 }

--- a/server/tests/server_harness/mod.rs
+++ b/server/tests/server_harness/mod.rs
@@ -206,7 +206,7 @@ pub fn query_all_dnssec(
     let response = query_message(
         io_loop,
         &mut client,
-        name,
+        name.clone(),
         RecordType::DNSSEC(DNSSECRecordType::DNSKEY),
     );
 
@@ -223,6 +223,13 @@ pub fn query_all_dnssec(
         })
         .find(|d| d.algorithm() == algorithm);
     assert!(dnskey.is_some(), "DNSKEY not found");
+
+    let response = query_message(
+        io_loop,
+        &mut client,
+        name,
+        RecordType::DNSSEC(DNSSECRecordType::DNSKEY),
+    );
 
     let rrsig = response
         .answers()


### PR DESCRIPTION
This adds the ability to set rollback points during serialization of the Message. This was pulled out of the #492 change, but is narrower. I need to add some tests for this case. The goal is that if we can't return all records, at least the set that could be written to the buffer are sent.

This went beyond the original scope a little bit to prepare for #492, by switching out temporary vectors during lookups for custom Iterator combinators.

Fixes: #319