### PR TITLE
upgrade rusqlite to avoid future compatibility problem

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -69,7 +69,7 @@ log = "^0.4.1"
 futures = "^0.1.17"
 openssl = { version = "^0.10", features = ["v102", "v110"] }
 rand = "^0.5"
-rusqlite = { version = "^0.13.0", features = ["bundled"] }
+rusqlite = { version = "0.14.0", features = ["bundled"] }
 rustls = { version = "^0.13.0" }
 tokio = "^0.1.6"
 tokio-tcp = "^0.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -77,7 +77,7 @@ futures = "^0.1.17"
 lazy_static = "^1.0"
 log = "^0.4.1"
 rand = "^0.5"
-rusqlite = { version = "^0.13.0", features = ["bundled"] }
+rusqlite = { version = "0.14.0", features = ["bundled"] }
 serde = "^1.0"
 serde_derive = "^1.0"
 time = "^0.1"

--- a/server/src/error/persistence_error.rs
+++ b/server/src/error/persistence_error.rs
@@ -25,9 +25,9 @@ pub enum ErrorKind {
     #[fail(display = "wrong insert count: {} expect: {}", got, expect)]
     WrongInsertCount {
         /// The number of inserted records
-        got: i32,
+        got: usize,
         /// The number of records expected to be inserted
-        expect: i32,
+        expect: usize,
     },
 
     // foreign


### PR DESCRIPTION
due to rust-lang/rust#49799

Compatibility note: with 0.14, rusqlite's result count type is now usize. I have chosen to cast it to i32 instead of changing `WrongInsertCount`, since it's a public type.

Should I also add a note to upgrade to usize when trust-dns-server bump major version? Or should I make the switch right away (it seems 0.15 is already in the work)?