### PR TITLE
add parallel query option

### DIFF
--- a/crates/resolver/CHANGELOG.md
+++ b/crates/resolver/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.11
 
+### Added
+
+- New option to execute queries concurrently, default is 2 #615
+
 ### Changed
 
 - Added option to distrust Nameservers on SERVFAIL responses, continue resolution #613

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -550,7 +550,12 @@ pub struct ResolverOpts {
     pub negative_max_ttl: Option<Duration>,
     /// Default is to distrust negative responses from upstream nameservers
     ///
+    /// Currently only SERVFAIL responses are continued on, this may be expanded to include NXDOMAIN or NoError/Empty responses
     pub distrust_nx_responses: bool,
+    /// Concurrent requests where more than one Nameserver is registered, the default is 2
+    ///
+    /// 0 or 1 will configure this to execute all requests serially
+    pub num_concurrent_reqs: usize,
 }
 
 impl Default for ResolverOpts {
@@ -574,6 +579,7 @@ impl Default for ResolverOpts {
             positive_max_ttl: None,
             negative_max_ttl: None,
             distrust_nx_responses: true,
+            num_concurrent_reqs: 2,
         }
     }
 }

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -715,9 +715,10 @@ impl<C: DnsHandle, P: ConnectionProvider<ConnHandle = C>> Eq for NameServer<C, P
 
 // TODO: once IPv6 is better understood, also make this a binary keep.
 #[cfg(feature = "mdns")]
-fn mdns_nameserver<C, P>(options: ResolverOpts, conn_provider: P) -> NameServer<C, P> 
-where 
-    C: DnsHandle, P: ConnectionProvider<ConnHandle = C> 
+fn mdns_nameserver<C, P>(options: ResolverOpts, conn_provider: P) -> NameServer<C, P>
+where
+    C: DnsHandle,
+    P: ConnectionProvider<ConnHandle = C>,
 {
     let config = NameServerConfig {
         socket_addr: *MDNS_IPV4,
@@ -954,7 +955,7 @@ where
 
                                 // construct the parallel requests, 2 is the default
                                 let mut par_conns = SmallVec::<[NameServer<C, P>; 2]>::new();
-                                let count = conns.len().min(opts.num_concurrent_reqs);
+                                let count = conns.len().min(opts.num_concurrent_reqs.max(1));
                                 for conn in conns.drain(..count) {
                                     par_conns.push(conn);
                                 }

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -1,3 +1,4 @@
+extern crate futures;
 extern crate tokio;
 extern crate trust_dns;
 extern crate trust_dns_integration;
@@ -6,7 +7,12 @@ extern crate trust_dns_resolver;
 
 use std::net::*;
 use std::str::FromStr;
+use std::sync::{
+    atomic::{AtomicIsize, Ordering},
+    Arc,
+};
 
+use futures::future::{self, Future, Loop};
 use tokio::runtime::current_thread::Runtime;
 
 use trust_dns::op::Query;
@@ -55,7 +61,9 @@ fn mock_nameserver_on_send<O: OnSend>(
     options: ResolverOpts,
     on_send: O,
 ) -> MockedNameServer<O> {
-    let conn_provider = MockConnProvider{ on_send: on_send.clone() };
+    let conn_provider = MockConnProvider {
+        on_send: on_send.clone(),
+    };
     let client = MockClientHandle::mock_on_send(messages, on_send);
 
     NameServer::from_conn(
@@ -77,7 +85,20 @@ fn mock_nameserver_pool(
     _mdns: Option<MockedNameServer<DefaultOnSend>>,
     options: ResolverOpts,
 ) -> MockedNameServerPool<DefaultOnSend> {
-    let conn_provider = MockConnProvider { on_send: DefaultOnSend };
+    mock_nameserver_pool_on_send::<DefaultOnSend>(udp, tcp, _mdns, options, DefaultOnSend)
+}
+
+#[cfg(test)]
+fn mock_nameserver_pool_on_send<O: OnSend>(
+    udp: Vec<MockedNameServer<O>>,
+    tcp: Vec<MockedNameServer<O>>,
+    _mdns: Option<MockedNameServer<O>>,
+    options: ResolverOpts,
+    on_send: O,
+) -> MockedNameServerPool<O> {
+    let conn_provider = MockConnProvider {
+        on_send: on_send.clone(),
+    };
 
     #[cfg(not(feature = "mdns"))]
     return NameServerPool::from_nameservers(&options, udp, tcp, conn_provider);
@@ -87,7 +108,7 @@ fn mock_nameserver_pool(
         &options,
         udp,
         tcp,
-        _mdns.unwrap_or_else(|| mock_nameserver(vec![], options)),
+        _mdns.unwrap_or_else(|| mock_nameserver_on_send(vec![], options, on_send)),
         conn_provider,
     );
 }
@@ -313,5 +334,211 @@ fn test_distrust_nx_responses() {
     assert_eq!(response.answers()[0], v4_record);
 }
 
+// === Concurrent requests ===
+
+#[derive(Clone)]
+struct OnSendBarrier {
+    barrier: Arc<AtomicIsize>,
+}
+
+impl OnSendBarrier {
+    fn new(count: isize) -> Self {
+        Self {
+            barrier: Arc::new(AtomicIsize::new(count)),
+        }
+    }
+}
+
+impl OnSend for OnSendBarrier {
+    fn on_send(
+        &mut self,
+        response: Result<DnsResponse, ProtoError>,
+    ) -> Box<Future<Item = DnsResponse, Error = ProtoError> + Send> {
+        self.barrier.fetch_sub(1, Ordering::Relaxed);
+
+        // loop until the barrier is 0
+        let loop_future = future::loop_fn(
+            (self.barrier.clone(), response),
+            move |(barrier, response)| {
+                let remaining = barrier.load(Ordering::Relaxed);
+
+                match remaining {
+                    0 => response.map(Loop::Break),
+                    i if i > 0 => Ok(Loop::Continue((barrier, response))),
+                    i if i < 0 => panic!("more concurrency than expected: {}", i),
+                    _ => panic!("all other cases handled"),
+                }
+            },
+        );
+
+        Box::new(loop_future)
+    }
+}
+
 #[test]
-fn test_concurrent_requests() {}
+fn test_concurrent_requests() {
+    let mut options = ResolverOpts::default();
+    // there are only 2 conns, so this matches that count
+    options.num_concurrent_reqs = 2;
+
+    // we want to make sure that both udp connections are called
+    //   this will count down to 0 only if both are called.
+    let on_send = OnSendBarrier::new(2);
+
+    let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
+
+    let udp_record = v4_record(query.name().clone(), Ipv4Addr::new(127, 0, 0, 1));
+
+    let udp_message = message(query.clone(), vec![udp_record.clone()], vec![], vec![]);
+
+    let mut reactor = Runtime::new().unwrap();
+
+    let udp1_nameserver =
+        mock_nameserver_on_send(vec![udp_message.map(Into::into)], options, on_send.clone());
+    let udp2_nameserver = udp1_nameserver.clone();
+
+    let mut pool = mock_nameserver_pool_on_send(
+        vec![udp2_nameserver, udp1_nameserver],
+        vec![],
+        None,
+        options,
+        on_send,
+    );
+
+    // lookup on UDP succeeds, any other would fail
+    let request = message(query, vec![], vec![], vec![]).unwrap();
+    let future = pool.send(request);
+
+    // there's no actual network traffic happening, 1 sec should be plenty
+    //   TODO: for some reason this timout doesn't work, not clear why...
+    // let future = Timeout::new(future, Duration::from_secs(1));
+
+    let response = reactor.block_on(future).unwrap();
+    assert_eq!(response.answers()[0], udp_record);
+}
+
+#[test]
+fn test_concurrent_requests_more_than_conns() {
+    let mut options = ResolverOpts::default();
+    // there are only two conns, but this requests 3 concurrent requests, only 2 called
+    options.num_concurrent_reqs = 3;
+
+    // we want to make sure that both udp connections are called
+    //   this will count down to 0 only if both are called.
+    let on_send = OnSendBarrier::new(2);
+
+    let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
+
+    let udp_record = v4_record(query.name().clone(), Ipv4Addr::new(127, 0, 0, 1));
+
+    let udp_message = message(query.clone(), vec![udp_record.clone()], vec![], vec![]);
+
+    let mut reactor = Runtime::new().unwrap();
+
+    let udp1_nameserver =
+        mock_nameserver_on_send(vec![udp_message.map(Into::into)], options, on_send.clone());
+    let udp2_nameserver = udp1_nameserver.clone();
+
+    let mut pool = mock_nameserver_pool_on_send(
+        vec![udp2_nameserver, udp1_nameserver],
+        vec![],
+        None,
+        options,
+        on_send,
+    );
+
+    // lookup on UDP succeeds, any other would fail
+    let request = message(query, vec![], vec![], vec![]).unwrap();
+    let future = pool.send(request);
+
+    // there's no actual network traffic happening, 1 sec should be plenty
+    //   TODO: for some reason this timout doesn't work, not clear why...
+    // let future = Timeout::new(future, Duration::from_secs(1));
+
+    let response = reactor.block_on(future).unwrap();
+    assert_eq!(response.answers()[0], udp_record);
+}
+
+#[test]
+fn test_concurrent_requests_1_conn() {
+    let mut options = ResolverOpts::default();
+    // there are two connections, but no concurrency requested
+    options.num_concurrent_reqs = 1;
+
+    // we want to make sure that both udp connections are called
+    //   this will count down to 0 only if both are called.
+    let on_send = OnSendBarrier::new(1);
+
+    let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
+
+    let udp_record = v4_record(query.name().clone(), Ipv4Addr::new(127, 0, 0, 1));
+
+    let udp_message = message(query.clone(), vec![udp_record.clone()], vec![], vec![]);
+
+    let mut reactor = Runtime::new().unwrap();
+
+    let udp1_nameserver =
+        mock_nameserver_on_send(vec![udp_message.map(Into::into)], options, on_send.clone());
+    let udp2_nameserver = udp1_nameserver.clone();
+
+    let mut pool = mock_nameserver_pool_on_send(
+        vec![udp2_nameserver, udp1_nameserver],
+        vec![],
+        None,
+        options,
+        on_send,
+    );
+
+    // lookup on UDP succeeds, any other would fail
+    let request = message(query, vec![], vec![], vec![]).unwrap();
+    let future = pool.send(request);
+
+    // there's no actual network traffic happening, 1 sec should be plenty
+    //   TODO: for some reason this timout doesn't work, not clear why...
+    // let future = Timeout::new(future, Duration::from_secs(1));
+
+    let response = reactor.block_on(future).unwrap();
+    assert_eq!(response.answers()[0], udp_record);
+}
+
+#[test]
+fn test_concurrent_requests_0_conn() {
+    let mut options = ResolverOpts::default();
+    // there are two connections, but no concurrency requested, 0==1
+    options.num_concurrent_reqs = 0;
+
+    // we want to make sure that both udp connections are called
+    //   this will count down to 0 only if both are called.
+    let on_send = OnSendBarrier::new(1);
+
+    let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
+
+    let udp_record = v4_record(query.name().clone(), Ipv4Addr::new(127, 0, 0, 1));
+
+    let udp_message = message(query.clone(), vec![udp_record.clone()], vec![], vec![]);
+
+    let mut reactor = Runtime::new().unwrap();
+
+    let udp1_nameserver =
+        mock_nameserver_on_send(vec![udp_message.map(Into::into)], options, on_send.clone());
+    let udp2_nameserver = udp1_nameserver.clone();
+
+    let mut pool = mock_nameserver_pool_on_send(
+        vec![udp2_nameserver, udp1_nameserver],
+        vec![],
+        None,
+        options,
+        on_send,
+    );
+
+    // lookup on UDP succeeds, any other would fail
+    let request = message(query, vec![], vec![], vec![]).unwrap();
+    let future = pool.send(request);
+
+    // there's no actual network traffic happening, 1 sec should be plenty
+    //   TODO: for some reason this timout doesn't work, not clear why...
+    // let future = Timeout::new(future, Duration::from_secs(1));
+
+    let response = reactor.block_on(future).unwrap();
+    assert_eq!(response.answers()[0], udp_record);
+}


### PR DESCRIPTION
This allow the NameserverPool to be configured to execute requests in parallel. By default parallel requests will be set to 2

@hawkw, I think this is something you might be interested in, as you may want to disable this? Though it could also help.

I'm currently working on a test to validate this code.

fixes #612