### PR TITLE
Wrap types in Restrict and force validation before usage

### DIFF
--- a/proto/src/op/header.rs
+++ b/proto/src/op/header.rs
@@ -423,9 +423,9 @@ impl BinEncodable for Header {
 
 impl<'r> BinDecodable<'r> for Header {
     fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Self> {
-        let id = decoder.read_u16()?.unverified();
+        let id = decoder.read_u16()?.unverified(/*it is valid for this to be any u16*/);
 
-        let q_opcd_a_t_r = decoder.pop()?.unverified();
+        let q_opcd_a_t_r = decoder.pop()?.unverified(/*used as a bitfield, this is safe*/);
         // if the first bit is set
         let message_type = if (0b1000_0000 & q_opcd_a_t_r) == 0b1000_0000 {
             MessageType::Response
@@ -438,7 +438,7 @@ impl<'r> BinDecodable<'r> for Header {
         let truncation = (0b0000_0010 & q_opcd_a_t_r) == 0b0000_0010;
         let recursion_desired = (0b0000_0001 & q_opcd_a_t_r) == 0b0000_0001;
 
-        let r_z_ad_cd_rcod = decoder.pop()?.unverified(); // fail fast...
+        let r_z_ad_cd_rcod = decoder.pop()?.unverified(/*used as a bitfield, this is safe*/); // fail fast...
 
         let recursion_available = (0b1000_0000 & r_z_ad_cd_rcod) == 0b1000_0000;
         let authentic_data = (0b0010_0000 & r_z_ad_cd_rcod) == 0b0010_0000;
@@ -447,10 +447,10 @@ impl<'r> BinDecodable<'r> for Header {
 
         // TODO: We should pass these restrictions on, they can't be trusted, but that would seriosly complicate the Header type..
         // TODO: perhaps the read methods for BinDecodable should return Restrict?
-        let query_count = decoder.read_u16()?.unverified();
-        let answer_count = decoder.read_u16()?.unverified();
-        let name_server_count = decoder.read_u16()?.unverified();
-        let additional_count = decoder.read_u16()?.unverified();
+        let query_count = decoder.read_u16()?.unverified(/*this must be verified when reading queries*/);
+        let answer_count = decoder.read_u16()?.unverified(/*this must be evaluated when reading records*/);
+        let name_server_count = decoder.read_u16()?.unverified(/*this must be evaluated when reading records*/);
+        let additional_count = decoder.read_u16()?.unverified(/*this must be evaluated when reading records*/);
 
         // TODO: question, should this use the builder pattern instead? might be cleaner code, but
         //  this guarantees that the Header is fully instantiated with all values...

--- a/proto/src/rr/dns_class.rs
+++ b/proto/src/rr/dns_class.rs
@@ -95,7 +95,7 @@ impl BinEncodable for DNSClass {
 
 impl<'r> BinDecodable<'r> for DNSClass {
     fn read(decoder: &mut BinDecoder) -> ProtoResult<Self> {
-        Self::from_u16(decoder.read_u16()?.unverified())
+        Self::from_u16(decoder.read_u16()?.unverified(/*DNSClass is verified as safe in processing this*/))
     }
 }
 

--- a/proto/src/rr/dns_class.rs
+++ b/proto/src/rr/dns_class.rs
@@ -7,14 +7,14 @@
 
 //! class of DNS operations, in general always IN for internet
 
-use std::convert::From;
 use std::cmp::Ordering;
+use std::convert::From;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-use serialize::binary::*;
 use error::*;
+use serialize::binary::*;
 
 /// The DNS Record class
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
@@ -95,7 +95,7 @@ impl BinEncodable for DNSClass {
 
 impl<'r> BinDecodable<'r> for DNSClass {
     fn read(decoder: &mut BinDecoder) -> ProtoResult<Self> {
-        Self::from_u16(decoder.read_u16()?)
+        Self::from_u16(decoder.read_u16()?.unverified())
     }
 }
 

--- a/proto/src/rr/dnssec/algorithm.rs
+++ b/proto/src/rr/dnssec/algorithm.rs
@@ -166,7 +166,7 @@ impl BinEncodable for Algorithm {
 impl<'r> BinDecodable<'r> for Algorithm {
     // http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
     fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Algorithm> {
-        let algorithm_id = decoder.read_u8()?.unverified();
+        let algorithm_id = decoder.read_u8()?.unverified(/*Algorithm is verified as safe in processing this*/);
         Algorithm::from_u8(algorithm_id)
     }
 }

--- a/proto/src/rr/dnssec/algorithm.rs
+++ b/proto/src/rr/dnssec/algorithm.rs
@@ -166,7 +166,7 @@ impl BinEncodable for Algorithm {
 impl<'r> BinDecodable<'r> for Algorithm {
     // http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
     fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Algorithm> {
-        let algorithm_id = decoder.read_u8()?;
+        let algorithm_id = decoder.read_u8()?.unverified();
         Algorithm::from_u8(algorithm_id)
     }
 }

--- a/proto/src/rr/dnssec/digest_type.rs
+++ b/proto/src/rr/dnssec/digest_type.rs
@@ -52,6 +52,7 @@ pub enum DigestType {
 }
 
 impl DigestType {
+    /// TODO: add an Unknown DigestType and make this infalible
     /// http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
     pub fn from_u8(value: u8) -> ProtoResult<Self> {
         match value {

--- a/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -351,7 +351,8 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
     let key_len = rdata_length
         .map(|u| u as usize)
         .checked_sub(4)
-        .map_err(|_| ProtoError::from("invalid rdata length in DNSKEY"))?;
+        .map_err(|_| ProtoError::from("invalid rdata length in DNSKEY"))?
+        .unverified(/*used only as length safely*/);
     let public_key: Vec<u8> = decoder.read_vec(key_len)?.unverified(/*the byte array will fail in usage if invalid*/);
 
     Ok(DNSKEY::new(

--- a/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -322,14 +322,14 @@ impl From<DNSKEY> for RData {
 
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<DNSKEY> {
-    let flags: u16 = decoder.read_u16()?;
+    let flags: u16 = decoder.read_u16()?.unverified();
 
     //    Bits 0-6 and 8-14 are reserved: these bits MUST have value 0 upon
     //    creation of the DNSKEY RR and MUST be ignored upon receipt.
     let zone_key: bool = flags & 0b0000_0001_0000_0000 == 0b0000_0001_0000_0000;
     let secure_entry_point: bool = flags & 0b0000_0000_0000_0001 == 0b0000_0000_0000_0001;
     let revoke: bool = flags & 0b0000_0000_1000_0000 == 0b0000_0000_1000_0000;
-    let protocol: u8 = decoder.read_u8()?;
+    let protocol: u8 = decoder.read_u8()?.unverified(); // verified below
 
     // RFC 4034                DNSSEC Resource Records               March 2005
     //
@@ -347,8 +347,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<DNSKEY> 
     let algorithm: Algorithm = Algorithm::read(decoder)?;
 
     // the public key is the left-over bytes minus 4 for the first fields
-    // TODO: decode the key here?
-    let public_key: Vec<u8> = decoder.read_vec((rdata_length - 4) as usize)?;
+    let public_key: Vec<u8> = decoder.read_vec((rdata_length - 4) as usize)?.unverified();
 
     Ok(DNSKEY::new(
         zone_key,

--- a/proto/src/rr/dnssec/rdata/ds.rs
+++ b/proto/src/rr/dnssec/rdata/ds.rs
@@ -188,12 +188,12 @@ impl DS {
 pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<DS> {
     let start_idx = decoder.index();
 
-    let key_tag: u16 = decoder.read_u16()?;
+    let key_tag: u16 = decoder.read_u16()?.unverified();
     let algorithm: Algorithm = Algorithm::read(decoder)?;
-    let digest_type: DigestType = DigestType::from_u8(decoder.read_u8()?)?;
+    let digest_type: DigestType = DigestType::from_u8(decoder.read_u8()?.unverified())?;
 
     let left: usize = rdata_length as usize - (decoder.index() - start_idx);
-    let digest = decoder.read_vec(left)?;
+    let digest = decoder.read_vec(left)?.unverified();
 
     Ok(DS::new(key_tag, algorithm, digest_type, digest))
 }

--- a/proto/src/rr/dnssec/rdata/ds.rs
+++ b/proto/src/rr/dnssec/rdata/ds.rs
@@ -196,7 +196,8 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
     let left: usize = rdata_length
         .map(|u| u as usize)
         .checked_sub(bytes_read)
-        .map_err(|_| ProtoError::from("invalid rdata length in DS"))?;
+        .map_err(|_| ProtoError::from("invalid rdata length in DS"))?
+        .unverified(/*used only as length safely*/);
     let digest = decoder.read_vec(left)?.unverified(/*the byte array will fail in usage if invalid*/);
 
     Ok(DS::new(key_tag, algorithm, digest_type, digest))

--- a/proto/src/rr/dnssec/rdata/ds.rs
+++ b/proto/src/rr/dnssec/rdata/ds.rs
@@ -188,16 +188,16 @@ impl DS {
 pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResult<DS> {
     let start_idx = decoder.index();
 
-    let key_tag: u16 = decoder.read_u16()?.unverified();
+    let key_tag: u16 = decoder.read_u16()?.unverified(/*key_tag is valid as any u16*/);
     let algorithm: Algorithm = Algorithm::read(decoder)?;
-    let digest_type: DigestType = DigestType::from_u8(decoder.read_u8()?.unverified())?;
+    let digest_type: DigestType = DigestType::from_u8(decoder.read_u8()?.unverified(/*DigestType is verified as safe*/))?;
 
     let bytes_read = decoder.index() - start_idx;
     let left: usize = rdata_length
         .map(|u| u as usize)
         .checked_sub(bytes_read)
         .map_err(|_| ProtoError::from("invalid rdata length in DS"))?;
-    let digest = decoder.read_vec(left)?.unverified();
+    let digest = decoder.read_vec(left)?.unverified(/*the byte array will fail in usage if invalid*/);
 
     Ok(DS::new(key_tag, algorithm, digest_type, digest))
 }

--- a/proto/src/rr/dnssec/rdata/key.rs
+++ b/proto/src/rr/dnssec/rdata/key.rs
@@ -807,7 +807,8 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
     let key_len = rdata_length
         .map(|u| u as usize)
         .checked_sub(4)
-        .map_err(|_| ProtoError::from("invalid rdata length in KEY"))?;
+        .map_err(|_| ProtoError::from("invalid rdata length in KEY"))?
+        .unverified(/*used only as length safely*/);
     let public_key: Vec<u8> = decoder.read_vec(key_len)?.unverified(/*the byte array will fail in usage if invalid*/);
 
     Ok(KEY::new(

--- a/proto/src/rr/dnssec/rdata/key.rs
+++ b/proto/src/rr/dnssec/rdata/key.rs
@@ -797,7 +797,8 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
         return Err("extended flags currently not supported".into());
     }
 
-    let protocol = Protocol::from(decoder.read_u8()?.unverified());
+    // FIXME: protocol my be infalible
+    let protocol = Protocol::from(decoder.read_u8()?.unverified(/*Protocol is verified as safe*/));
 
     let algorithm: Algorithm = Algorithm::read(decoder)?;
 
@@ -807,7 +808,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
         .map(|u| u as usize)
         .checked_sub(4)
         .map_err(|_| ProtoError::from("invalid rdata length in KEY"))?;
-    let public_key: Vec<u8> = decoder.read_vec(key_len)?.unverified();
+    let public_key: Vec<u8> = decoder.read_vec(key_len)?.unverified(/*the byte array will fail in usage if invalid*/);
 
     Ok(KEY::new(
         key_trust, key_usage, signatory, protocol, algorithm, public_key,

--- a/proto/src/rr/dnssec/rdata/mod.rs
+++ b/proto/src/rr/dnssec/rdata/mod.rs
@@ -459,7 +459,7 @@ impl DNSSECRData {
     pub(crate) fn read(
         decoder: &mut BinDecoder,
         record_type: DNSSECRecordType,
-        rdata_length: u16,
+        rdata_length: Restrict<u16>,
     ) -> ProtoResult<Self> {
         match record_type {
             DNSSECRecordType::DNSKEY => {

--- a/proto/src/rr/dnssec/rdata/nsec3param.rs
+++ b/proto/src/rr/dnssec/rdata/nsec3param.rs
@@ -160,20 +160,20 @@ impl NSEC3PARAM {
 
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<NSEC3PARAM> {
-    let hash_algorithm = Nsec3HashAlgorithm::from_u8(decoder.read_u8()?.unverified())?;
+    let hash_algorithm = Nsec3HashAlgorithm::from_u8(decoder.read_u8()?.unverified(/*Algorithm verified as safe*/))?;
     let flags: u8 = decoder
         .read_u8()?
         .verify_unwrap(|flags| flags & 0b1111_1110 == 0)
         .map_err(|flags| ProtoError::from(ProtoErrorKind::UnrecognizedNsec3Flags(flags)))?;
 
     let opt_out: bool = flags & 0b0000_0001 == 0b0000_0001;
-    let iterations: u16 = decoder.read_u16()?.unverified();
+    let iterations: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
     let salt_len: usize = decoder
         .read_u8()?
         .map(|u| u as usize)
         .verify_unwrap(|salt_len| *salt_len <= decoder.len())
         .map_err(|_| ProtoError::from("salt_len exceeds buffer length"))?;
-    let salt: Vec<u8> = decoder.read_vec(salt_len)?.unverified();
+    let salt: Vec<u8> = decoder.read_vec(salt_len)?.unverified(/*valid as any array of u8*/);
 
     Ok(NSEC3PARAM::new(hash_algorithm, opt_out, iterations, salt))
 }

--- a/proto/src/rr/dnssec/rdata/sig.rs
+++ b/proto/src/rr/dnssec/rdata/sig.rs
@@ -455,11 +455,11 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
     // TODO should we verify here? or elsewhere...
     let type_covered = RecordType::read(decoder)?;
     let algorithm = Algorithm::read(decoder)?;
-    let num_labels = decoder.read_u8()?.unverified();
-    let original_ttl = decoder.read_u32()?.unverified();
-    let sig_expiration = decoder.read_u32()?.unverified();
-    let sig_inception = decoder.read_u32()?.unverified();
-    let key_tag = decoder.read_u16()?.unverified();
+    let num_labels = decoder.read_u8()?.unverified(/*technically valid as any u8*/);
+    let original_ttl = decoder.read_u32()?.unverified(/*valid as any u32*/);
+    let sig_expiration = decoder.read_u32()?.unverified(/*valid as any u32, in practice should be in the future*/);
+    let sig_inception = decoder.read_u32()?.unverified(/*valid as any u32, in practice should be before expiration*/);
+    let key_tag = decoder.read_u16()?.unverified(/*valid as any u16*/);
     let signer_name = Name::read(decoder)?;
 
     // read the signature, this will vary buy key size
@@ -469,7 +469,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
         .map_err(|_| ProtoError::from("invalid rdata length in SIG"))?;
     let sig = decoder
         .read_vec(sig_len)?
-        .unverified();
+        .unverified(/*will fail in usage if invalid*/);
 
     Ok(SIG::new(
         type_covered,

--- a/proto/src/rr/dnssec/rdata/sig.rs
+++ b/proto/src/rr/dnssec/rdata/sig.rs
@@ -16,10 +16,10 @@
 
 //! signature record for signing queries, updates, and responses
 
-use serialize::binary::*;
 use error::*;
-use rr::{Name, RecordType};
 use rr::dnssec::Algorithm;
+use rr::{Name, RecordType};
+use serialize::binary::*;
 
 /// [RFC 2535, Domain Name System Security Extensions, March 1999](https://tools.ietf.org/html/rfc2535#section-4)
 ///
@@ -455,16 +455,18 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<SIG> {
     // TODO should we verify here? or elsewhere...
     let type_covered = RecordType::read(decoder)?;
     let algorithm = Algorithm::read(decoder)?;
-    let num_labels = decoder.read_u8()?;
-    let original_ttl = decoder.read_u32()?;
-    let sig_expiration = decoder.read_u32()?;
-    let sig_inception = decoder.read_u32()?;
-    let key_tag = decoder.read_u16()?;
+    let num_labels = decoder.read_u8()?.unverified();
+    let original_ttl = decoder.read_u32()?.unverified();
+    let sig_expiration = decoder.read_u32()?.unverified();
+    let sig_inception = decoder.read_u32()?.unverified();
+    let key_tag = decoder.read_u16()?.unverified();
     let signer_name = Name::read(decoder)?;
 
     // read the signature, this will vary buy key size
     let bytes_read = decoder.index() - start_idx;
-    let sig = decoder.read_vec(rdata_length as usize - bytes_read)?;
+    let sig = decoder
+        .read_vec(rdata_length as usize - bytes_read)?
+        .unverified();
 
     Ok(SIG::new(
         type_covered,
@@ -550,38 +552,8 @@ fn test() {
         5,
         Name::from_str("www.example.com").unwrap(),
         vec![
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23,
-            24,
-            25,
-            26,
-            27,
-            28,
-            29,
-            29,
-            31,
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 29, 31,
         ], // 32 bytes for SHA256
     );
 

--- a/proto/src/rr/dnssec/rdata/sig.rs
+++ b/proto/src/rr/dnssec/rdata/sig.rs
@@ -466,7 +466,8 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
     let sig_len = rdata_length
         .map(|u| u as usize)
         .checked_sub(decoder.index() - start_idx)
-        .map_err(|_| ProtoError::from("invalid rdata length in SIG"))?;
+        .map_err(|_| ProtoError::from("invalid rdata length in SIG"))?
+        .unverified(/*used only as length safely*/);
     let sig = decoder
         .read_vec(sig_len)?
         .unverified(/*will fail in usage if invalid*/);

--- a/proto/src/rr/domain/name.rs
+++ b/proto/src/rr/domain/name.rs
@@ -940,7 +940,7 @@ fn read_inner<'r>(decoder: &mut BinDecoder<'r>, max_idx: Option<usize>) -> Proto
         state = match state {
             LabelParseState::LabelLengthOrPointer => {
                 // determine what the next label is
-                match decoder.peek().map(|b| b.unverified()) {
+                match decoder.peek().map(Restrict::unverified/*verified in this usage*/) {
                     Some(0) | None => LabelParseState::Root,
                     Some(byte) if byte & 0b1100_0000 == 0b1100_0000 => LabelParseState::Pointer,
                     Some(byte) if byte & 0b1100_0000 == 0b0000_0000 => LabelParseState::Label,

--- a/proto/src/rr/rdata/a.rs
+++ b/proto/src/rr/rdata/a.rs
@@ -48,10 +48,10 @@ use error::*;
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<Ipv4Addr> {
     Ok(Ipv4Addr::new(
-        decoder.pop()?.unverified(),
-        decoder.pop()?.unverified(),
-        decoder.pop()?.unverified(),
-        decoder.pop()?.unverified(),
+        decoder.pop()?.unverified(/*valid as any u8*/),
+        decoder.pop()?.unverified(/*valid as any u8*/),
+        decoder.pop()?.unverified(/*valid as any u8*/),
+        decoder.pop()?.unverified(/*valid as any u8*/),
     ))
 }
 

--- a/proto/src/rr/rdata/a.rs
+++ b/proto/src/rr/rdata/a.rs
@@ -48,10 +48,10 @@ use error::*;
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<Ipv4Addr> {
     Ok(Ipv4Addr::new(
-        decoder.pop()?,
-        decoder.pop()?,
-        decoder.pop()?,
-        decoder.pop()?,
+        decoder.pop()?.unverified(),
+        decoder.pop()?.unverified(),
+        decoder.pop()?.unverified(),
+        decoder.pop()?.unverified(),
     ))
 }
 

--- a/proto/src/rr/rdata/aaaa.rs
+++ b/proto/src/rr/rdata/aaaa.rs
@@ -39,14 +39,14 @@ use error::*;
 
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<Ipv6Addr> {
-    let a: u16 = decoder.read_u16()?.unverified();
-    let b: u16 = decoder.read_u16()?.unverified();
-    let c: u16 = decoder.read_u16()?.unverified();
-    let d: u16 = decoder.read_u16()?.unverified();
-    let e: u16 = decoder.read_u16()?.unverified();
-    let f: u16 = decoder.read_u16()?.unverified();
-    let g: u16 = decoder.read_u16()?.unverified();
-    let h: u16 = decoder.read_u16()?.unverified();
+    let a: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
+    let b: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
+    let c: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
+    let d: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
+    let e: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
+    let f: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
+    let g: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
+    let h: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);
 
     Ok(Ipv6Addr::new(a, b, c, d, e, f, g, h))
 }

--- a/proto/src/rr/rdata/aaaa.rs
+++ b/proto/src/rr/rdata/aaaa.rs
@@ -39,14 +39,14 @@ use error::*;
 
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<Ipv6Addr> {
-    let a: u16 = decoder.read_u16()?;
-    let b: u16 = decoder.read_u16()?;
-    let c: u16 = decoder.read_u16()?;
-    let d: u16 = decoder.read_u16()?;
-    let e: u16 = decoder.read_u16()?;
-    let f: u16 = decoder.read_u16()?;
-    let g: u16 = decoder.read_u16()?;
-    let h: u16 = decoder.read_u16()?;
+    let a: u16 = decoder.read_u16()?.unverified();
+    let b: u16 = decoder.read_u16()?.unverified();
+    let c: u16 = decoder.read_u16()?.unverified();
+    let d: u16 = decoder.read_u16()?.unverified();
+    let e: u16 = decoder.read_u16()?.unverified();
+    let f: u16 = decoder.read_u16()?.unverified();
+    let g: u16 = decoder.read_u16()?.unverified();
+    let h: u16 = decoder.read_u16()?.unverified();
 
     Ok(Ipv6Addr::new(a, b, c, d, e, f, g, h))
 }

--- a/proto/src/rr/rdata/caa.rs
+++ b/proto/src/rr/rdata/caa.rs
@@ -746,7 +746,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
     let tag_len = decoder.read_u8()?; 
     let value_len: Restrict<u16> = rdata_length
         .checked_sub(u16::from(tag_len.unverified(/*safe usage here*/)))
-        .and_then(|l| l.checked_sub(2))
+        .checked_sub(2)
         .map_err(|_| ProtoError::from("CAA tag character(s) out of bounds"))?;
 
     let tag = read_tag(decoder, tag_len)?;

--- a/proto/src/rr/rdata/mx.rs
+++ b/proto/src/rr/rdata/mx.rs
@@ -85,7 +85,7 @@ impl MX {
 
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<MX> {
-    Ok(MX::new(decoder.read_u16()?, Name::read(decoder)?))
+    Ok(MX::new(decoder.read_u16()?.unverified(), Name::read(decoder)?))
 }
 
 /// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005

--- a/proto/src/rr/rdata/mx.rs
+++ b/proto/src/rr/rdata/mx.rs
@@ -85,7 +85,7 @@ impl MX {
 
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<MX> {
-    Ok(MX::new(decoder.read_u16()?.unverified(), Name::read(decoder)?))
+    Ok(MX::new(decoder.read_u16()?.unverified(/*any u16 is valid*/), Name::read(decoder)?))
 }
 
 /// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005

--- a/proto/src/rr/rdata/null.rs
+++ b/proto/src/rr/rdata/null.rs
@@ -16,8 +16,8 @@
 
 //! null record type, generally not used except as an internal tool for representing null data
 
-use serialize::binary::*;
 use error::*;
+use serialize::binary::*;
 
 /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
 ///
@@ -61,9 +61,10 @@ impl NULL {
 }
 
 /// Read the RData from the given Decoder
-pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<NULL> {
+pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResult<NULL> {
+    let rdata_length = rdata_length.map(|u| u as usize).unverified();
     if rdata_length > 0 {
-        let anything = decoder.read_vec(rdata_length as usize)?.unverified();
+        let anything = decoder.read_vec(rdata_length)?.unverified();
         Ok(NULL::with(anything))
     } else {
         Ok(NULL::new())
@@ -93,7 +94,7 @@ pub fn test() {
     println!("bytes: {:?}", bytes);
 
     let mut decoder: BinDecoder = BinDecoder::new(bytes);
-    let read_rdata = read(&mut decoder, bytes.len() as u16);
+    let read_rdata = read(&mut decoder, Restrict::new(bytes.len() as u16));
     assert!(
         read_rdata.is_ok(),
         format!("error decoding: {:?}", read_rdata.unwrap_err())

--- a/proto/src/rr/rdata/null.rs
+++ b/proto/src/rr/rdata/null.rs
@@ -62,9 +62,9 @@ impl NULL {
 
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResult<NULL> {
-    let rdata_length = rdata_length.map(|u| u as usize).unverified();
+    let rdata_length = rdata_length.map(|u| u as usize).unverified(/*any u16 is valid*/);
     if rdata_length > 0 {
-        let anything = decoder.read_vec(rdata_length)?.unverified();
+        let anything = decoder.read_vec(rdata_length)?.unverified(/*any byte array is good*/);
         Ok(NULL::with(anything))
     } else {
         Ok(NULL::new())

--- a/proto/src/rr/rdata/null.rs
+++ b/proto/src/rr/rdata/null.rs
@@ -63,15 +63,7 @@ impl NULL {
 /// Read the RData from the given Decoder
 pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<NULL> {
     if rdata_length > 0 {
-        let mut anything: Vec<u8> = Vec::with_capacity(rdata_length as usize);
-        for _ in 0..rdata_length {
-            if let Ok(byte) = decoder.pop() {
-                anything.push(byte);
-            } else {
-                return Err("unexpected end of input reached".into());
-            }
-        }
-
+        let anything = decoder.read_vec(rdata_length as usize)?.unverified();
         Ok(NULL::with(anything))
     } else {
         Ok(NULL::new())

--- a/proto/src/rr/rdata/soa.rs
+++ b/proto/src/rr/rdata/soa.rs
@@ -214,11 +214,11 @@ pub fn read(decoder: &mut BinDecoder) -> ProtoResult<SOA> {
     Ok(SOA {
         mname: Name::read(decoder)?,
         rname: Name::read(decoder)?,
-        serial: decoder.read_u32()?.unverified(),
-        refresh: decoder.read_i32()?.unverified(),
-        retry: decoder.read_i32()?.unverified(),
-        expire: decoder.read_i32()?.unverified(),
-        minimum: decoder.read_u32()?.unverified(),
+        serial: decoder.read_u32()?.unverified(/*any u32 is valie*/),
+        refresh: decoder.read_i32()?.unverified(/*any i32 is valie*/),
+        retry: decoder.read_i32()?.unverified(/*any i32 is valie*/),
+        expire: decoder.read_i32()?.unverified(/*any i32 is valie*/),
+        minimum: decoder.read_u32()?.unverified(/*any u32 is valie*/),
     })
 }
 

--- a/proto/src/rr/rdata/soa.rs
+++ b/proto/src/rr/rdata/soa.rs
@@ -214,11 +214,11 @@ pub fn read(decoder: &mut BinDecoder) -> ProtoResult<SOA> {
     Ok(SOA {
         mname: Name::read(decoder)?,
         rname: Name::read(decoder)?,
-        serial: decoder.read_u32()?.unverified(/*any u32 is valie*/),
-        refresh: decoder.read_i32()?.unverified(/*any i32 is valie*/),
-        retry: decoder.read_i32()?.unverified(/*any i32 is valie*/),
-        expire: decoder.read_i32()?.unverified(/*any i32 is valie*/),
-        minimum: decoder.read_u32()?.unverified(/*any u32 is valie*/),
+        serial: decoder.read_u32()?.unverified(/*any u32 is valid*/),
+        refresh: decoder.read_i32()?.unverified(/*any i32 is valid*/),
+        retry: decoder.read_i32()?.unverified(/*any i32 is valid*/),
+        expire: decoder.read_i32()?.unverified(/*any i32 is valid*/),
+        minimum: decoder.read_u32()?.unverified(/*any u32 is valid*/),
     })
 }
 

--- a/proto/src/rr/rdata/soa.rs
+++ b/proto/src/rr/rdata/soa.rs
@@ -214,11 +214,11 @@ pub fn read(decoder: &mut BinDecoder) -> ProtoResult<SOA> {
     Ok(SOA {
         mname: Name::read(decoder)?,
         rname: Name::read(decoder)?,
-        serial: decoder.read_u32()?,
-        refresh: decoder.read_i32()?,
-        retry: decoder.read_i32()?,
-        expire: decoder.read_i32()?,
-        minimum: decoder.read_u32()?,
+        serial: decoder.read_u32()?.unverified(),
+        refresh: decoder.read_i32()?.unverified(),
+        retry: decoder.read_i32()?.unverified(),
+        expire: decoder.read_i32()?.unverified(),
+        minimum: decoder.read_u32()?.unverified(),
     })
 }
 

--- a/proto/src/rr/rdata/srv.rs
+++ b/proto/src/rr/rdata/srv.rs
@@ -196,9 +196,9 @@ impl SRV {
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<SRV> {
     // SRV { priority: u16, weight: u16, port: u16, target: Name, },
     Ok(SRV::new(
-        decoder.read_u16()?,
-        decoder.read_u16()?,
-        decoder.read_u16()?,
+        decoder.read_u16()?.unverified(),
+        decoder.read_u16()?.unverified(),
+        decoder.read_u16()?.unverified(),
         Name::read(decoder)?,
     ))
 }

--- a/proto/src/rr/rdata/srv.rs
+++ b/proto/src/rr/rdata/srv.rs
@@ -196,9 +196,9 @@ impl SRV {
 pub fn read(decoder: &mut BinDecoder) -> ProtoResult<SRV> {
     // SRV { priority: u16, weight: u16, port: u16, target: Name, },
     Ok(SRV::new(
-        decoder.read_u16()?.unverified(),
-        decoder.read_u16()?.unverified(),
-        decoder.read_u16()?.unverified(),
+        decoder.read_u16()?.unverified(/*any u16 is valid*/),
+        decoder.read_u16()?.unverified(/*any u16 is valid*/),
+        decoder.read_u16()?.unverified(/*any u16 is valid*/),
         Name::read(decoder)?,
     ))
 }

--- a/proto/src/rr/rdata/tlsa.rs
+++ b/proto/src/rr/rdata/tlsa.rs
@@ -348,12 +348,12 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<TLSA> {
         return Err("TLSA Resource Record too short".into());
     }
 
-    let cert_usage = decoder.read_u8()?.into();
-    let selector = decoder.read_u8()?.into();
-    let matching = decoder.read_u8()?.into();
+    let cert_usage = decoder.read_u8()?.unverified().into();
+    let selector = decoder.read_u8()?.unverified().into();
+    let matching = decoder.read_u8()?.unverified().into();
 
     // the remaining data is for the cert
-    let cert_data = decoder.read_vec((rdata_length - 3) as usize)?;
+    let cert_data = decoder.read_vec((rdata_length - 3) as usize)?.unverified();
 
     Ok(TLSA {
         cert_usage,

--- a/proto/src/rr/rdata/tlsa.rs
+++ b/proto/src/rr/rdata/tlsa.rs
@@ -344,16 +344,16 @@ impl TLSA {
 ///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResult<TLSA> {
-    let cert_usage = decoder.read_u8()?.unverified().into();
-    let selector = decoder.read_u8()?.unverified().into();
-    let matching = decoder.read_u8()?.unverified().into();
+    let cert_usage = decoder.read_u8()?.unverified(/*CertUsage is verified*/).into();
+    let selector = decoder.read_u8()?.unverified(/*Selector is verified*/).into();
+    let matching = decoder.read_u8()?.unverified(/*Matching is verified*/).into();
 
     // the remaining data is for the cert
     let cert_len = rdata_length
         .map(|u| u as usize)
         .checked_sub(3)
         .map_err(|_| ProtoError::from("invalid rdata length in TLSA"))?;
-    let cert_data = decoder.read_vec(cert_len)?.unverified();
+    let cert_data = decoder.read_vec(cert_len)?.unverified(/*will fail in usage if invalid*/);
 
     Ok(TLSA {
         cert_usage,

--- a/proto/src/rr/rdata/tlsa.rs
+++ b/proto/src/rr/rdata/tlsa.rs
@@ -352,7 +352,8 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
     let cert_len = rdata_length
         .map(|u| u as usize)
         .checked_sub(3)
-        .map_err(|_| ProtoError::from("invalid rdata length in TLSA"))?;
+        .map_err(|_| ProtoError::from("invalid rdata length in TLSA"))?
+        .unverified(/*used purely as length safely*/);
     let cert_data = decoder.read_vec(cert_len)?.unverified(/*will fail in usage if invalid*/);
 
     Ok(TLSA {

--- a/proto/src/rr/rdata/txt.rs
+++ b/proto/src/rr/rdata/txt.rs
@@ -78,7 +78,7 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: u16) -> ProtoResult<TXT> {
     let mut strings = Vec::with_capacity(1);
 
     while data_len - decoder.len() < rdata_length as usize {
-        let string = decoder.read_character_data()?;
+        let string = decoder.read_character_data()?.unverified();
         strings.push(string.to_vec().into_boxed_slice());
     }
     Ok(TXT {

--- a/proto/src/rr/rdata/txt.rs
+++ b/proto/src/rr/rdata/txt.rs
@@ -78,9 +78,9 @@ pub fn read(decoder: &mut BinDecoder, rdata_length: Restrict<u16>) -> ProtoResul
     let mut strings = Vec::with_capacity(1);
 
     // no unsafe usage of rdata length ofter this point
-    let rdata_length = rdata_length.map(|u| u as usize).unverified();
+    let rdata_length = rdata_length.map(|u| u as usize).unverified(/*used as a higher bound, safely*/);
     while data_len - decoder.len() < rdata_length {
-        let string = decoder.read_character_data()?.unverified();
+        let string = decoder.read_character_data()?.unverified(/*any data should be validat in TXT usage*/);
         strings.push(string.to_vec().into_boxed_slice());
     }
     Ok(TXT {

--- a/proto/src/rr/record_type.rs
+++ b/proto/src/rr/record_type.rs
@@ -212,7 +212,7 @@ impl BinEncodable for RecordType {
 
 impl<'r> BinDecodable<'r> for RecordType {
     fn read(decoder: &mut BinDecoder) -> ProtoResult<Self> {
-        decoder.read_u16().map(Self::from)
+        decoder.read_u16().map(|u| u.unverified()).map(Self::from)
     }
 }
 

--- a/proto/src/rr/record_type.rs
+++ b/proto/src/rr/record_type.rs
@@ -212,7 +212,7 @@ impl BinEncodable for RecordType {
 
 impl<'r> BinDecodable<'r> for RecordType {
     fn read(decoder: &mut BinDecoder) -> ProtoResult<Self> {
-        decoder.read_u16().map(|u| u.unverified()).map(Self::from)
+        decoder.read_u16().map(|u| u.unverified(/*RecordType is safe with any u16*/)).map(Self::from)
     }
 }
 

--- a/proto/src/rr/resource.rs
+++ b/proto/src/rr/resource.rs
@@ -280,7 +280,7 @@ impl<'r> BinDecodable<'r> for Record {
             }
 
             //  DNS Class is overloaded for OPT records in EDNS - RFC 6891
-            DNSClass::for_opt(decoder.read_u16()?.unverified())
+            DNSClass::for_opt(decoder.read_u16()?.unverified(/*restricted to a min of 512 in for_opt*/))
         } else {
             DNSClass::read(decoder)?
         };
@@ -294,7 +294,7 @@ impl<'r> BinDecodable<'r> for Record {
         //                with a zero TTL to prohibit caching.  Zero values can
         //                also be used for extremely volatile data.
         // note: u32 seems more accurate given that it can only be positive
-        let ttl: u32 = decoder.read_u32()?.unverified();
+        let ttl: u32 = decoder.read_u32()?.unverified(/*any u32 is valid*/);
 
         // RDLENGTH        an unsigned 16 bit integer that specifies the length in
         //                octets of the RDATA field.

--- a/proto/src/rr/resource.rs
+++ b/proto/src/rr/resource.rs
@@ -313,7 +313,9 @@ impl<'r> BinDecodable<'r> for Record {
             // RDATA           a variable length string of octets that describes the
             //                resource.  The format of this information varies
             //                according to the TYPE and CLASS of the resource record.
-            RData::read(decoder, record_type, rd_length)?
+            // Adding restrict to the rdata length because it's used for many calculations later
+            //  and must be validated before hand
+            RData::read(decoder, record_type, Restrict::new(rd_length))?
         };
 
         Ok(Record {

--- a/proto/src/serialize/binary/bin_tests.rs
+++ b/proto/src/serialize/binary/bin_tests.rs
@@ -31,7 +31,7 @@ fn get_character_data() -> Vec<(&'static str, Vec<u8>)> {
 fn read_character_data() {
     for (string, bytes) in get_character_data() {
         let mut decoder = BinDecoder::new(&bytes);
-        assert_eq!(decoder.read_character_data().unwrap(), string.as_bytes());
+        assert_eq!(decoder.read_character_data().unwrap().unverified(), string.as_bytes());
     }
 }
 
@@ -54,7 +54,7 @@ fn get_u16_data() -> Vec<(u16, Vec<u8>)> {
 
 #[test]
 fn read_u16() {
-    test_read_data_set(get_u16_data(), |mut d| d.read_u16());
+    test_read_data_set(get_u16_data(), |mut d| d.read_u16().map(Restrict::unverified));
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn get_i32_data() -> Vec<(i32, Vec<u8>)> {
 
 #[test]
 fn read_i32() {
-    test_read_data_set(get_i32_data(), |mut d| d.read_i32());
+    test_read_data_set(get_i32_data(), |mut d| d.read_i32().map(Restrict::unverified));
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn get_u32_data() -> Vec<(u32, Vec<u8>)> {
 
 #[test]
 fn read_u32() {
-    test_read_data_set(get_u32_data(), |mut d| d.read_u32());
+    test_read_data_set(get_u32_data(), |mut d| d.read_u32().map(Restrict::unverified));
 }
 
 #[test]

--- a/proto/src/serialize/binary/encoder.rs
+++ b/proto/src/serialize/binary/encoder.rs
@@ -562,7 +562,7 @@ mod tests {
         assert_eq!(buf.len(), 4);
 
         let mut decoder = BinDecoder::new(&buf);
-        let written = decoder.read_u16().expect("cound not read u16");
+        let written = decoder.read_u16().expect("cound not read u16").unverified();
 
         assert_eq!(written, 4);
     }

--- a/proto/src/serialize/binary/mod.rs
+++ b/proto/src/serialize/binary/mod.rs
@@ -23,7 +23,7 @@ mod restrict;
 pub use self::decoder::BinDecoder;
 pub use self::encoder::BinEncoder;
 pub use self::encoder::EncodeMode;
-pub use self::restrict::{Restrict, Verified};
+pub use self::restrict::{Restrict, RestrictedMath, Verified};
 
 #[cfg(test)]
 pub mod bin_tests;
@@ -100,4 +100,3 @@ impl BinEncodable for Vec<u8> {
         encoder.emit_vec(self)
     }
 }
-

--- a/proto/src/serialize/binary/mod.rs
+++ b/proto/src/serialize/binary/mod.rs
@@ -18,10 +18,12 @@
 
 mod decoder;
 mod encoder;
+mod restrict;
 
 pub use self::decoder::BinDecoder;
 pub use self::encoder::BinEncoder;
 pub use self::encoder::EncodeMode;
+pub use self::restrict::{Restrict, Verified};
 
 #[cfg(test)]
 pub mod bin_tests;

--- a/proto/src/serialize/binary/mod.rs
+++ b/proto/src/serialize/binary/mod.rs
@@ -67,7 +67,7 @@ impl BinEncodable for u16 {
 
 impl<'r> BinDecodable<'r> for u16 {
     fn read(decoder: &mut BinDecoder) -> ProtoResult<Self> {
-        decoder.read_u16()
+        decoder.read_u16().map(Restrict::unverified)
     }
 }
 
@@ -79,7 +79,7 @@ impl BinEncodable for i32 {
 
 impl<'r> BinDecodable<'r> for i32 {
     fn read(decoder: &mut BinDecoder) -> ProtoResult<i32> {
-        decoder.read_i32()
+        decoder.read_i32().map(Restrict::unverified)
     }
 }
 
@@ -91,7 +91,7 @@ impl BinEncodable for u32 {
 
 impl<'r> BinDecodable<'r> for u32 {
     fn read(decoder: &mut BinDecoder) -> ProtoResult<Self> {
-        decoder.read_u32()
+        decoder.read_u32().map(Restrict::unverified)
     }
 }
 
@@ -101,8 +101,3 @@ impl BinEncodable for Vec<u8> {
     }
 }
 
-impl<'r> BinDecodable<'r> for Vec<u8> {
-    fn read(_: &mut BinDecoder) -> ProtoResult<Self> {
-        panic!("do not know amount to read in this context")
-    }
-}

--- a/proto/src/serialize/binary/restrict.rs
+++ b/proto/src/serialize/binary/restrict.rs
@@ -1,0 +1,101 @@
+/// Untrusted types are boxed in this, only access is through the verify method
+pub struct Restrict<T>(T);
+
+impl<T> Restrict<T> {
+    /// Create a new restricted type
+    #[inline]
+    pub fn new(restricted: T) -> Self {
+        Restrict(restricted)
+    }
+
+    /// it is the responsibility of th function to verfy
+    ///
+    /// ```
+    /// use trust_dns_proto::serialize::binary::Restrict;
+    ///
+    /// let unrestricted = Restrict::new(0).verify(|r| *r == 0).then(|r| *r + 1).unwrap();
+    /// assert!(unrestricted == 1);
+    /// ```
+    #[inline]
+    pub fn verify<'a, F: Fn(&'a T) -> bool>(&'a self, f: F) -> Verified<'a, T> {
+        if f(&self.0) {
+            Verified(VerifiedInner::Valid(&self.0))
+        } else {
+            Verified(VerifiedInner::Invalid)
+        }
+    }
+
+    /// it is the responsibility of th function to verfy
+    ///
+    /// ```
+    /// use trust_dns_proto::serialize::binary::Restrict;
+    ///
+    /// let unrestricted = Restrict::new(0).verify_unwrap(|r| *r == 0).unwrap();
+    /// assert!(unrestricted == 0);
+    /// ```
+    #[inline]
+    pub fn verify_unwrap<F: Fn(&T) -> bool>(self, f: F) -> Result<T, ()> {
+        if f(&self.0) {
+            Ok(self.0)
+        } else {
+            Err(())
+        }
+    }
+
+    /// Combine with another value to create a chained Restriction
+    ///
+    /// ```
+    /// use trust_dns_proto::serialize::binary::Restrict;
+    ///
+    /// let restricted = Restrict::new(vec![0]).fold(|mut v| {v.push(1); v});
+    /// assert!(restricted.verify(|v| v == &[0, 1]).is_valid());
+    /// assert!(!restricted.verify(|v| v == &[1, 0]).is_valid());
+    /// ```
+    #[inline]
+    fn fold<R, F: Fn(T) -> R>(self, f: F) -> Restrict<R> {
+        Restrict(f(self.0))
+    }
+
+    /// Combine with another value to create a chained Restriction
+    ///
+    /// ```
+    /// use trust_dns_proto::serialize::binary::Restrict;
+    ///
+    /// let restricted = Restrict::new(vec![0]).with(|mut v| {v.push(1); v});
+    /// assert!(restricted.verify(|v| v == &[0, 1]).is_valid());
+    /// assert!(!restricted.verify(|v| v == &[1, 0]).is_valid());
+    /// ```
+    #[inline]
+    fn with<R, F: Fn(T) -> R>(self, f: F) -> Restrict<R> {
+        Restrict(f(self.0))
+    }
+}
+
+/// Verified data that can be operated on
+pub struct Verified<'a, T: 'a>(VerifiedInner<'a, T>);
+
+impl<'a, T> Verified<'a, T> {
+    /// Perform some operation on the data, and return a result.
+    #[inline]
+    pub fn then<R, F: Fn(&T) -> R>(&self, f: F) -> Result<R, ()> {
+        match self.0 {
+            VerifiedInner::Valid(t) => Ok(f(t)),
+            VerifiedInner::Invalid => Err(()),
+        }
+    }
+
+    /// Is this valid
+    #[inline]
+    pub fn is_valid(&self) -> bool {
+        match self.0 {
+            VerifiedInner::Valid(_) => true,
+            VerifiedInner::Invalid => false,
+        }
+    }
+}
+
+/// Verified data that can be operated on
+enum VerifiedInner<'a, T: 'a> {
+    Valid(&'a T),
+    Invalid,
+}

--- a/proto/src/serialize/binary/restrict.rs
+++ b/proto/src/serialize/binary/restrict.rs
@@ -121,6 +121,15 @@ impl RestrictedMath for Restrict<usize> {
     }
 }
 
+impl RestrictedMath for Restrict<u8> {
+    type Arg = u8;
+    type Value = u8;
+
+    fn checked_sub(&self, arg: Self::Arg) -> Result<Self::Value, Self::Arg> {
+        self.0.checked_sub(arg).ok_or_else(|| arg)
+    }
+}
+
 impl RestrictedMath for Restrict<u16> {
     type Arg = u16;
     type Value = u16;

--- a/proto/src/serialize/binary/restrict.rs
+++ b/proto/src/serialize/binary/restrict.rs
@@ -63,6 +63,15 @@ impl<T> Restrict<T> {
     }
 }
 
+impl<T: Clone> Clone for Restrict<T> {
+    fn clone(&self) -> Self {
+        Restrict(self.0.clone())
+    }
+}
+
+impl<T: Copy> Copy for Restrict<T> {}
+
+
 /// Verified data that can be operated on
 pub struct Verified<'a, T: 'a>(VerifiedInner<'a, T>);
 
@@ -90,4 +99,33 @@ impl<'a, T> Verified<'a, T> {
 enum VerifiedInner<'a, T: 'a> {
     Valid(&'a T),
     Invalid(&'a T),
+}
+
+/// Common checked math operations for the Restrict type
+pub trait RestrictedMath {
+    /// Argument for the math operations
+    type Arg: 'static + Sized + Copy;
+    /// Return value, generally the same as Arg
+    type Value: 'static + Sized + Copy;
+
+    /// Checked subtraction, see `usize::checked_sub`
+    fn checked_sub(&self, arg: Self::Arg) -> Result<Self::Value, Self::Arg>;
+}
+
+impl RestrictedMath for Restrict<usize> {
+    type Arg = usize;
+    type Value = usize;
+
+    fn checked_sub(&self, arg: Self::Arg) -> Result<Self::Value, Self::Arg> {
+        self.0.checked_sub(arg).ok_or_else(|| arg)
+    }
+}
+
+impl RestrictedMath for Restrict<u16> {
+    type Arg = u16;
+    type Value = u16;
+
+    fn checked_sub(&self, arg: Self::Arg) -> Result<Self::Value, Self::Arg> {
+        self.0.checked_sub(arg).ok_or_else(|| arg)
+    }
 }


### PR DESCRIPTION
@hawkw you may be interested in reviewing this? I broke it up into three commits to follow more easily.

@oherrala I think this completely covers all uses where data read from potentially malicious packets.