### PR TITLE
strictly enforce name and label lengths during label parsing

### DIFF
--- a/proto/benches/name_benches.rs
+++ b/proto/benches/name_benches.rs
@@ -102,7 +102,7 @@ fn name_cmp_long_case(b: &mut Bencher) {
 #[bench]
 fn name_to_lower_short(b: &mut Bencher) {
     let name1 = Name::from_ascii("COM").unwrap();
-    
+
     b.iter(|| {
         let lower = name1.to_lowercase();
         assert_eq!(lower.num_labels(), 1);
@@ -132,7 +132,7 @@ fn name_to_lower_long(b: &mut Bencher) {
 #[bench]
 fn name_no_lower_short(b: &mut Bencher) {
     let name1 = Name::from_ascii("com").unwrap();
-    
+
     b.iter(|| {
         let lower = name1.to_lowercase();
         assert_eq!(lower.num_labels(), 1);

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -36,9 +36,23 @@ pub enum ProtoErrorKind {
     #[fail(display = "future was canceled: {:?}", _0)]
     Canceled(::futures::sync::oneshot::Canceled),
 
-    /// Character data length exceeded the limit of 255
-    #[fail(display = "char data length exceeds 255: {}", _0)]
-    CharacterDataTooLong(usize),
+    /// Character data length exceeded the limit
+    #[fail(display = "char data length exceeds {}: {}", _0, _1)]
+    CharacterDataTooLong {
+        /// Specified maximum
+        max: usize,
+        /// Actual length
+        len: usize,
+    },
+
+    /// Overlapping labels
+    #[fail(display = "overlapping labels name {} other {}", _0, _1)]
+    LabelOverlapsWithOther {
+        /// Start of the label that is overlaps
+        label: usize,
+        /// Start of the other label
+        other: usize,
+    },
 
     /// DNS protocol version doesn't have the expected version 3
     #[fail(display = "dns key value unknown, must be 3: {}", _0)]
@@ -368,7 +382,8 @@ impl Clone for ProtoErrorKind {
         use self::ProtoErrorKind::*;
         match *self {
             Canceled(ref c) => Canceled(*c),
-            CharacterDataTooLong(len) => CharacterDataTooLong(len),
+            CharacterDataTooLong { max, len } => CharacterDataTooLong { max, len },
+            LabelOverlapsWithOther { label, other } => LabelOverlapsWithOther { label, other },
             DnsKeyProtocolNot3(protocol) => DnsKeyProtocolNot3(protocol),
             DomainNameTooLong(len) => DomainNameTooLong(len),
             EdnsNameNotRoot(ref found) => EdnsNameNotRoot(found.clone()),

--- a/proto/src/serialize/binary/encoder.rs
+++ b/proto/src/serialize/binary/encoder.rs
@@ -279,7 +279,10 @@ impl<'a> BinEncoder<'a> {
     pub fn emit_character_data<S: AsRef<[u8]>>(&mut self, char_data: S) -> ProtoResult<()> {
         let char_bytes = char_data.as_ref();
         if char_bytes.len() > 255 {
-            return Err(ProtoErrorKind::CharacterDataTooLong(char_bytes.len()).into());
+            return Err(ProtoErrorKind::CharacterDataTooLong {
+                max: 255,
+                len: char_bytes.len(),
+            }.into());
         }
 
         // first the length is written


### PR DESCRIPTION
fyi @andrewtj

Took your advice. After further investigation, there were two gaps. I used your test verbatim, I hope that's alright with you.