### PR TITLE
resolver: Add missing `fmt::Debug`s and re-export returned futures

### DIFF
--- a/resolver/src/async_resolver/mod.rs
+++ b/resolver/src/async_resolver/mod.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 //! Structs for creating and using a AsyncResolver
+use std::fmt;
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
@@ -91,6 +92,7 @@ pub struct AsyncResolver {
 /// A future that represents sending a request to a background task,
 /// waiting for it to send back a lookup future, and then running the
 /// lookup future.
+#[derive(Debug)]
 pub struct Background<F, G = F>
 where
     F: Future<Error = ResolveError>,
@@ -365,8 +367,19 @@ impl AsyncResolver {
     lookup_fn!(txt_lookup, lookup::TxtLookupFuture, RecordType::TXT);
 }
 
-// ===== impl Background =====
+impl fmt::Debug for AsyncResolver {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 
+        f.debug_struct("AsyncResolver")
+            // We probably don't want to print out the `fmt::Debug` output
+            // for `mpsc::UnboundedSender`, as it's *quite* wordy but not
+            // terribly useful...
+            .field("request_tx", &"...")
+            .finish()
+    }
+}
+
+// ===== impl Background =====
 
 impl<F, G> Future for Background<F, G>
 where

--- a/resolver/src/lib.rs
+++ b/resolver/src/lib.rs
@@ -216,7 +216,12 @@ pub use self::trust_dns_proto::rr::{IntoName, Name, TryParseIp};
 
 pub use hosts::Hosts;
 pub use resolver::Resolver;
-pub use async_resolver::AsyncResolver;
+pub use async_resolver::{
+    AsyncResolver,
+    Background,
+    BackgroundLookup,
+    BackgroundLookupIp,
+};
 
 /// This is an alias for [`AsyncResolver`], which replaced the type previously
 /// called `ResolverFuture`.


### PR DESCRIPTION
This PR fixes a handful of minor usability issues in the new 
`AsyncResolver`'s API that I hit while trying to use it downstream in
runconduit/conduit#1033. In particular, it adds a missing `fmt::Debug`
implementation to `AsyncResolver` (since the old `ResolverFuture` 
implemented `fmt::Debug`, and not implementing it may break
downstream code that tries to format it), and publically re-exports 
the futures returned by `AsyncResolver`'s lookup methods, so that 
their types are actually nameable in downstream code.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>