### PR TITLE
Expose the originating Query from Lookup

### DIFF
--- a/crates/resolver/src/async_resolver/background.rs
+++ b/crates/resolver/src/async_resolver/background.rs
@@ -16,6 +16,7 @@ use lookup::{Lookup, LookupEither, LookupFuture};
 use lookup_ip::LookupIpFuture;
 use lookup_state::CachingClient;
 use name_server_pool::{ConnectionHandle, NameServerPool, StandardConnection};
+use proto::op::Query;
 
 use super::Request;
 
@@ -107,7 +108,7 @@ impl Task {
             } else {
                 return LookupIpFuture::ok(
                     self.client_cache.clone(),
-                    Lookup::new_with_max_ttl(Arc::new(vec![ip_addr])),
+                    Lookup::new_with_max_ttl(Query::new(), Arc::new(vec![ip_addr])),
                 );
             }
         }
@@ -118,7 +119,7 @@ impl Task {
                 // it was a valid IP, return that...
                 return LookupIpFuture::ok(
                     self.client_cache.clone(),
-                    Lookup::new_with_max_ttl(Arc::new(vec![ip_addr.clone()])),
+                    Lookup::new_with_max_ttl(Query::new(), Arc::new(vec![ip_addr.clone()])),
                 );
             }
             (Err(err), None) => {

--- a/crates/resolver/src/async_resolver/background.rs
+++ b/crates/resolver/src/async_resolver/background.rs
@@ -106,10 +106,9 @@ impl Task {
             if self.options.ndots > 4 {
                 finally_ip_addr = Some(ip_addr);
             } else {
-                return LookupIpFuture::ok(
-                    self.client_cache.clone(),
-                    Lookup::new_with_max_ttl(Query::new(), Arc::new(vec![ip_addr])),
-                );
+                let query = Query::query(maybe_name.unwrap_or_default(), ip_addr.to_record_type());
+                let lookup = Lookup::new_with_max_ttl(query, Arc::new(vec![ip_addr]));
+                return LookupIpFuture::ok(self.client_cache.clone(), lookup);
             }
         }
 
@@ -117,10 +116,9 @@ impl Task {
             (Ok(name), _) => name,
             (Err(_), Some(ip_addr)) => {
                 // it was a valid IP, return that...
-                return LookupIpFuture::ok(
-                    self.client_cache.clone(),
-                    Lookup::new_with_max_ttl(Query::new(), Arc::new(vec![ip_addr.clone()])),
-                );
+                let query = Query::query(Name::default(), ip_addr.to_record_type());
+                let lookup = Lookup::new_with_max_ttl(query, Arc::new(vec![ip_addr.clone()]));
+                return LookupIpFuture::ok(self.client_cache.clone(), lookup);
             }
             (Err(err), None) => {
                 return LookupIpFuture::error(self.client_cache.clone(), err);

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -164,7 +164,7 @@ impl DnsLru {
         let valid_until = now + ttl;
 
         // insert into the LRU
-        let lookup = Lookup::new_with_deadline(Arc::new(rdatas), valid_until);
+        let lookup = Lookup::new_with_deadline(query.clone(), Arc::new(rdatas), valid_until);
         self.cache.insert(
             query,
             LruValue {

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -89,7 +89,7 @@ impl Lookup {
     }
 
     #[cfg(test)]
-    pub fn rdatas(&self) -> &Vec<RData> {
+    pub fn rdatas(&self) -> &[RData] {
         self.rdatas.as_ref()
     }
 

--- a/crates/resolver/src/lookup_ip.rs
+++ b/crates/resolver/src/lookup_ip.rs
@@ -122,9 +122,8 @@ impl<C: DnsHandle + 'static> Future for LookupIpFuture<C> {
                 } else if let Some(ip_addr) = self.finally_ip_addr.take() {
                     // Otherwise, if there's an IP address to fall back to,
                     // we'll return it.
-                    return Ok(Async::Ready(
-                        Lookup::new_with_max_ttl(Arc::new(vec![ip_addr])).into(),
-                    ));
+                    let lookup = Lookup::new_with_max_ttl(Query::new(), Arc::new(vec![ip_addr]));
+                    return Ok(Async::Ready(lookup.into()));
                 }
             };
 

--- a/crates/resolver/src/lookup_state.rs
+++ b/crates/resolver/src/lookup_state.rs
@@ -980,7 +980,7 @@ mod tests {
                 .wait()
                 .expect("should have returned localhost");
             assert_eq!(lookup.query(), &query);
-            assert_eq!(lookup.rdatas(), &vec![LOCALHOST_V4.clone()]);
+            assert_eq!(lookup.rdatas(), &[LOCALHOST_V4.clone()]);
         }
 
         {
@@ -990,7 +990,7 @@ mod tests {
                 .wait()
                 .expect("should have returned localhost");
             assert_eq!(lookup.query(), &query);
-            assert_eq!(lookup.rdatas(), &vec![LOCALHOST_V6.clone()]);
+            assert_eq!(lookup.rdatas(), &[LOCALHOST_V6.clone()]);
         }
 
         {
@@ -1000,7 +1000,7 @@ mod tests {
                 .wait()
                 .expect("should have returned localhost");
             assert_eq!(lookup.query(), &query);
-            assert_eq!(lookup.rdatas(), &vec![LOCALHOST.clone()]);
+            assert_eq!(lookup.rdatas(), &[LOCALHOST.clone()]);
         }
 
         {
@@ -1013,7 +1013,7 @@ mod tests {
                 .wait()
                 .expect("should have returned localhost");
             assert_eq!(lookup.query(), &query);
-            assert_eq!(lookup.rdatas(), &vec![LOCALHOST.clone()]);
+            assert_eq!(lookup.rdatas(), &[LOCALHOST.clone()]);
         }
 
         assert!(

--- a/tests/integration-tests/tests/lookup_tests.rs
+++ b/tests/integration-tests/tests/lookup_tests.rs
@@ -79,7 +79,10 @@ fn test_lookup_hosts() {
     hosts.insert(
         Name::from_str("www.example.com.").unwrap(),
         RecordType::A,
-        Lookup::new_with_max_ttl(Arc::new(vec![RData::A(Ipv4Addr::new(10, 0, 1, 104))])),
+        Lookup::new_with_max_ttl(
+            Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A),
+            Arc::new(vec![RData::A(Ipv4Addr::new(10, 0, 1, 104))])
+        ),
     );
 
     let lookup = LookupIpFuture::lookup(


### PR DESCRIPTION
When resolving a relative name like `foo.bar` with a search path like
`a.b c.d`, it's not currently possible to know which FQDN actually
resolved (e.g., `foo.bar.a.b.`, `foo.bar.c.d.`, or `foo.bar.`).

This change modifies the `Lookup` type to include the `Query` that
was looked up.

Fixes bluejekyll/trust-dns#599