### PR TITLE
Matching of CAA Tag value should be done case insensitively

### DIFF
--- a/proto/src/rr/rdata/caa.rs
+++ b/proto/src/rr/rdata/caa.rs
@@ -287,7 +287,10 @@ impl Property {
 
 impl From<String> for Property {
     fn from(tag: String) -> Property {
-        match &tag as &str {
+        // RFC6488 section 5.1 states that "Matching of tag values is case
+        // insensitive."
+        let lower = tag.to_ascii_lowercase();
+        match &lower as &str {
             "issue" => return Property::Issue,
             "issuewild" => return Property::IssueWild,
             "iodef" => return Property::Iodef,
@@ -861,8 +864,8 @@ mod tests {
 
     #[test]
     fn test_from_str_property() {
-        assert_eq!(Property::from("issue".to_string()), Property::Issue);
-        assert_eq!(Property::from("issuewild".to_string()), Property::IssueWild);
+        assert_eq!(Property::from("Issue".to_string()), Property::Issue);
+        assert_eq!(Property::from("issueWild".to_string()), Property::IssueWild);
         assert_eq!(Property::from("iodef".to_string()), Property::Iodef);
         assert_eq!(
             Property::from("unknown".to_string()),


### PR DESCRIPTION
[RFC6488 section 5.1](https://tools.ietf.org/html/rfc6844#section-5.1) states that

> Tag values MAY contain US-ASCII characters 'a' through 'z', 'A' through 'Z', and the numbers 0 through 9. Tag values SHOULD NOT contain any other characters.  **Matching of tag values is case insensitive.**

so make the tag lowercase before comparison.