### PR TITLE
Delays all connections until actual use.

### DIFF
--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -23,6 +23,7 @@ use openssl::error::ErrorStack as SslErrorStack;
 use ring::error::Unspecified;
 
 use failure::{Backtrace, Context, Fail};
+use tokio_executor::SpawnError;
 use tokio_timer::Error as TimerError;
 
 /// An alias for results returned by functions of this crate
@@ -151,6 +152,10 @@ pub enum ProtoErrorKind {
     #[fail(display = "ring error")]
     Ring,
 
+    /// Tokio Spawn Error
+    #[fail(display = "tokio spawn error")]
+    SpawnError,
+
     /// An ssl error
     #[fail(display = "ssl error")]
     SSL,
@@ -253,6 +258,12 @@ impl<T> From<sync::PoisonError<T>> for ProtoError {
 impl From<Unspecified> for ProtoError {
     fn from(e: Unspecified) -> ProtoError {
         e.context(ProtoErrorKind::Ring).into()
+    }
+}
+
+impl From<SpawnError> for ProtoError {
+    fn from(e: SpawnError) -> ProtoError {
+        e.context(ProtoErrorKind::SpawnError).into()
     }
 }
 
@@ -374,6 +385,7 @@ impl Clone for ProtoErrorKind {
             Io => Io,
             Poisoned => Poisoned,
             Ring => Ring,
+            SpawnError => SpawnError,
             SSL => SSL,
             Timeout => Timeout,
             Timer => Timer,

--- a/proto/src/xfer/dns_exchange.rs
+++ b/proto/src/xfer/dns_exchange.rs
@@ -134,7 +134,7 @@ where
                 // On not ready, this is our time to return...
                 Async::NotReady => return Ok(Async::NotReady),
                 Async::Ready(None) => {
-                    //debug!("all handles closed, shutting down: {}", self.io_stream);
+                    debug!("all handles closed, shutting down: {}", self.io_stream);
                     // if there is nothing that can use this connection to send messages, then this is done...
                     self.io_stream.shutdown();
 

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -69,7 +69,7 @@ rustls = {version  = "0.14", optional = true}
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 smallvec = "^0.6"
-tokio = "^0.1.6"
+tokio = "^0.1.7"
 trust-dns-https = { version = "0.1.0-alpha", path = "../https", optional = true }
 trust-dns-native-tls = { version = "0.4.0-alpha", path = "../native-tls", optional = true }
 trust-dns-openssl = { version = "0.4.0-alpha", path = "../openssl", optional = true }

--- a/resolver/examples/multithreaded_runtime.rs
+++ b/resolver/examples/multithreaded_runtime.rs
@@ -3,6 +3,7 @@
 //! This example shows how to create a resolver that uses the tokio multithreaded runtime. This is how
 //! you might integrate the resolver into a more complex application.
 
+extern crate env_logger;
 extern crate futures;
 extern crate tokio;
 extern crate trust_dns_resolver;
@@ -12,6 +13,8 @@ use tokio::runtime::Runtime;
 use trust_dns_resolver::AsyncResolver;
 
 fn main() {
+    env_logger::init();
+
     // Set up the standard tokio runtime (multithreaded by default).
     let mut runtime = Runtime::new().expect("Failed to create runtime");
 

--- a/resolver/src/async_resolver/background.rs
+++ b/resolver/src/async_resolver/background.rs
@@ -4,7 +4,9 @@ use futures::{future, sync::mpsc, Async, Future, Poll, Stream};
 #[cfg(feature = "dnssec")]
 use trust_dns_proto::SecureDnsHandle;
 use trust_dns_proto::{
-    error::ProtoResult, rr::{Name, RData, RecordType}, xfer::{DnsRequestOptions, RetryDnsHandle},
+    error::ProtoResult,
+    rr::{Name, RData, RecordType},
+    xfer::{DnsRequestOptions, RetryDnsHandle},
 };
 
 use config::{ResolverConfig, ResolverOpts};

--- a/resolver/src/name_server_pool.rs
+++ b/resolver/src/name_server_pool.rs
@@ -286,7 +286,7 @@ impl ConnectionHandleConnect {
 
                 let (stream, handle) = DnsExchange::connect(dns_conn);
                 let stream = stream.and_then(|stream| stream).map_err(|e| {
-                    error!("error, udp connection shutting down: {}", e);
+                    debug!("udp connection shutting down: {}", e);
                 });
                 let handle = BufDnsRequestStreamHandle::new(handle);
 
@@ -308,7 +308,7 @@ impl ConnectionHandleConnect {
 
                 let (stream, handle) = DnsExchange::connect(dns_conn);
                 let stream = stream.and_then(|stream| stream).map_err(|e| {
-                    error!("error, udp connection shutting down: {}", e);
+                    debug!("tcp connection shutting down: {}", e);
                 });
                 let handle = BufDnsRequestStreamHandle::new(handle);
 
@@ -331,7 +331,7 @@ impl ConnectionHandleConnect {
 
                 let (stream, handle) = DnsExchange::connect(dns_conn);
                 let stream = stream.and_then(|stream| stream).map_err(|e| {
-                    error!("error, udp connection shutting down: {}", e);
+                    debug!("tls connection shutting down: {}", e);
                 });
                 let handle = BufDnsRequestStreamHandle::new(handle);
 
@@ -348,7 +348,7 @@ impl ConnectionHandleConnect {
                 let (stream, handle) = ::https::new_https_stream(socket_addr, tls_dns_name);
 
                 let stream = stream.and_then(|stream| stream).map_err(|e| {
-                    error!("error, udp connection shutting down: {}", e);
+                    debug!("https connection shutting down: {}", e);
                 });
 
                 tokio::executor::spawn(stream);
@@ -371,7 +371,7 @@ impl ConnectionHandleConnect {
 
                 let (stream, handle) = DnsExchange::connect(dns_conn);
                 let stream = stream.and_then(|stream| stream).map_err(|e| {
-                    error!("error, udp connection shutting down: {}", e);
+                    debug!("mdns connection shutting down: {}", e);
                 });
                 let handle = BufDnsRequestStreamHandle::new(handle);
 


### PR DESCRIPTION
This also changes the ordering to prefer established connections over others.
It also fixes an issue with established connections being dropped early.
Also, demoting connection shutdown to debug from error

fixes: #532 
fixes: #560
fixes: #546
fixes: #524