### PR TITLE
Make trust_dns_server::server::ResponseHandler Send

### DIFF
--- a/crates/server/src/server/response_handler.rs
+++ b/crates/server/src/server/response_handler.rs
@@ -15,7 +15,7 @@ use trust_dns_proto::xfer::SerialMessage;
 use authority::MessageResponse;
 
 /// A handler for send a response to a client
-pub trait ResponseHandler {
+pub trait ResponseHandler: Send {
     // TODO: add associated error type
     //type Error;
 


### PR DESCRIPTION
To build an asynchronous DNS server upon `trust-dns-server`, I create my own `RequestHandler`. In the `handle_request` function that I have to implement, I intend to spawn a `Future` which captures and uses  `response_handle` to the Tokio runtime. 

It is known that most of the `spawn` functions (except that of `current_thread`) in Tokio require the `Future` to be `Send`. However, `ResponseHandler` is not marked `Send` and this prevents the `Future` captures it from being spawned to the Tokio runtime.

Currently, the only implementor of `ResponseHandler` is `ResponseHandle` which is `Send`. So it is okay to add `Send` to `ResponseHandler` at this stage. 

Of course, as I know little about your future development plan, if adding `Send` constraint to `ResponseHandle` could make some trouble, close it as you like.