### PR TITLE
Updated `ipconfig` dependency from 0.1.4 to 0.1.7

### DIFF
--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -77,7 +77,7 @@ trust-dns-rustls = { version = "0.4.0-alpha", path = "../rustls", optional = tru
 webpki-roots = { version = "^0.15", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-ipconfig = { version = "^0.1.4" }
+ipconfig = { version = "^0.1.7" }
 
 [dev-dependencies]
 env_logger = "^0.5"


### PR DESCRIPTION
This PR updates the Windows-only dependency `ipconfig` of the `resolver` module from version 0.1.4 to 0.1.7. This new version includes, among other fixes, a fix to [a panic in some default Windows configurations](https://github.com/liranringel/ipconfig/issues/15) which also affects `trust-dns`.