### PR TITLE
Add LookupIp::query

### DIFF
--- a/crates/resolver/src/lookup_ip.rs
+++ b/crates/resolver/src/lookup_ip.rs
@@ -40,6 +40,11 @@ impl LookupIp {
         LookupIpIter(self.0.iter())
     }
 
+    /// Returns a reference to the Query that was used to produce this result.
+    pub fn query(&self) -> &Query {
+        self.0.query()
+    }
+
     /// Returns the `Instant` at which this lookup is no longer valid.
     pub fn valid_until(&self) -> Instant {
         self.0.valid_until()


### PR DESCRIPTION
bluejekyll/trust-dns#601 added a `query()` method to `Lookup`, but it
unfortunately was not wired through `LookupIp`.

This change adds a `LookupIp::query` that proxies the call to the
underlying `Lookup`.