### PR TITLE
Make tokio-rustls optional for server

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -48,12 +48,12 @@ dnssec = []
 
 # TODO: Need to figure out how to be consistent with ring/openssl usage...
 # dns-over-https-openssl = ["dns-over-openssl", "trust-dns/dns-over-https-openssl", "dns-over-https"]
-dns-over-https-rustls = ["dns-over-https", "dns-over-rustls", "trust-dns/dns-over-https-rustls"]
+dns-over-https-rustls = ["dns-over-https", "dns-over-rustls", "trust-dns/dns-over-https-rustls", "tokio-rustls"]
 dns-over-https = ["h2", "http", "trust-dns-https"]
 
 # TODO: migrate all tls and tls-openssl features to dns-over-tls, et al
 dns-over-openssl = ["dns-over-tls", "dnssec-openssl", "trust-dns-openssl", "trust-dns/dns-over-openssl"]
-dns-over-rustls = ["dns-over-tls", "dnssec-ring", "trust-dns-rustls", "rustls", "trust-dns/dns-over-rustls"]
+dns-over-rustls = ["dns-over-tls", "dnssec-ring", "trust-dns-rustls", "rustls", "trust-dns/dns-over-rustls", "tokio-rustls"]
 dns-over-tls = []
 
 # This is a deprecated feature...
@@ -93,7 +93,7 @@ tokio = "0.1.6"
 tokio-executor = "0.1"
 tokio-io = "0.1"
 tokio-reactor = "0.1"
-tokio-rustls = "0.8"
+tokio-rustls = { version = "0.8", optional = true }
 tokio-tcp = "0.1"
 tokio-timer = "0.2"
 tokio-udp = "0.1"


### PR DESCRIPTION
`tokio-rustls` is only used when feature `dns-over-https-rustls` or `dns-over-rustls` is enabled. 

So, we should make it optional to prevent introducing unnecessary dependencies when rustls is not used.