### PR TITLE
(RFC) Prefer Queen and Drone for Primary and Secondary references

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Zone signing support is complete, to insert a key store a pem encoded rsa file
  key rotation. Rotating the key currently is not available online and requires
  a restart of the server process.
 
+*note on terminology* This library uses the terms `Queen` and `Drone` in defining 
+ the relationship of a source or primary server which is the source of truth for
+ any following secondary zone servers. The terms `Master` and `Slave` will be
+ accepted, but only for backward compatible reasons (and an warning will be logged).
+ In addition, those terms appear in the documentation from old DNS RFCs, but have
+ been replaced in all locations where they appear in this library. 
+
 ### DNS over TLS on the Server
 
 Support of TLS on the Server is managed through a pkcs12 der file. The documentation is captured in the example test config file, [example.toml](https://github.com/bluejekyll/trust-dns/blob/master/server/tests/named_test_configs/example.toml). A registered certificate to the server can be pinned to the Client with the `add_ca()` method. Alternatively, as the client uses the rust-native-tls library, it should work with certificate signed by any standard CA.

--- a/client/src/client/client.rs
+++ b/client/src/client/client.rs
@@ -134,7 +134,7 @@ pub trait Client {
     ///    RRs are added to the Update Section whose NAME, TYPE, TTL, RDLENGTH
     ///    and RDATA are those being added, and CLASS is the same as the zone
     ///    class.  Any duplicate RRs will be silently ignored by the primary
-    ///    master.
+    ///    queen server.
     /// ```
     ///
     /// # Arguments
@@ -177,7 +177,7 @@ pub trait Client {
     ///    RRs are added to the Update Section whose NAME, TYPE, TTL, RDLENGTH
     ///    and RDATA are those being added, and CLASS is the same as the zone
     ///    class.  Any duplicate RRs will be silently ignored by the primary
-    ///    master.
+    ///    queen server.
     /// ```
     ///
     /// # Arguments
@@ -221,16 +221,16 @@ pub trait Client {
     ///   RRs to be deleted are added to the Update Section.  The NAME, TYPE,
     ///   RDLENGTH and RDATA must match the RR being deleted.  TTL must be
     ///   specified as zero (0) and will otherwise be ignored by the primary
-    ///   master.  CLASS must be specified as NONE to distinguish this from an
+    ///   queen server.  CLASS must be specified as NONE to distinguish this from an
     ///   RR addition.  If no such RRs exist, then this Update RR will be
-    ///   silently ignored by the primary master.
+    ///   silently ignored by the primary queen server.
     ///
     ///  2.5.1 - Add To An RRset
     ///
     ///   RRs are added to the Update Section whose NAME, TYPE, TTL, RDLENGTH
     ///   and RDATA are those being added, and CLASS is the same as the zone
     ///   class.  Any duplicate RRs will be silently ignored by the primary
-    ///   master.
+    ///   queen server.
     /// ```
     ///
     /// # Arguments
@@ -279,9 +279,9 @@ pub trait Client {
     ///   RRs to be deleted are added to the Update Section.  The NAME, TYPE,
     ///   RDLENGTH and RDATA must match the RR being deleted.  TTL must be
     ///   specified as zero (0) and will otherwise be ignored by the primary
-    ///   master.  CLASS must be specified as NONE to distinguish this from an
+    ///   queen server.  CLASS must be specified as NONE to distinguish this from an
     ///   RR addition.  If no such RRs exist, then this Update RR will be
-    ///   silently ignored by the primary master.
+    ///   silently ignored by the primary queen server.
     /// ```
     ///
     /// # Arguments
@@ -324,10 +324,10 @@ pub trait Client {
     ///
     ///   One RR is added to the Update Section whose NAME and TYPE are those
     ///   of the RRset to be deleted.  TTL must be specified as zero (0) and is
-    ///   otherwise not used by the primary master.  CLASS must be specified as
+    ///   otherwise not used by the primary queen server.  CLASS must be specified as
     ///   ANY.  RDLENGTH must be zero (0) and RDATA must therefore be empty.
     ///   If no such RRset exists, then this Update RR will be silently ignored
-    ///   by the primary master.
+    ///   by the primary queen.
     /// ```
     ///
     /// # Arguments
@@ -356,9 +356,9 @@ pub trait Client {
     ///   One RR is added to the Update Section whose NAME is that of the name
     ///   to be cleansed of RRsets.  TYPE must be specified as ANY.  TTL must
     ///   be specified as zero (0) and is otherwise not used by the primary
-    ///   master.  CLASS must be specified as ANY.  RDLENGTH must be zero (0)
+    ///   queen server.  CLASS must be specified as ANY.  RDLENGTH must be zero (0)
     ///   and RDATA must therefore be empty.  If no such RRsets exist, then
-    ///   this Update RR will be silently ignored by the primary master.
+    ///   this Update RR will be silently ignored by the primary queen.
     /// ```
     ///
     /// # Arguments

--- a/integration-tests/src/authority.rs
+++ b/integration-tests/src/authority.rs
@@ -14,7 +14,7 @@ pub fn create_example() -> Authority {
     let mut records: Authority = Authority::new(
         origin.clone(),
         BTreeMap::new(),
-        ZoneType::Master,
+        ZoneType::Queen,
         false,
         false,
     );

--- a/integration-tests/tests/authority_tests.rs
+++ b/integration-tests/tests/authority_tests.rs
@@ -915,7 +915,7 @@ fn test_journal() {
     let mut recovered_authority = Authority::new(
         authority.origin().clone().into(),
         BTreeMap::new(),
-        ZoneType::Master,
+        ZoneType::Queen,
         false,
         false,
     );
@@ -957,7 +957,7 @@ fn test_recovery() {
     let mut recovered_authority = Authority::new(
         authority.origin().clone().into(),
         BTreeMap::new(),
-        ZoneType::Master,
+        ZoneType::Queen,
         false,
         false,
     );

--- a/integration-tests/tests/catalog_tests.rs
+++ b/integration-tests/tests/catalog_tests.rs
@@ -20,7 +20,7 @@ pub fn create_test() -> Authority {
     let mut records: Authority = Authority::new(
         origin.clone(),
         BTreeMap::new(),
-        ZoneType::Master,
+        ZoneType::Queen,
         false,
         false,
     );
@@ -38,8 +38,7 @@ pub fn create_test() -> Authority {
                 3600,
                 1209600,
                 3600,
-            )))
-            .clone(),
+            ))).clone(),
         0,
     );
 
@@ -82,8 +81,7 @@ pub fn create_test() -> Authority {
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
-            .clone(),
+            ))).clone(),
         0,
     );
 
@@ -106,8 +104,7 @@ pub fn create_test() -> Authority {
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
-            .clone(),
+            ))).clone(),
         0,
     );
 
@@ -261,8 +258,7 @@ fn test_axfr() {
             3600,
             1209600,
             3600,
-        )))
-        .clone();
+        ))).clone();
 
     let mut catalog: Catalog = Catalog::new();
     catalog.upsert(origin.clone().into(), test);
@@ -306,8 +302,7 @@ fn test_axfr() {
                 3600,
                 1209600,
                 3600,
-            )))
-            .clone(),
+            ))).clone(),
         Record::new()
             .set_name(origin.clone().into())
             .set_ttl(86400)
@@ -336,8 +331,7 @@ fn test_axfr() {
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
-            .clone(),
+            ))).clone(),
         Record::new()
             .set_name(www_name.clone())
             .set_ttl(86400)
@@ -352,8 +346,7 @@ fn test_axfr() {
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
-            .clone(),
+            ))).clone(),
         Record::new()
             .set_name(origin.clone().into())
             .set_ttl(3600)
@@ -367,8 +360,7 @@ fn test_axfr() {
                 3600,
                 1209600,
                 3600,
-            )))
-            .clone(),
+            ))).clone(),
     ];
 
     expected_set.sort();

--- a/proto/src/rr/rdata/soa.rs
+++ b/proto/src/rr/rdata/soa.rs
@@ -16,9 +16,9 @@
 
 //! start of authority record defining ownership and defaults for the zone
 
-use serialize::binary::*;
 use error::*;
 use rr::domain::Name;
+use serialize::binary::*;
 
 /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
 ///
@@ -80,12 +80,12 @@ impl SOA {
     ///
     /// # Arguments
     ///
-    /// * `mname` - the name of the master, primary, authority for this zone.
+    /// * `mname` - the name of the queen, primary, authority for this zone.
     /// * `rname` - the name of the responsible party for this zone, e.g. an email address.
     /// * `serial` - the serial number of the zone, used for caching purposes.
     /// * `refresh` - the amount of time to wait before a zone is resynched.
     /// * `retry` - the minimum period to wait if there is a failure during refresh.
-    /// * `expire` - the time until this master is no longer authoritative for the zone.
+    /// * `expire` - the time until this queen is no longer authoritative for the zone.
     /// * `minimum` - no zone records should have time-to-live values less than this minimum.
     ///
     /// # Return value
@@ -124,7 +124,7 @@ impl SOA {
     /// # Return value
     ///
     /// The `domain-name` of the name server that was the original or primary source of data for
-    /// this zone, i.e. the master name server.
+    /// this zone, i.e. the queen (primary) name server.
     pub fn mname(&self) -> &Name {
         &self.mname
     }

--- a/server/src/authority/authority.rs
+++ b/server/src/authority/authority.rs
@@ -28,7 +28,7 @@ use error::{PersistenceErrorKind, PersistenceResult};
 /// Authority is responsible for storing the resource records for a particular zone.
 ///
 /// Authorities default to DNSClass IN. The ZoneType specifies if this should be treated as the
-/// start of authority for the zone, is a slave, or a cached zone.
+/// start of authority for the zone, is a drone (secondary), or a cached zone.
 pub struct Authority {
     origin: LowerName,
     class: DNSClass,
@@ -36,6 +36,7 @@ pub struct Authority {
     records: BTreeMap<RrKey, RecordSet>,
     zone_type: ZoneType,
     allow_update: bool,
+    allow_axfr: bool,
     is_dnssec_enabled: bool,
     // Private key mapped to the Record of the DNSKey
     //  TODO: these private_keys should be stored securely. Ideally, we have keys only stored per
@@ -387,66 +388,89 @@ impl Authority {
             }
 
             match require.dns_class() {
-        DNSClass::ANY =>
-          if let RData::NULL( .. ) = *require.rdata() {
-            match require.rr_type() {
-              // ANY      ANY      empty    Name is in use
-              RecordType::ANY => {
-                if self.lookup(&required_name, RecordType::ANY, false, SupportedAlgorithms::new()).is_totally_empty() {
-                  return Err(ResponseCode::NXDomain);
+                DNSClass::ANY => if let RData::NULL(..) = *require.rdata() {
+                    match require.rr_type() {
+                        // ANY      ANY      empty    Name is in use
+                        RecordType::ANY => {
+                            if self
+                                .lookup(
+                                    &required_name,
+                                    RecordType::ANY,
+                                    false,
+                                    SupportedAlgorithms::new(),
+                                ).is_totally_empty()
+                            {
+                                return Err(ResponseCode::NXDomain);
+                            } else {
+                                continue;
+                            }
+                        }
+                        // ANY      rrset    empty    RRset exists (value independent)
+                        rrset => {
+                            if self
+                                .lookup(&required_name, rrset, false, SupportedAlgorithms::new())
+                                .is_totally_empty()
+                            {
+                                return Err(ResponseCode::NXRRSet);
+                            } else {
+                                continue;
+                            }
+                        }
+                    }
                 } else {
-                  continue;
-                }
-              },
-              // ANY      rrset    empty    RRset exists (value independent)
-              rrset => {
-                if self.lookup(&required_name, rrset, false, SupportedAlgorithms::new()).is_totally_empty() {
-                  return Err(ResponseCode::NXRRSet);
+                    return Err(ResponseCode::FormErr);
+                },
+                DNSClass::NONE => if let RData::NULL(..) = *require.rdata() {
+                    match require.rr_type() {
+                        // NONE     ANY      empty    Name is not in use
+                        RecordType::ANY => {
+                            if !self
+                                .lookup(
+                                    &required_name,
+                                    RecordType::ANY,
+                                    false,
+                                    SupportedAlgorithms::new(),
+                                ).is_totally_empty()
+                            {
+                                return Err(ResponseCode::YXDomain);
+                            } else {
+                                continue;
+                            }
+                        }
+                        // NONE     rrset    empty    RRset does not exist
+                        rrset => {
+                            if !self
+                                .lookup(&required_name, rrset, false, SupportedAlgorithms::new())
+                                .is_totally_empty()
+                            {
+                                return Err(ResponseCode::YXRRSet);
+                            } else {
+                                continue;
+                            }
+                        }
+                    }
                 } else {
-                  continue;
+                    return Err(ResponseCode::FormErr);
+                },
+                class if class == self.class =>
+                // zone     rrset    rr       RRset exists (value dependent)
+                {
+                    if self
+                        .lookup(
+                            &required_name,
+                            require.rr_type(),
+                            false,
+                            SupportedAlgorithms::new(),
+                        ).find(|rr| *rr == require)
+                        .is_none()
+                    {
+                        return Err(ResponseCode::NXRRSet);
+                    } else {
+                        continue;
+                    }
                 }
-              },
+                _ => return Err(ResponseCode::FormErr),
             }
-          } else {
-            return Err(ResponseCode::FormErr);
-          }
-        ,
-        DNSClass::NONE =>
-          if let RData::NULL( .. ) = *require.rdata() {
-            match require.rr_type() {
-              // NONE     ANY      empty    Name is not in use
-              RecordType::ANY => {
-                if !self.lookup(&required_name, RecordType::ANY, false, SupportedAlgorithms::new()).is_totally_empty() {
-                  return Err(ResponseCode::YXDomain);
-                } else {
-                  continue;
-                }
-              },
-              // NONE     rrset    empty    RRset does not exist
-              rrset => {
-                if !self.lookup(&required_name, rrset, false, SupportedAlgorithms::new()).is_totally_empty() {
-                  return Err(ResponseCode::YXRRSet);
-                } else {
-                  continue;
-                }
-              },
-            }
-          } else {
-            return Err(ResponseCode::FormErr);
-          }
-        ,
-        class if class == self.class =>
-          // zone     rrset    rr       RRset exists (value dependent)
-          if self.lookup(&required_name, require.rr_type(), false, SupportedAlgorithms::new())
-                 .find(|rr| *rr == require)
-                 .is_none() {
-            return Err(ResponseCode::NXRRSet);
-          } else {
-            continue;
-          }
-          ,
-        _ => return Err(ResponseCode::FormErr),
-      }
         }
 
         // if we didn't bail everything checked out...
@@ -502,44 +526,41 @@ impl Authority {
         // verify sig0, currently the only authorization that is accepted.
         let sig0s: &[Record] = update_message.sig0();
         debug!("authorizing with: {:?}", sig0s);
-        if !sig0s.is_empty()
-            && sig0s
-                .iter()
-                .filter_map(|sig0| {
-                    if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *sig0.rdata() {
-                        Some(sig)
+        if !sig0s.is_empty() && sig0s
+            .iter()
+            .filter_map(|sig0| {
+                if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *sig0.rdata() {
+                    Some(sig)
+                } else {
+                    None
+                }
+            }).any(|sig| {
+                let name = LowerName::from(sig.signer_name());
+                let keys = self.lookup(
+                    &name,
+                    RecordType::DNSSEC(DNSSECRecordType::KEY),
+                    false,
+                    SupportedAlgorithms::new(),
+                );
+                debug!("found keys {:?}", keys);
+                // FIXME: check key usage flags and restrictions
+                keys.filter_map(|rr_set| {
+                    if let RData::DNSSEC(DNSSECRData::KEY(ref key)) = *rr_set.rdata() {
+                        Some(key)
                     } else {
                         None
                     }
+                }).any(|key| {
+                    key.verify_message(update_message, sig.sig(), sig)
+                        .map(|_| {
+                            info!("verified sig: {:?} with key: {:?}", sig, key);
+                            true
+                        }).unwrap_or_else(|_| {
+                            debug!("did not verify sig: {:?} with key: {:?}", sig, key);
+                            false
+                        })
                 })
-                .any(|sig| {
-                    let name = LowerName::from(sig.signer_name());
-                    let keys = self.lookup(
-                        &name,
-                        RecordType::DNSSEC(DNSSECRecordType::KEY),
-                        false,
-                        SupportedAlgorithms::new(),
-                    );
-                    debug!("found keys {:?}", keys);
-                    // FIXME: check key usage flags and restrictions
-                    keys.filter_map(|rr_set| {
-                        if let RData::DNSSEC(DNSSECRData::KEY(ref key)) = *rr_set.rdata() {
-                            Some(key)
-                        } else {
-                            None
-                        }
-                    }).any(|key| {
-                        key.verify_message(update_message, sig.sig(), sig)
-                            .map(|_| {
-                                info!("verified sig: {:?} with key: {:?}", sig, key);
-                                true
-                            })
-                            .unwrap_or_else(|_| {
-                                debug!("did not verify sig: {:?} with key: {:?}", sig, key);
-                                false
-                            })
-                    })
-                }) {
+            }) {
             return Ok(());
         } else {
             warn!(
@@ -771,8 +792,7 @@ impl Authority {
                                     !((k.record_type == RecordType::SOA
                                         || k.record_type == RecordType::NS)
                                         && k.name != self.origin)
-                                })
-                                .filter(|k| k.name == rr_name)
+                                }).filter(|k| k.name == rr_name)
                                 .cloned()
                                 .collect::<Vec<RrKey>>();
                             for delete in to_delete {
@@ -948,11 +968,11 @@ impl Authority {
         let lookup_name = query.name();
         let record_type: RecordType = query.query_type();
 
-        // if this is an AXFR zone transfer, verify that this is either the slave or master
+        // if this is an AXFR zone transfer, verify that this is either the drone or queen
         //  for AXFR the first and last record must be the SOA
         if RecordType::AXFR == record_type {
             match self.zone_type() {
-                ZoneType::Master | ZoneType::Slave => (),
+                ZoneType::Queen | ZoneType::Master | ZoneType::Drone | ZoneType::Slave => (),
                 // TODO: Forward?
                 _ => return AuthLookup::NxDomain, // TODO: this sould be an error.
             }
@@ -1339,12 +1359,10 @@ impl<'r, 'q> Iterator for AnyRecordsIter<'r, 'q> {
                     .by_ref()
                     .filter(|rr_set| {
                         query_type == RecordType::ANY || rr_set.record_type() != RecordType::SOA
-                    })
-                    .filter(|rr_set| {
+                    }).filter(|rr_set| {
                         query_type == RecordType::AXFR
                             || &LowerName::from(rr_set.name()) == query_name
-                    })
-                    .next();
+                    }).next();
 
                 if record.is_some() {
                     return record;

--- a/server/src/authority/mod.rs
+++ b/server/src/authority/mod.rs
@@ -25,8 +25,12 @@ pub type UpdateResult<T> = Result<T, ResponseCode>;
 #[derive(Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
 pub enum ZoneType {
     /// This authority for a zone, i.e. the Primary
+    Queen,
+    #[doc(hidden)] // TODO: make serde alias Queen with Master... or remove this.
     Master,
-    /// A secondary, i.e. replicated from the Master
+    /// A secondary, i.e. replicated from the Queen
+    Drone,
+    #[doc(hidden)]
     Slave,
     /// A cached zone with recursive resolver abilities
     Hint,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -169,9 +169,10 @@ impl ZoneConfig {
     /// # Arguments
     ///
     /// * `zone` - name of a zone, e.g. example.com
-    /// * `zone_type` - Type of zone, e.g. Master
+    /// * `zone_type` - Type of zone, e.g. Queen or Drone
     /// * `file` - relative to Config base path, to the zone file
     /// * `allow_update` - enable dynamic updates
+    /// * `allow_axfr` - enable AXFR transfers
     /// * `enable_dnssec` - enable signing of the zone for DNSSec
     /// * `keys` - list of private and public keys used to sign a zone
     pub fn new(
@@ -179,16 +180,18 @@ impl ZoneConfig {
         zone_type: ZoneType,
         file: String,
         allow_update: Option<bool>,
+        allow_axfr: Option<bool>,
         enable_dnssec: Option<bool>,
         keys: Vec<KeyConfig>,
     ) -> Self {
         ZoneConfig {
-            zone: zone,
-            zone_type: zone_type,
-            file: file,
-            allow_update: allow_update,
-            enable_dnssec: enable_dnssec,
-            keys: keys,
+            zone,
+            zone_type,
+            file,
+            allow_update,
+            allow_axfr,
+            enable_dnssec,
+            keys,
         }
     }
 
@@ -214,6 +217,11 @@ impl ZoneConfig {
     /// enable dynamic updates for the zone (see SIG0 and the registered keys)
     pub fn is_update_allowed(&self) -> bool {
         self.allow_update.unwrap_or(false)
+    }
+
+    /// enable AXFR transfers
+    pub fn is_axfr_allowed(&self) -> bool {
+        self.allow_axfr.unwrap_or(false)
     }
 
     /// declare that this zone should be signed, see keys for configuration of the keys for signing

--- a/server/tests/txt_tests.rs
+++ b/server/tests/txt_tests.rs
@@ -71,7 +71,7 @@ _443._tcp.www.example.com. IN TLSA (
     }
 
     let (origin, records) = records.unwrap();
-    let authority = Authority::new(origin, records, ZoneType::Master, false, false);
+    let authority = Authority::new(origin, records, ZoneType::Queen, false, false);
 
     // not validating everything, just one of each...
 
@@ -104,8 +104,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::NS,
             false,
             SupportedAlgorithms::new(),
-        )
-        .collect();
+        ).collect();
     let mut compare = vec![
         // this is cool, zip up the expected results... works as long as the order is good.
         Name::from_str("a.isi.edu").unwrap(),
@@ -136,8 +135,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::MX,
             false,
             SupportedAlgorithms::new(),
-        )
-        .collect();
+        ).collect();
     let mut compare = vec![
         (10, Name::from_str("venera.isi.edu").unwrap()),
         (20, Name::from_str("vaxa.isi.edu").unwrap()),
@@ -167,8 +165,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::A,
             false,
             SupportedAlgorithms::new(),
-        )
-        .next()
+        ).next()
         .unwrap();
     assert_eq!(&Name::from_str("a.isi.edu").unwrap(), a_record.name());
     assert_eq!(60, a_record.ttl()); // TODO: should this be minimum or expire?
@@ -187,8 +184,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::AAAA,
             false,
             SupportedAlgorithms::new(),
-        )
-        .next()
+        ).next()
         .unwrap();
     assert_eq!(&Name::from_str("aaaa.isi.edu").unwrap(), aaaa_record.name());
     if let RData::AAAA(ref address) = *aaaa_record.rdata() {
@@ -207,8 +203,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::A,
             false,
             SupportedAlgorithms::new(),
-        )
-        .next()
+        ).next()
         .unwrap();
     assert_eq!(
         &Name::from_str("short.isi.edu").unwrap(),
@@ -228,8 +223,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::TXT,
             false,
             SupportedAlgorithms::new(),
-        )
-        .collect();
+        ).collect();
     let compare = vec![
         vec![
             Box::from("I".as_bytes()),
@@ -274,8 +268,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::PTR,
             false,
             SupportedAlgorithms::new(),
-        )
-        .next()
+        ).next()
         .unwrap();
     if let RData::PTR(ref ptrdname) = *ptr_record.rdata() {
         assert_eq!(&Name::from_str("a.isi.edu").unwrap(), ptrdname);
@@ -290,8 +283,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::SRV,
             false,
             SupportedAlgorithms::new(),
-        )
-        .next()
+        ).next()
         .unwrap();
     if let RData::SRV(ref rdata) = *srv_record.rdata() {
         assert_eq!(rdata.priority(), 1);
@@ -309,8 +301,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::A,
             false,
             SupportedAlgorithms::new(),
-        )
-        .next()
+        ).next()
         .unwrap();
     assert_eq!(
         &Name::from_str("rust-❤️-🦀.isi.edu").unwrap(),
@@ -329,8 +320,7 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::CAA,
             false,
             SupportedAlgorithms::new(),
-        )
-        .next()
+        ).next()
         .expect("nocerts not found");
     if let RData::CAA(ref rdata) = *caa_record.rdata() {
         assert!(!rdata.issuer_critical());
@@ -349,8 +339,8 @@ _443._tcp.www.example.com. IN TLSA (
             RecordType::TLSA,
             false,
             SupportedAlgorithms::new(),
-        )
-        .next().expect("tlsa record not found");
+        ).next()
+        .expect("tlsa record not found");
 
     if let RData::TLSA(ref rdata) = *tlsa_record.rdata() {
         assert_eq!(*rdata.cert_usage(), CertUsage::CA);


### PR DESCRIPTION
In an attempt to remove morally questionable terms from the library, all references to ‘master’ and ‘slave’ have been replaced with ‘queen’ and ‘drone’. 

I like these terms, but as I haven’t seen them in wide usage, I figure it’s important for others to weigh in. I find them more interesting and colorful than ‘primary’ and ‘secondary’, which would be another, more bland, option possibly more clear due to their general usage.