### PR TITLE
makes the IDNA library optional

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -35,6 +35,8 @@ appveyor = { repository = "bluejekyll/trust-dns", branch = "master", service = "
 codecov = { repository = "bluejekyll/trust-dns", branch = "master", service = "github" }
 
 [features]
+default = ["idna"]
+
 dnssec-openssl = ["dnssec", "openssl"]
 dnssec-ring = ["dnssec", "ring", "untrusted"]
 dnssec = ["data-encoding"]
@@ -56,7 +58,7 @@ byteorder = "^1.2"
 data-encoding = { version = "2.1.0", optional = true }
 failure = "0.1"
 futures = "^0.1.17"
-idna = "^0.1.4"
+idna = { version = "0.1.4", optional = true }
 lazy_static = "^1.0"
 log = "^0.4.1"
 openssl = { version = "^0.10", features = ["v102", "v110"], optional = true }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -20,6 +20,7 @@ extern crate env_logger;
 extern crate failure;
 #[macro_use]
 extern crate futures;
+#[cfg(feature = "idna")]
 extern crate idna;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
this will disable utf8 and i18n support

fixes: #551 

@aep if you have some time, please take a look at this. This will disable all i18n support, so it will be the responsibility of any library that needs that to encode the labels correctly.