### PR TITLE
on servfail, continue requests to other nameservers

### DIFF
--- a/crates/resolver/CHANGELOG.md
+++ b/crates/resolver/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.11
+
+### Changed
+
+- Added option to distrust Nameservers on SERVFAIL responses, continue resolution #613
+
 ## 0.10
 
 ### Fixed

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -548,6 +548,9 @@ pub struct ResolverOpts {
     ///
     /// [`MAX_TTL`]: ../dns_lru/const.MAX_TTL.html
     pub negative_max_ttl: Option<Duration>,
+    /// Default is to distrust negative responses from upstream nameservers
+    ///
+    pub distrust_nx_responses: bool,
 }
 
 impl Default for ResolverOpts {
@@ -570,6 +573,7 @@ impl Default for ResolverOpts {
             negative_min_ttl: None,
             positive_max_ttl: None,
             negative_max_ttl: None,
+            distrust_nx_responses: true,
         }
     }
 }

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -64,7 +64,7 @@ fn mock_nameserver_pool(
         &options,
         udp,
         tcp,
-        _mdns.unwrap_or_else(|| mock_nameserver(vec![])),
+        _mdns.unwrap_or_else(|| mock_nameserver(vec![], options)),
     );
 }
 
@@ -207,7 +207,7 @@ fn test_trust_nx_responses_fails_servfail() {
     let mut options = ResolverOpts::default();
     options.distrust_nx_responses = false;
 
-    let query = Query::query(Name::from_str("www.example.local.").unwrap(), RecordType::A);
+    let query = Query::query(Name::from_str("www.example.").unwrap(), RecordType::A);
 
     let mut servfail_message = message(query.clone(), vec![], vec![], vec![]).unwrap();
     servfail_message.set_response_code(ResponseCode::ServFail);
@@ -261,7 +261,7 @@ fn test_distrust_nx_responses() {
     let mut options = ResolverOpts::default();
     options.distrust_nx_responses = true;
 
-    let query = Query::query(Name::from_str("www.example.local.").unwrap(), RecordType::A);
+    let query = Query::query(Name::from_str("www.example.").unwrap(), RecordType::A);
 
     let mut servfail_message = message(query.clone(), vec![], vec![], vec![]).unwrap();
     servfail_message.set_response_code(ResponseCode::ServFail);


### PR DESCRIPTION
When SERVFAIL is returned by Nameserver, this change will cause the request to fail. This has the effect of transitioning to another Namerserver in the NameserverPool.

fixes #606 