### PR TITLE
Fix multithreaded example

### DIFF
--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -69,7 +69,7 @@ rustls = {version  = "0.14", optional = true}
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 smallvec = "^0.6"
-tokio = "^0.1.6"
+tokio = "^0.1.7"
 trust-dns-https = { version = "0.1.0-alpha", path = "../https", optional = true }
 trust-dns-native-tls = { version = "0.4.0-alpha", path = "../native-tls", optional = true }
 trust-dns-openssl = { version = "0.4.0-alpha", path = "../openssl", optional = true }


### PR DESCRIPTION
This branch fixes the `multithreaded_runtime` example by replacing calls to `Future::wait` with `tokio:runtime::Runtime::block_on`, and waiting to shut down the runtime until after the calls to `block_on`. 

Note that this requires updating the minimum `tokio` dependency to version 0.1.7, as the `Runtime::block_on` method was added in this version.