### PR TITLE
server: switch comparison_benches to use tokio-executor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,12 @@ matrix:
       script:
         - cargo fmt --all -- --write-mode=diff
 
+    # benchmark tests; built but not run in Travis to avoid inconsistent timing results
+    - rust: nightly
+      env: NAME=bench
+      script:
+        - scripts/build_benches.sh
+
     # compatiblity tests
     - rust: stable
       env: NAME=compatiblity

--- a/scripts/build_benches.sh
+++ b/scripts/build_benches.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+set -x
+
+trust_dns_dir=$(dirname $0)/..
+cd $trust_dns_dir
+
+# Benchmark tests build only on nightly
+
+cargo bench --no-run


### PR DESCRIPTION
Client APIs changed during the switch to tokio-executor, but the uses in comparison_benches weren't updated.

See commit eb1f6102: Initial conversion to tokio-executor.