### PR TITLE
Don't require DnsExchange in ClientFuture usage

### DIFF
--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -438,9 +438,9 @@ where
         ClientFuture<Self::SenderFuture, Self::Sender, Self::Response>,
         Self::Handle,
     ) {
-        let (stream, stream_handle) = self.conn.new_stream(self.signer.clone());
+        let stream = self.conn.new_stream(self.signer.clone());
 
-        ClientFuture::from_exchange(stream, stream_handle)
+        ClientFuture::connect(stream)
     }
 }
 
@@ -522,10 +522,10 @@ where
         ClientFuture<Self::SenderFuture, Self::Sender, Self::Response>,
         Self::Handle,
     ) {
-        let (stream, stream_handle) = self.conn.new_stream(self.signer.clone());
+        let stream = self.conn.new_stream(self.signer.clone());
 
-        let (background, client) = ClientFuture::from_exchange(stream, stream_handle);
-        (background, SecureClientHandle::new(client))
+        let (background, handle) = ClientFuture::connect(stream);
+        (background, SecureClientHandle::new(handle))
     }
 }
 

--- a/crates/client/src/client/client_connection.rs
+++ b/crates/client/src/client/client_connection.rs
@@ -18,9 +18,7 @@ use std::sync::Arc;
 use futures::Future;
 
 use trust_dns_proto::error::ProtoError;
-use trust_dns_proto::xfer::{
-    DnsExchangeConnect, DnsRequestSender, DnsRequestStreamHandle, DnsResponse,
-};
+use trust_dns_proto::xfer::{DnsRequestSender, DnsResponse};
 
 use rr::dnssec::Signer;
 
@@ -34,11 +32,5 @@ pub trait ClientConnection: 'static + Sized + Send {
     type SenderFuture: Future<Item = Self::Sender, Error = ProtoError> + 'static + Send;
 
     /// Construct a new stream for use in the Client
-    fn new_stream(
-        &self,
-        signer: Option<Arc<Signer>>,
-    ) -> (
-        DnsExchangeConnect<Self::SenderFuture, Self::Sender, Self::Response>,
-        DnsRequestStreamHandle<Self::Response>,
-    );
+    fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture;
 }

--- a/crates/client/src/client/client_future.rs
+++ b/crates/client/src/client/client_future.rs
@@ -14,8 +14,7 @@ use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::{
     BufDnsRequestStreamHandle, DnsClientStream, DnsExchange, DnsExchangeConnect, DnsHandle,
     DnsMultiplexer, DnsMultiplexerConnect, DnsMultiplexerSerialResponse, DnsRequest,
-    DnsRequestOptions, DnsRequestSender, DnsRequestStreamHandle, DnsResponse, DnsStreamHandle,
-    OneshotDnsResponseReceiver,
+    DnsRequestOptions, DnsRequestSender, DnsResponse, DnsStreamHandle, OneshotDnsResponseReceiver,
 };
 
 use error::*;
@@ -83,50 +82,33 @@ impl<S: DnsClientStream + 'static>
     ) -> (Self, BasicClientHandle<DnsMultiplexerSerialResponse>) {
         let mp =
             DnsMultiplexer::with_timeout(Box::new(stream), stream_handle, timeout_duration, signer);
-        let (exchange, handle) = DnsExchange::connect(mp);
-
-        Self::from_exchange_with_timeout(exchange, handle)
+        Self::connect(mp)
     }
 }
 
-impl<SenderFuture, Sender, Response> ClientFuture<SenderFuture, Sender, Response>
+impl<F, S, R> ClientFuture<F, S, R>
 where
-    SenderFuture: Future<Item = Sender, Error = ProtoError> + Send,
-    Sender: DnsRequestSender<DnsResponseFuture = Response>,
-    Response: Future<Item = DnsResponse, Error = ProtoError> + Send,
+    F: Future<Item = S, Error = ProtoError> + 'static + Send,
+    S: DnsRequestSender<DnsResponseFuture = R>,
+    R: Future<Item = DnsResponse, Error = ProtoError> + 'static + Send,
 {
-    // TODO: consider changing this to take the multiplexed connection, and create the exchange internally...
-    /// Spawns a new ClientFuture Stream. This uses a default timeout of 5 seconds for all requests.
+    /// Returns a future, which itself wraps a future which is awaiting connection.
     ///
-    /// # Arguments
+    /// The connect_future should be lazy.
     ///
-    /// * `stream` - A stream of bytes that can be used to send/receive DNS messages
-    ///              (see TcpClientStream or UdpClientStream)
-    /// * `stream_handle` - The handle for the `stream` on which bytes can be sent/received.
-    pub fn from_exchange(
-        stream: DnsExchangeConnect<SenderFuture, Sender, Response>,
-        stream_handle: DnsRequestStreamHandle<Response>,
-    ) -> (Self, BasicClientHandle<Response>) {
-        Self::from_exchange_with_timeout(stream, stream_handle)
-    }
+    /// # Returns
+    ///
+    /// This returns a tuple of Self and a handle to send dns messages. Self is a
+    ///  background task, it must be run on an executor before handle is used.
+    pub fn connect(connect_future: F) -> (Self, BasicClientHandle<R>) {
+        let (exchange, handle) = DnsExchange::connect(connect_future);
 
-    /// Spawns a new ClientFuture Stream.
-    ///
-    /// # Arguments
-    ///
-    /// * `stream` - A stream of bytes that can be used to send/receive DNS messages
-    ///              (see TcpClientStream or UdpClientStream)
-    /// * `stream_handle` - The handle for the `stream` on which bytes can be sent/received.
-    pub fn from_exchange_with_timeout(
-        stream: DnsExchangeConnect<SenderFuture, Sender, Response>,
-        stream_handle: DnsRequestStreamHandle<Response>,
-    ) -> (Self, BasicClientHandle<Response>) {
         (
             Self {
-                inner: InnerClientFuture::DnsExchangeConnect(stream),
+                inner: InnerClientFuture::DnsExchangeConnect(exchange),
             },
             BasicClientHandle {
-                message_sender: BufDnsRequestStreamHandle::new(stream_handle),
+                message_sender: BufDnsRequestStreamHandle::new(handle),
             },
         )
     }

--- a/crates/client/src/https_client_connection.rs
+++ b/crates/client/src/https_client_connection.rs
@@ -12,9 +12,7 @@ use std::sync::Arc;
 
 use rustls::{Certificate, ClientConfig};
 use trust_dns_https::{HttpsClientConnect, HttpsClientStream, HttpsClientStreamBuilder};
-use trust_dns_proto::xfer::{
-    DnsExchange, DnsExchangeConnect, DnsRequestSender, DnsRequestStreamHandle,
-};
+use trust_dns_proto::xfer::DnsRequestSender;
 
 use client::ClientConnection;
 use rr::dnssec::Signer;
@@ -50,18 +48,13 @@ impl ClientConnection for HttpsClientConnection {
 
     fn new_stream(
         &self,
-        // FIXME: maybe signer needs to be applied in https...
+        // TODO: maybe signer needs to be applied in https...
         _signer: Option<Arc<Signer>>,
-    ) -> (
-        DnsExchangeConnect<Self::SenderFuture, Self::Sender, Self::Response>,
-        DnsRequestStreamHandle<Self::Response>,
-    ) {
-        // FIXME: maybe signer needs to be applied in https...
+    ) -> Self::SenderFuture {
+        // TODO: maybe signer needs to be applied in https...
         let https_builder =
             HttpsClientStreamBuilder::with_client_config(self.client_config.clone());
-        let https_connect = https_builder.build(self.name_server, self.dns_name.clone());
-
-        DnsExchange::connect(https_connect)
+        https_builder.build(self.name_server, self.dns_name.clone())
     }
 }
 

--- a/crates/client/src/multicast/mdns_client_connection.rs
+++ b/crates/client/src/multicast/mdns_client_connection.rs
@@ -10,7 +10,9 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
-use trust_dns_proto::multicast::{MdnsClientStream, MdnsQueryType, MDNS_IPV4, MDNS_IPV6};
+use trust_dns_proto::multicast::{
+    MdnsClientConnect, MdnsClientStream, MdnsQueryType, MDNS_IPV4, MDNS_IPV6,
+};
 use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 
 use client::ClientConnection;
@@ -52,7 +54,7 @@ impl MdnsClientConnection {
 impl ClientConnection for MdnsClientConnection {
     type Sender = DnsMultiplexer<MdnsClientStream, Signer>;
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
-    type SenderFuture = DnsMultiplexerConnect<MdnsClientStream, Signer>;
+    type SenderFuture = DnsMultiplexerConnect<MdnsClientConnect, MdnsClientStream, Signer>;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (mdns_client_stream, handle) = MdnsClientStream::new(
@@ -63,6 +65,6 @@ impl ClientConnection for MdnsClientConnection {
             self.ipv6_if,
         );
 
-        DnsMultiplexer::new(Box::new(mdns_client_stream), handle, signer)
+        DnsMultiplexer::new(mdns_client_stream, handle, signer)
     }
 }

--- a/crates/client/src/multicast/mdns_client_connection.rs
+++ b/crates/client/src/multicast/mdns_client_connection.rs
@@ -10,11 +10,8 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
-use trust_dns_proto::multicast::{MDNS_IPV4, MDNS_IPV6, MdnsClientStream, MdnsQueryType};
-use trust_dns_proto::xfer::{
-    DnsExchange, DnsExchangeConnect, DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender,
-    DnsRequestStreamHandle,
-};
+use trust_dns_proto::multicast::{MdnsClientStream, MdnsQueryType, MDNS_IPV4, MDNS_IPV6};
+use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 
 use client::ClientConnection;
 use rr::dnssec::Signer;
@@ -57,13 +54,7 @@ impl ClientConnection for MdnsClientConnection {
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
     type SenderFuture = DnsMultiplexerConnect<MdnsClientStream, Signer>;
 
-    fn new_stream(
-        &self,
-        signer: Option<Arc<Signer>>,
-    ) -> (
-        DnsExchangeConnect<Self::SenderFuture, Self::Sender, Self::Response>,
-        DnsRequestStreamHandle<Self::Response>,
-    ) {
+    fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (mdns_client_stream, handle) = MdnsClientStream::new(
             self.multicast_addr,
             MdnsQueryType::OneShot,
@@ -72,7 +63,6 @@ impl ClientConnection for MdnsClientConnection {
             self.ipv6_if,
         );
 
-        let mp = DnsMultiplexer::new(Box::new(mdns_client_stream), handle, signer);
-        DnsExchange::connect(mp)
+        DnsMultiplexer::new(Box::new(mdns_client_stream), handle, signer)
     }
 }

--- a/crates/client/src/tcp/tcp_client_connection.rs
+++ b/crates/client/src/tcp/tcp_client_connection.rs
@@ -13,10 +13,7 @@ use std::time::Duration;
 
 use tokio_tcp::TcpStream;
 use trust_dns_proto::tcp::TcpClientStream;
-use trust_dns_proto::xfer::{
-    DnsExchange, DnsExchangeConnect, DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender,
-    DnsRequestStreamHandle,
-};
+use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 
 use client::ClientConnection;
 use error::*;
@@ -67,16 +64,9 @@ impl ClientConnection for TcpClientConnection {
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
     type SenderFuture = DnsMultiplexerConnect<TcpClientStream<TcpStream>, Signer>;
 
-    fn new_stream(
-        &self,
-        signer: Option<Arc<Signer>>,
-    ) -> (
-        DnsExchangeConnect<Self::SenderFuture, Self::Sender, Self::Response>,
-        DnsRequestStreamHandle<Self::Response>,
-    ) {
+    fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (tcp_client_stream, handle) =
             TcpClientStream::<TcpStream>::with_timeout(self.name_server, self.timeout);
-        let mp = DnsMultiplexer::new(Box::new(tcp_client_stream), handle, signer);
-        DnsExchange::connect(mp)
+        DnsMultiplexer::new(Box::new(tcp_client_stream), handle, signer)
     }
 }

--- a/crates/client/src/tcp/tcp_client_connection.rs
+++ b/crates/client/src/tcp/tcp_client_connection.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio_tcp::TcpStream;
-use trust_dns_proto::tcp::TcpClientStream;
+use trust_dns_proto::tcp::{TcpClientConnect, TcpClientStream};
 use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 
 use client::ClientConnection;
@@ -62,11 +62,11 @@ impl TcpClientConnection {
 impl ClientConnection for TcpClientConnection {
     type Sender = DnsMultiplexer<TcpClientStream<TcpStream>, Signer>;
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
-    type SenderFuture = DnsMultiplexerConnect<TcpClientStream<TcpStream>, Signer>;
+    type SenderFuture = DnsMultiplexerConnect<TcpClientConnect, TcpClientStream<TcpStream>, Signer>;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (tcp_client_stream, handle) =
             TcpClientStream::<TcpStream>::with_timeout(self.name_server, self.timeout);
-        DnsMultiplexer::new(Box::new(tcp_client_stream), handle, signer)
+        DnsMultiplexer::new(tcp_client_stream, handle, signer)
     }
 }

--- a/crates/client/src/udp/udp_client_connection.rs
+++ b/crates/client/src/udp/udp_client_connection.rs
@@ -10,7 +10,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use trust_dns_proto::udp::UdpClientStream;
+use trust_dns_proto::udp::{UdpClientConnect, UdpClientStream};
 use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 
 use client::ClientConnection;
@@ -42,10 +42,10 @@ impl UdpClientConnection {
 impl ClientConnection for UdpClientConnection {
     type Sender = DnsMultiplexer<UdpClientStream, Signer>;
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
-    type SenderFuture = DnsMultiplexerConnect<UdpClientStream, Signer>;
+    type SenderFuture = DnsMultiplexerConnect<UdpClientConnect, UdpClientStream, Signer>;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (udp_client_stream, handle) = UdpClientStream::new(self.name_server);
-        DnsMultiplexer::new(Box::new(udp_client_stream), handle, signer)
+        DnsMultiplexer::new(udp_client_stream, handle, signer)
     }
 }

--- a/crates/client/src/udp/udp_client_connection.rs
+++ b/crates/client/src/udp/udp_client_connection.rs
@@ -11,10 +11,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use trust_dns_proto::udp::UdpClientStream;
-use trust_dns_proto::xfer::{
-    DnsExchange, DnsExchangeConnect, DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender,
-    DnsRequestStreamHandle,
-};
+use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 
 use client::ClientConnection;
 use error::*;
@@ -47,15 +44,8 @@ impl ClientConnection for UdpClientConnection {
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
     type SenderFuture = DnsMultiplexerConnect<UdpClientStream, Signer>;
 
-    fn new_stream(
-        &self,
-        signer: Option<Arc<Signer>>,
-    ) -> (
-        DnsExchangeConnect<Self::SenderFuture, Self::Sender, Self::Response>,
-        DnsRequestStreamHandle<Self::Response>,
-    ) {
+    fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (udp_client_stream, handle) = UdpClientStream::new(self.name_server);
-        let mp = DnsMultiplexer::new(Box::new(udp_client_stream), handle, signer);
-        DnsExchange::connect(mp)
+        DnsMultiplexer::new(Box::new(udp_client_stream), handle, signer)
     }
 }

--- a/crates/proto/src/multicast/mod.rs
+++ b/crates/proto/src/multicast/mod.rs
@@ -10,7 +10,7 @@
 mod mdns_client_stream;
 mod mdns_stream;
 
-pub use self::mdns_client_stream::MdnsClientStream;
+pub use self::mdns_client_stream::{MdnsClientConnect, MdnsClientStream};
 pub use self::mdns_stream::{MdnsStream, MDNS_IPV4, MDNS_IPV6};
 
 /// See [rfc6762](https://tools.ietf.org/html/rfc6762#section-5) details on these different types.
@@ -28,10 +28,10 @@ pub enum MdnsQueryType {
     ///   port 5353 to be available on the system (many modern OSes already have mDNSResponders running taking this port).
     Continuous,
     /// The querier operates under the OneShot semantics, but also joins the multicast group. (non-compliant servers, clients)
-    /// 
+    ///
     /// This is not defined in the mDNS RFC, but allows for a multicast client to join the group, receiving all multicast network
     ///   traffic. This is useful where listening for all mDNS traffic is of interest, but because another mDNS process may have
-    ///   already taken the known port, 5353. Query responses will come from and to the standard UDP socket with a random port, 
+    ///   already taken the known port, 5353. Query responses will come from and to the standard UDP socket with a random port,
     ///   multicast traffic will come from the multicast socket. This will create two sockets.
     OneShotJoin,
     /// The querier operates under the OneShot semantics, but also joins the multicast group. (servers)
@@ -57,11 +57,11 @@ impl MdnsQueryType {
             MdnsQueryType::Continuous => true,
         }
     }
-    
+
     /// Returns true if this mDNS client should join, listen, on the multicast address
     pub fn join_multicast(&self) -> bool {
         match *self {
-            MdnsQueryType::OneShot  => false,
+            MdnsQueryType::OneShot => false,
             MdnsQueryType::Continuous | MdnsQueryType::OneShotJoin | MdnsQueryType::Passive => true,
         }
     }

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -659,7 +659,7 @@ impl Deref for Message {
 ///
 /// An example of this is a SIG0 signer, which needs the final form of the message,
 ///  but then needs to attach additional data to the body of the message.
-pub trait MessageFinalizer {
+pub trait MessageFinalizer: Send {
     /// The message taken in should be processed and then return [`Record`]s which should be
     ///  appended to the additional section of the message.
     ///

--- a/crates/proto/src/tcp/mod.rs
+++ b/crates/proto/src/tcp/mod.rs
@@ -19,5 +19,5 @@
 mod tcp_client_stream;
 mod tcp_stream;
 
-pub use self::tcp_client_stream::TcpClientStream;
+pub use self::tcp_client_stream::{TcpClientConnect, TcpClientStream};
 pub use self::tcp_stream::TcpStream;

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -55,7 +55,8 @@ impl TcpClientStream<TokioTcpStream> {
             stream_future
                 .map(move |tcp_stream| TcpClientStream {
                     tcp_stream: tcp_stream,
-                }).map_err(ProtoError::from),
+                })
+                .map_err(ProtoError::from),
         );
 
         let sender = Box::new(BufDnsStreamHandle::new(name_server, sender));
@@ -107,7 +108,7 @@ impl<S: AsyncRead + AsyncWrite + Send> Stream for TcpClientStream<S> {
 }
 
 // TODO: create unboxed future for the TCP Stream
-/// A future that resolves to an HttpsClientStream
+/// A future that resolves to an TcpClientStream
 pub struct TcpClientConnect(
     Box<Future<Item = TcpClientStream<TokioTcpStream>, Error = ProtoError> + Send>,
 );
@@ -167,7 +168,8 @@ fn tcp_client_stream_test(server_addr: IpAddr) {
             }
 
             panic!("timeout");
-        }).unwrap();
+        })
+        .unwrap();
 
     // TODO: need a timeout on listen
     let server = std::net::TcpListener::bind(SocketAddr::new(server_addr, 0)).unwrap();
@@ -213,7 +215,8 @@ fn tcp_client_stream_test(server_addr: IpAddr) {
                 // println!("wrote bytes iter: {}", i);
                 std::thread::yield_now();
             }
-        }).unwrap();
+        })
+        .unwrap();
 
     // setup the client, which is going to run on the testing thread...
     let mut io_loop = Runtime::new().unwrap();

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -127,7 +127,8 @@ impl TcpStream<TokioTcpStream> {
                         format!("timed out connecting to: {}", name_server),
                     )
                 })
-            }).map(move |tcp_stream| {
+            })
+            .map(move |tcp_stream| {
                 debug!("TCP connection established to: {}", name_server);
                 TcpStream {
                     socket: tcp_stream,
@@ -221,24 +222,26 @@ impl<S: AsyncRead + AsyncWrite> Stream for TcpStream<S> {
 
                 // switch states
                 match current_state {
-                    Some(WriteTcpState::LenBytes { pos, length, bytes }) => if pos < length.len() {
-                        mem::replace(
-                            &mut self.send_state,
-                            Some(WriteTcpState::LenBytes {
-                                pos: pos,
-                                length: length,
-                                bytes: bytes,
-                            }),
-                        );
-                    } else {
-                        mem::replace(
-                            &mut self.send_state,
-                            Some(WriteTcpState::Bytes {
-                                pos: 0,
-                                bytes: bytes,
-                            }),
-                        );
-                    },
+                    Some(WriteTcpState::LenBytes { pos, length, bytes }) => {
+                        if pos < length.len() {
+                            mem::replace(
+                                &mut self.send_state,
+                                Some(WriteTcpState::LenBytes {
+                                    pos: pos,
+                                    length: length,
+                                    bytes: bytes,
+                                }),
+                            );
+                        } else {
+                            mem::replace(
+                                &mut self.send_state,
+                                Some(WriteTcpState::Bytes {
+                                    pos: 0,
+                                    bytes: bytes,
+                                }),
+                            );
+                        }
+                    }
                     Some(WriteTcpState::Bytes { pos, bytes }) => {
                         if pos < bytes.len() {
                             mem::replace(
@@ -324,7 +327,7 @@ impl<S: AsyncRead + AsyncWrite> Stream for TcpStream<S> {
                     if read == 0 {
                         // the Stream was closed!
                         debug!("zero bytes read, stream closed?");
-                        //try!(self.socket.shutdown(Shutdown::Both)); // FIXME: add generic shutdown function
+                        //try!(self.socket.shutdown(Shutdown::Both)); // TODO: add generic shutdown function
 
                         if *pos == 0 {
                             // Since this is the start of the next message, we have a clean end
@@ -366,7 +369,7 @@ impl<S: AsyncRead + AsyncWrite> Stream for TcpStream<S> {
                         debug!("zero bytes read for message, stream closed?");
 
                         // Since this is the start of the next message, we have a clean end
-                        // try!(self.socket.shutdown(Shutdown::Both));  // FIXME: add generic shutdown function
+                        // try!(self.socket.shutdown(Shutdown::Both));  // TODO: add generic shutdown function
                         return Err(io::Error::new(
                             io::ErrorKind::BrokenPipe,
                             "closed while reading message",
@@ -462,7 +465,8 @@ fn tcp_client_stream_test(server_addr: IpAddr) {
             }
 
             panic!("timeout");
-        }).unwrap();
+        })
+        .unwrap();
 
     // TODO: need a timeout on listen
     let server = std::net::TcpListener::bind(SocketAddr::new(server_addr, 0)).unwrap();
@@ -508,7 +512,8 @@ fn tcp_client_stream_test(server_addr: IpAddr) {
                 // println!("wrote bytes iter: {}", i);
                 std::thread::yield_now();
             }
-        }).unwrap();
+        })
+        .unwrap();
 
     // setup the client, which is going to run on the testing thread...
     let mut io_loop = Runtime::new().unwrap();

--- a/crates/proto/src/udp/mod.rs
+++ b/crates/proto/src/udp/mod.rs
@@ -19,5 +19,5 @@
 mod udp_client_stream;
 mod udp_stream;
 
-pub use self::udp_client_stream::UdpClientStream;
+pub use self::udp_client_stream::{UdpClientConnect, UdpClientStream};
 pub use self::udp_stream::UdpStream;

--- a/crates/server/benches/comparison_benches.rs
+++ b/crates/server/benches/comparison_benches.rs
@@ -27,8 +27,8 @@ use trust_dns::op::*;
 use trust_dns::rr::*;
 use trust_dns::tcp::*;
 use trust_dns::udp::*;
-use trust_dns_proto::xfer::*;
 use trust_dns_proto::error::*;
+use trust_dns_proto::xfer::*;
 
 fn find_test_port() -> u16 {
     let server = std::net::UdpSocket::bind(("0.0.0.0", 0)).unwrap();
@@ -109,13 +109,10 @@ fn trust_dns_process() -> (NamedProcess, u16) {
 }
 
 /// Runs the bench tesk using the specified client
-fn bench<S>(
-    b: &mut Bencher,
-    stream: Box<Future<Item = S, Error = ProtoError> + Send>, 
-    stream_handle: Box<DnsStreamHandle>, 
-)
+fn bench<F, S>(b: &mut Bencher, stream: F, stream_handle: Box<DnsStreamHandle>)
 where
-    S: DnsClientStream + 'static,
+    F: Future<Item = S, Error = ProtoError> + Send + 'static,
+    S: DnsClientStream + Send + 'static,
 {
     let mut io_loop = Runtime::new().unwrap();
     let (bg, mut client) = ClientFuture::new(stream, stream_handle, None);

--- a/crates/server/tests/z_named_https_tests.rs
+++ b/crates/server/tests/z_named_https_tests.rs
@@ -30,7 +30,6 @@ use rustls::Certificate;
 use tokio::runtime::current_thread::Runtime;
 use trust_dns::client::*;
 use trust_dns_https::HttpsClientStreamBuilder;
-use trust_dns_proto::xfer::DnsExchange;
 
 use server_harness::{named_test_harness, query_a};
 
@@ -47,7 +46,8 @@ fn test_example_https_toml_startup() {
         File::open(&format!(
             "{}/tests/named_test_configs/sec/example.cert",
             server_path
-        )).expect("failed to open cert")
+        ))
+        .expect("failed to open cert")
         .read_to_end(&mut cert_der)
         .expect("failed to read cert");
 
@@ -64,8 +64,7 @@ fn test_example_https_toml_startup() {
         let cert = to_trust_anchor(&cert_der);
         https_conn_builder.add_ca(cert);
         let mp = https_conn_builder.build(addr, "ns.example.com".to_string());
-        let (exchange, handle) = DnsExchange::connect(mp);
-        let (bg, mut client) = ClientFuture::from_exchange(exchange, handle);
+        let (bg, mut client) = ClientFuture::connect(mp);
 
         // ipv4 should succeed
         io_loop.spawn(bg);

--- a/crates/server/tests/z_named_test_rsa_dnssec.rs
+++ b/crates/server/tests/z_named_test_rsa_dnssec.rs
@@ -22,8 +22,8 @@ use tokio_tcp::TcpStream as TokioTcpStream;
 
 use trust_dns::client::*;
 use trust_dns::rr::dnssec::*;
-use trust_dns::tcp::TcpClientStream;
 use trust_dns_proto::error::ProtoError;
+use trust_dns_proto::tcp::{TcpClientConnect, TcpClientStream};
 use trust_dns_proto::xfer::{
     DnsMultiplexer, DnsMultiplexerConnect, DnsMultiplexerSerialResponse, DnsResponse,
 };
@@ -65,7 +65,7 @@ fn standard_conn(
     port: u16,
 ) -> (
     ClientFuture<
-        DnsMultiplexerConnect<TcpClientStream<TokioTcpStream>, Signer>,
+        DnsMultiplexerConnect<TcpClientConnect, TcpClientStream<TokioTcpStream>, Signer>,
         DnsMultiplexer<TcpClientStream<TokioTcpStream>, Signer>,
         DnsMultiplexerSerialResponse,
     >,
@@ -77,7 +77,7 @@ fn standard_conn(
         .next()
         .unwrap();
     let (stream, sender) = TcpClientStream::new(addr);
-    ClientFuture::new(Box::new(stream), sender, None)
+    ClientFuture::new(stream, sender, None)
 }
 
 fn generic_test(config_toml: &str, key_path: &str, key_format: KeyFormat, algorithm: Algorithm) {

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -237,7 +237,11 @@ impl NeverReturnsClientConnection {
 impl ClientConnection for NeverReturnsClientConnection {
     type Sender = DnsMultiplexer<NeverReturnsClientStream, Signer>;
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
-    type SenderFuture = DnsMultiplexerConnect<NeverReturnsClientStream, Signer>;
+    type SenderFuture = DnsMultiplexerConnect<
+        Box<Future<Item = NeverReturnsClientStream, Error = ProtoError> + Send>,
+        NeverReturnsClientStream,
+        Signer,
+    >;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (client_stream, handle) = NeverReturnsClientStream::new();

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -30,8 +30,7 @@ use trust_dns::rr::dnssec::Signer;
 use trust_dns::serialize::binary::*;
 use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::{
-    DnsClientStream, DnsExchange, DnsExchangeConnect, DnsMultiplexer, DnsMultiplexerConnect,
-    DnsRequestSender, DnsRequestStreamHandle, SerialMessage,
+    DnsClientStream, DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender, SerialMessage,
 };
 use trust_dns_proto::StreamHandle;
 
@@ -240,16 +239,9 @@ impl ClientConnection for NeverReturnsClientConnection {
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
     type SenderFuture = DnsMultiplexerConnect<NeverReturnsClientStream, Signer>;
 
-    fn new_stream(
-        &self,
-        signer: Option<Arc<Signer>>,
-    ) -> (
-        DnsExchangeConnect<Self::SenderFuture, Self::Sender, Self::Response>,
-        DnsRequestStreamHandle<Self::Response>,
-    ) {
+    fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (client_stream, handle) = NeverReturnsClientStream::new();
 
-        let mp = DnsMultiplexer::new(Box::new(client_stream), Box::new(handle), signer);
-        DnsExchange::connect(mp)
+        DnsMultiplexer::new(Box::new(client_stream), Box::new(handle), signer)
     }
 }

--- a/tests/integration-tests/src/tls_client_connection.rs
+++ b/tests/integration-tests/src/tls_client_connection.rs
@@ -16,10 +16,7 @@ use rustls::Certificate;
 use trust_dns::client::ClientConnection;
 use trust_dns::error::*;
 use trust_dns::rr::dnssec::Signer;
-use trust_dns_proto::xfer::{
-    DnsExchange, DnsExchangeConnect, DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender,
-    DnsRequestStreamHandle,
-};
+use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 
 use trust_dns_rustls::TlsClientStream;
 use trust_dns_rustls::TlsClientStreamBuilder;
@@ -44,20 +41,13 @@ impl ClientConnection for TlsClientConnection {
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
     type SenderFuture = DnsMultiplexerConnect<TlsClientStream, Signer>;
 
-    fn new_stream(
-        &self,
-        signer: Option<Arc<Signer>>,
-    ) -> (
-        DnsExchangeConnect<Self::SenderFuture, Self::Sender, Self::Response>,
-        DnsRequestStreamHandle<Self::Response>,
-    ) {
+    fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (tls_client_stream, handle) = self
             .builder
             .clone()
             .build(self.name_server, self.dns_name.clone());
 
-        let mp = DnsMultiplexer::new(Box::new(tls_client_stream), Box::new(handle), signer);
-        DnsExchange::connect(mp)
+        DnsMultiplexer::new(Box::new(tls_client_stream), Box::new(handle), signer)
     }
 }
 

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -52,17 +52,10 @@ impl ClientConnection for TestClientConnection {
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
     type SenderFuture = DnsMultiplexerConnect<TestClientStream, Signer>;
 
-    fn new_stream(
-        &self,
-        signer: Option<Arc<Signer>>,
-    ) -> (
-        DnsExchangeConnect<Self::SenderFuture, Self::Sender, Self::Response>,
-        DnsRequestStreamHandle<Self::Response>,
-    ) {
+    fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
         let (client_stream, handle) = TestClientStream::new(self.catalog.clone());
 
-        let mp = DnsMultiplexer::new(Box::new(client_stream), Box::new(handle), signer);
-        DnsExchange::connect(mp)
+        DnsMultiplexer::new(Box::new(client_stream), Box::new(handle), signer)
     }
 }
 
@@ -113,14 +106,12 @@ where
     let response = response.unwrap();
 
     println!("response records: {:?}", response);
-    assert!(
-        response
-            .queries()
-            .first()
-            .expect("expected query")
-            .name()
-            .eq_case(&name)
-    );
+    assert!(response
+        .queries()
+        .first()
+        .expect("expected query")
+        .name()
+        .eq_case(&name));
 
     let record = &response.answers()[0];
     assert_eq!(record.name(), &name);
@@ -507,26 +498,22 @@ fn test_append() {
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 2);
 
-    assert!(
-        result
-            .answers()
-            .iter()
-            .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
-                *ip == Ipv4Addr::new(100, 10, 100, 10)
-            } else {
-                false
-            })
-    );
-    assert!(
-        result
-            .answers()
-            .iter()
-            .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
-                *ip == Ipv4Addr::new(101, 11, 101, 11)
-            } else {
-                false
-            })
-    );
+    assert!(result
+        .answers()
+        .iter()
+        .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
+            *ip == Ipv4Addr::new(100, 10, 100, 10)
+        } else {
+            false
+        }));
+    assert!(result
+        .answers()
+        .iter()
+        .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
+            *ip == Ipv4Addr::new(101, 11, 101, 11)
+        } else {
+            false
+        }));
 
     // show that appending the same thing again is ok, but doesn't add any records
     let result = client
@@ -574,16 +561,14 @@ fn test_compare_and_swap() {
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
-    assert!(
-        result
-            .answers()
-            .iter()
-            .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
-                *ip == Ipv4Addr::new(101, 11, 101, 11)
-            } else {
-                false
-            })
-    );
+    assert!(result
+        .answers()
+        .iter()
+        .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
+            *ip == Ipv4Addr::new(101, 11, 101, 11)
+        } else {
+            false
+        }));
 
     // check the it fails if tried again.
     let mut new = new;
@@ -599,16 +584,14 @@ fn test_compare_and_swap() {
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
-    assert!(
-        result
-            .answers()
-            .iter()
-            .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
-                *ip == Ipv4Addr::new(101, 11, 101, 11)
-            } else {
-                false
-            })
-    );
+    assert!(result
+        .answers()
+        .iter()
+        .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
+            *ip == Ipv4Addr::new(101, 11, 101, 11)
+        } else {
+            false
+        }));
 }
 
 #[cfg(feature = "dnssec")]
@@ -655,16 +638,14 @@ fn test_delete_by_rdata() {
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
-    assert!(
-        result
-            .answers()
-            .iter()
-            .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
-                *ip == Ipv4Addr::new(100, 10, 100, 10)
-            } else {
-                false
-            })
-    );
+    assert!(result
+        .answers()
+        .iter()
+        .any(|rr| if let &RData::A(ref ip) = rr.rdata() {
+            *ip == Ipv4Addr::new(100, 10, 100, 10)
+        } else {
+            false
+        }));
 }
 
 #[cfg(feature = "dnssec")]

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -121,7 +121,8 @@ fn test_server_unknown_type() {
             &Name::from_str("www.example.com.").unwrap(),
             DNSClass::IN,
             RecordType::Unknown(65535),
-        ).expect("query failed for unknown");
+        )
+        .expect("query failed for unknown");
 
     assert_eq!(client_result.response_code(), ResponseCode::NoError);
     assert_eq!(
@@ -144,12 +145,7 @@ fn read_file(path: &str) -> Vec<u8> {
 }
 
 // TODO: move all this to future based clients
-#[cfg(
-    all(
-        feature = "dns-over-openssl",
-        not(feature = "dns-over-rustls")
-    )
-)]
+#[cfg(all(feature = "dns-over-openssl", not(feature = "dns-over-rustls")))]
 #[test]
 
 fn test_server_www_tls() {
@@ -268,7 +264,8 @@ fn server_thread_udp(udp_socket: UdpSocket, server_continue: Arc<AtomicBool>) {
     io_loop
         .block_on::<Box<Future<Item = (), Error = ()> + Send>>(Box::new(future::lazy(|| {
             future::ok(server.register_socket(udp_socket))
-        }))).unwrap();
+        })))
+        .unwrap();
 
     while server_continue.load(Ordering::Relaxed) {
         io_loop
@@ -284,7 +281,8 @@ fn server_thread_tcp(tcp_listener: TcpListener, server_continue: Arc<AtomicBool>
     io_loop
         .block_on::<Box<Future<Item = (), Error = io::Error> + Send>>(Box::new(future::lazy(
             || future::result(server.register_listener(tcp_listener, Duration::from_secs(30))),
-        ))).expect("tcp registration failed");
+        )))
+        .expect("tcp registration failed");
 
     while server_continue.load(Ordering::Relaxed) {
         io_loop
@@ -294,12 +292,7 @@ fn server_thread_tcp(tcp_listener: TcpListener, server_continue: Arc<AtomicBool>
 }
 
 // FIXME: need a rustls option
-#[cfg(
-    all(
-        feature = "dns-over-openssl",
-        not(feature = "dns-over-rustls")
-    )
-)]
+#[cfg(all(feature = "dns-over-openssl", not(feature = "dns-over-rustls")))]
 fn server_thread_tls(
     tls_listener: TcpListener,
     server_continue: Arc<AtomicBool>,
@@ -322,7 +315,8 @@ fn server_thread_tls(
                     pkcs12,
                 ))
             },
-        ))).expect("tcp registration failed");
+        )))
+        .expect("tcp registration failed");
 
     while server_continue.load(Ordering::Relaxed) {
         io_loop


### PR DESCRIPTION
This should simplify the ClientFuture usage a bit.