### PR TITLE
Reuse Rustls ClientConfig

### DIFF
--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -19,10 +19,10 @@ use futures::Future;
 
 use proto::error::ProtoError;
 use proto::BufDnsStreamHandle;
-use trust_dns_rustls::{TlsClientStream, TlsClientStreamBuilder};
+use trust_dns_rustls::{tls_client_connect, TlsClientStream};
 
 lazy_static! {
-       // using the mozilla default root store
+    // using the mozilla default root store
     static ref CLIENT_CONFIG: Arc<ClientConfig> = {
         let mut root_store = RootCertStore::empty();
         root_store.add_server_trust_anchors(&self::webpki_roots::TLS_SERVER_ROOTS);
@@ -43,7 +43,6 @@ pub(crate) fn new_tls_stream(
     Box<Future<Item = TlsClientStream, Error = ProtoError> + Send>,
     BufDnsStreamHandle,
 ) {
-    let tls_builder = TlsClientStreamBuilder::with_client_config(CLIENT_CONFIG.clone());
-    let (stream, handle) = tls_builder.build(socket_addr, dns_name);
+    let (stream, handle) = tls_client_connect(socket_addr, dns_name, CLIENT_CONFIG.clone());
     (Box::new(stream), handle)
 }

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -12,6 +12,7 @@ extern crate rustls;
 extern crate webpki_roots;
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use self::rustls::{ClientConfig, ProtocolVersion, RootCertStore};
 use futures::Future;
@@ -20,6 +21,21 @@ use proto::error::ProtoError;
 use proto::BufDnsStreamHandle;
 use trust_dns_rustls::{TlsClientStream, TlsClientStreamBuilder};
 
+lazy_static! {
+       // using the mozilla default root store
+    static ref CLIENT_CONFIG: Arc<ClientConfig> = {
+        let mut root_store = RootCertStore::empty();
+        root_store.add_server_trust_anchors(&self::webpki_roots::TLS_SERVER_ROOTS);
+        let versions = vec![ProtocolVersion::TLSv1_2];
+
+        let mut client_config = ClientConfig::new();
+        client_config.root_store = root_store;
+        client_config.versions = versions;
+
+        Arc::new(client_config)
+    };
+}
+
 pub(crate) fn new_tls_stream(
     socket_addr: SocketAddr,
     dns_name: String,
@@ -27,16 +43,7 @@ pub(crate) fn new_tls_stream(
     Box<Future<Item = TlsClientStream, Error = ProtoError> + Send>,
     BufDnsStreamHandle,
 ) {
-    // using the mozilla default root store
-    let mut root_store = RootCertStore::empty();
-    root_store.add_server_trust_anchors(&self::webpki_roots::TLS_SERVER_ROOTS);
-    let versions = vec![ProtocolVersion::TLSv1_2];
-
-    let mut client_config = ClientConfig::new();
-    client_config.root_store = root_store;
-    client_config.versions = versions;
-
-    let tls_builder = TlsClientStreamBuilder::with_client_config(client_config);
+    let tls_builder = TlsClientStreamBuilder::with_client_config(CLIENT_CONFIG.clone());
     let (stream, handle) = tls_builder.build(socket_addr, dns_name);
     (Box::new(stream), handle)
 }

--- a/crates/rustls/src/lib.rs
+++ b/crates/rustls/src/lib.rs
@@ -31,8 +31,8 @@ pub mod tls_client_stream;
 pub mod tls_server;
 pub mod tls_stream;
 
-pub use self::tls_client_stream::{TlsClientStream, TlsClientStreamBuilder};
-pub use self::tls_stream::{tls_from_stream, TlsStream, TlsStreamBuilder};
+pub use self::tls_client_stream::{TlsClientStream, tls_client_connect};
+pub use self::tls_stream::{tls_from_stream, TlsStream, tls_connect};
 
 #[cfg(test)]
 mod tests;

--- a/crates/rustls/src/tests.rs
+++ b/crates/rustls/src/tests.rs
@@ -26,6 +26,7 @@ use self::openssl::x509::*;
 
 use futures::Stream;
 use rustls::Certificate;
+use rustls::ClientConfig;
 use tokio::runtime::current_thread::Runtime;
 
 use trust_dns_proto::xfer::SerialMessage;
@@ -199,9 +200,11 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
 
     let trust_chain = Certificate(root_cert_der);
 
+    let mut config = ClientConfig::new();
+    config.root_store.add(&trust_chain).expect("bad certificate!");
+
     // barrier.wait();
-    let mut builder = TlsStreamBuilder::new();
-    builder.add_ca(trust_chain);
+    let mut builder = TlsStreamBuilder::with_client_config(Arc::new(config));
 
     // fix MTLS
     // if mtls {

--- a/crates/rustls/src/tests.rs
+++ b/crates/rustls/src/tests.rs
@@ -31,7 +31,7 @@ use tokio::runtime::current_thread::Runtime;
 
 use trust_dns_proto::xfer::SerialMessage;
 
-use TlsStreamBuilder;
+use tls_connect;
 
 // this fails on linux for some reason. It appears that a buffer somewhere is dirty
 //  and subsequent reads of a mesage buffer reads the wrong length. It works for 2 iterations
@@ -204,14 +204,12 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     config.root_store.add(&trust_chain).expect("bad certificate!");
 
     // barrier.wait();
-    let mut builder = TlsStreamBuilder::with_client_config(Arc::new(config));
-
     // fix MTLS
     // if mtls {
     //     config_mtls(&root_pkey, &root_name, &root_cert, &mut builder);
     // }
 
-    let (stream, sender) = builder.build(server_addr, dns_name.to_string());
+    let (stream, sender) = tls_connect(server_addr, dns_name.to_string(), Arc::new(config));
 
     // TODO: there is a race failure here... a race with the server thread most likely...
     let mut stream = io_loop.block_on(stream).expect("run failed to get stream");

--- a/crates/rustls/src/tls_client_stream.rs
+++ b/crates/rustls/src/tls_client_stream.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use futures::Future;
-use rustls::{Certificate, ClientConfig, ClientSession};
+use rustls::{ClientConfig, ClientSession};
 use tokio_rustls::TlsStream as TokioTlsStream;
 use tokio_tcp::TcpStream as TokioTcpStream;
 

--- a/crates/rustls/src/tls_client_stream.rs
+++ b/crates/rustls/src/tls_client_stream.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use futures::Future;
 use rustls::{Certificate, ClientConfig, ClientSession};
@@ -24,21 +25,9 @@ pub type TlsClientStream = TcpClientStream<TokioTlsStream<TokioTcpStream, Client
 pub struct TlsClientStreamBuilder(TlsStreamBuilder);
 
 impl TlsClientStreamBuilder {
-    /// Returns a new Builder for the TlsClientSteam
-    pub fn new() -> Self {
-        TlsClientStreamBuilder(TlsStreamBuilder::new())
-    }
-
     /// Constructs a new TlsClientStreamBuilder with the associated ClientConfig
-    pub fn with_client_config(client_config: ClientConfig) -> Self {
+    pub fn with_client_config(client_config: Arc<ClientConfig>) -> Self {
         TlsClientStreamBuilder(TlsStreamBuilder::with_client_config(client_config))
-    }
-
-    /// Add a custom trusted peer certificate or certificate auhtority.
-    ///
-    /// If this is the 'client' then the 'server' must have it associated as it's `identity`, or have had the `identity` signed by this certificate.
-    pub fn add_ca(&mut self, ca: Certificate) {
-        self.0.add_ca(ca);
     }
 
     /// Client side identity for client auth in TLS (aka mutual TLS auth)
@@ -72,11 +61,5 @@ impl TlsClientStreamBuilder {
         let sender = BufDnsStreamHandle::new(name_server, sender);
 
         (new_future, sender)
-    }
-}
-
-impl Default for TlsClientStreamBuilder {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/rustls/src/tls_stream.rs
+++ b/crates/rustls/src/tls_stream.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use futures::sync::mpsc::unbounded;
 use futures::{Future, IntoFuture};
-use rustls::{Certificate, ClientConfig, ClientSession, Session};
+use rustls::{ClientConfig, ClientSession, Session};
 use tokio_rustls::{TlsConnector, TlsStream as TokioTlsStream};
 use tokio_tcp::TcpStream as TokioTcpStream;
 use webpki::{DNSName, DNSNameRef};

--- a/crates/rustls/src/tls_stream.rs
+++ b/crates/rustls/src/tls_stream.rs
@@ -36,96 +36,75 @@ pub fn tls_from_stream<S: Session>(
     (stream, message_sender)
 }
 
-#[derive(Clone)]
-pub struct TlsStreamBuilder {
+/// Creates a new TlsStream to the specified name_server
+///
+/// [RFC 7858](https://tools.ietf.org/html/rfc7858), DNS over TLS, May 2016
+///
+/// ```text
+/// 3.2.  TLS Handshake and Authentication
+///
+///   Once the DNS client succeeds in connecting via TCP on the well-known
+///   port for DNS over TLS, it proceeds with the TLS handshake [RFC5246],
+///   following the best practices specified in [BCP195].
+///
+///   The client will then authenticate the server, if required.  This
+///   document does not propose new ideas for authentication.  Depending on
+///   the privacy profile in use (Section 4), the DNS client may choose not
+///   to require authentication of the server, or it may make use of a
+///   trusted Subject Public Key Info (SPKI) Fingerprint pin set.
+///
+///   After TLS negotiation completes, the connection will be encrypted and
+///   is now protected from eavesdropping.
+/// ```
+///
+/// # Arguments
+///
+/// * `name_server` - IP and Port for the remote DNS resolver
+/// * `dns_name` - The DNS name,  Subject Public Key Info (SPKI) name, as associated to a certificate
+pub fn tls_connect(
+    name_server: SocketAddr,
+    dns_name: String,
     client_config: Arc<ClientConfig>,
-}
+) -> (
+    Box<Future<Item = TlsStream<ClientSession>, Error = io::Error> + Send>,
+    BufStreamHandle,
+) {
+    let (message_sender, outbound_messages) = unbounded();
+    let message_sender = BufStreamHandle::new(message_sender);
 
-impl TlsStreamBuilder {
-    /// Constructs a new TlsStreamBuilder with the associated ClientConfig
-    pub fn with_client_config(client_config: Arc<ClientConfig>) -> Self {
-        TlsStreamBuilder { client_config }
-    }
+    let tls_connector = TlsConnector::from(client_config);
+    let tcp = TokioTcpStream::connect(&name_server);
 
-    /// Client side identity for client auth in TLS (aka mutual TLS auth)
-    #[cfg(feature = "mtls")]
-    pub fn identity(&mut self, pkcs12: Pkcs12) {
-        self.identity = Some(pkcs12);
-    }
+    // This set of futures collapses the next tcp socket into a stream which can be used for
+    //  sending and receiving tcp packets.
+    let stream: Box<Future<Item = TlsStream<ClientSession>, Error = io::Error> + Send> = Box::new(
+        tcp.and_then(move |tcp_stream| {
+            let dns_name = DNSNameRef::try_from_ascii_str(&dns_name).map(DNSName::from);
 
-    /// Creates a new TlsStream to the specified name_server
-    ///
-    /// [RFC 7858](https://tools.ietf.org/html/rfc7858), DNS over TLS, May 2016
-    ///
-    /// ```text
-    /// 3.2.  TLS Handshake and Authentication
-    ///
-    ///   Once the DNS client succeeds in connecting via TCP on the well-known
-    ///   port for DNS over TLS, it proceeds with the TLS handshake [RFC5246],
-    ///   following the best practices specified in [BCP195].
-    ///
-    ///   The client will then authenticate the server, if required.  This
-    ///   document does not propose new ideas for authentication.  Depending on
-    ///   the privacy profile in use (Section 4), the DNS client may choose not
-    ///   to require authentication of the server, or it may make use of a
-    ///   trusted Subject Public Key Info (SPKI) Fingerprint pin set.
-    ///
-    ///   After TLS negotiation completes, the connection will be encrypted and
-    ///   is now protected from eavesdropping.
-    /// ```
-    ///
-    /// # Arguments
-    ///
-    /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name,  Subject Public Key Info (SPKI) name, as associated to a certificate
-    pub fn build(
-        self,
-        name_server: SocketAddr,
-        dns_name: String,
-    ) -> (
-        Box<Future<Item = TlsStream<ClientSession>, Error = io::Error> + Send>,
-        BufStreamHandle,
-    ) {
-        let (message_sender, outbound_messages) = unbounded();
-        let message_sender = BufStreamHandle::new(message_sender);
-
-        let tls_connector = TlsConnector::from(self.client_config);
-        let tcp = TokioTcpStream::connect(&name_server);
-
-        // This set of futures collapses the next tcp socket into a stream which can be used for
-        //  sending and receiving tcp packets.
-        let stream: Box<Future<Item = TlsStream<ClientSession>, Error = io::Error> + Send> =
-            Box::new(
-                tcp.and_then(move |tcp_stream| {
-                    let dns_name = DNSNameRef::try_from_ascii_str(&dns_name).map(DNSName::from);
-
-                    dns_name
-                        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "bad dns_name"))
-                        .into_future()
-                        .and_then(move |dns_name| {
-                            tls_connector
-                                .connect(dns_name.as_ref(), tcp_stream)
-                                .map(move |s| {
-                                    TcpStream::from_stream_with_receiver(
-                                        s,
-                                        name_server,
-                                        outbound_messages,
-                                    )
-                                }).map_err(|e| {
-                                    io::Error::new(
-                                        io::ErrorKind::ConnectionRefused,
-                                        format!("tls error: {}", e),
-                                    )
-                                })
+            dns_name
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "bad dns_name"))
+                .into_future()
+                .and_then(move |dns_name| {
+                    tls_connector
+                        .connect(dns_name.as_ref(), tcp_stream)
+                        .map(move |s| {
+                            TcpStream::from_stream_with_receiver(s, name_server, outbound_messages)
                         })
-                }).map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::ConnectionRefused,
-                        format!("tls error: {}", e),
-                    )
-                }),
-            );
+                        .map_err(|e| {
+                            io::Error::new(
+                                io::ErrorKind::ConnectionRefused,
+                                format!("tls error: {}", e),
+                            )
+                        })
+                })
+        })
+        .map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                format!("tls error: {}", e),
+            )
+        }),
+    );
 
-        (stream, message_sender)
-    }
+    (stream, message_sender)
 }

--- a/crates/server/tests/z_named_rustls_tests.rs
+++ b/crates/server/tests/z_named_rustls_tests.rs
@@ -31,7 +31,7 @@ use rustls::ClientConfig;
 use tokio::runtime::current_thread::Runtime;
 
 use trust_dns::client::*;
-use trust_dns_rustls::TlsClientStreamBuilder;
+use trust_dns_rustls::tls_client_connect;
 
 use server_harness::{named_test_harness, query_a};
 
@@ -63,9 +63,7 @@ fn test_example_tls_toml_startup() {
             config.root_store.add(&cert).expect("bad certificate");
             let config = Arc::new(config);
 
-            let tls_conn_builder = TlsClientStreamBuilder::with_client_config(config.clone());
-
-            let (stream, sender) = tls_conn_builder.build(addr, "ns.example.com".to_string());
+            let (stream, sender) = tls_client_connect(addr, "ns.example.com".to_string(), config.clone());
             let (bg, mut client) = ClientFuture::new(stream, Box::new(sender), None);
 
             // ipv4 should succeed
@@ -77,8 +75,7 @@ fn test_example_tls_toml_startup() {
                 .unwrap()
                 .next()
                 .unwrap();
-            let tls_conn_builder = TlsClientStreamBuilder::with_client_config(config.clone());
-            let (stream, sender) = tls_conn_builder.build(addr, "ns.example.com".to_string());
+            let (stream, sender) = tls_client_connect(addr, "ns.example.com".to_string(), config.clone());
             let (bg, mut client) = ClientFuture::new(stream, Box::new(sender), None);
             io_loop.spawn(bg);
 

--- a/tests/integration-tests/src/tls_client_connection.rs
+++ b/tests/integration-tests/src/tls_client_connection.rs
@@ -12,7 +12,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use futures::Future;
-use rustls::Certificate;
 
 use trust_dns::client::ClientConnection;
 use trust_dns::error::*;

--- a/tests/integration-tests/src/tls_client_connection.rs
+++ b/tests/integration-tests/src/tls_client_connection.rs
@@ -14,31 +14,34 @@ use std::sync::Arc;
 use futures::Future;
 
 use trust_dns::client::ClientConnection;
-use trust_dns::error::*;
 use trust_dns::rr::dnssec::Signer;
 use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 
-use trust_dns_rustls::TlsClientStream;
-use trust_dns_rustls::TlsClientStreamBuilder;
-use rustls::{Certificate, ClientConfig};
+use rustls::ClientConfig;
+use trust_dns_rustls::{tls_client_connect, TlsClientStream};
 
 /// Tls client connection
 ///
 /// Use with `trust_dns::client::Client` impls
 pub struct TlsClientConnection {
-    builder: TlsClientStreamBuilder,
     name_server: SocketAddr,
     dns_name: String,
+    client_config: Arc<ClientConfig>,
 }
 
-#[cfg(all(
-    feature = "dns-over-openssl",
-    not(feature = "dns-over-rustls")
-))]
+#[cfg(all(feature = "dns-over-openssl", not(feature = "dns-over-rustls")))]
 impl TlsClientConnection {
-    pub fn builder(client_config: Arc<ClientConfig>) -> TlsClientConnectionBuilder {
-        TlsClientConnectionBuilder(TlsClientStreamBuilder::with_client_config(client_config))
+    pub fn new(
+        name_server: SocketAddr,
+        dns_name: String,
+        client_config: Arc<ClientConfig>,
+    ) -> Self {
+        TlsClientConnection {
+            name_server,
+            dns_name,
+            client_config,
+        }
     }
 }
 
@@ -52,42 +55,12 @@ impl ClientConnection for TlsClientConnection {
     >;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
-        let (tls_client_stream, handle) = self
-            .builder
-            .clone()
-            .build(self.name_server, self.dns_name.clone());
+        let (tls_client_stream, handle) = tls_client_connect(
+            self.name_server,
+            self.dns_name.clone(),
+            self.client_config.clone(),
+        );
 
         DnsMultiplexer::new(Box::new(tls_client_stream), Box::new(handle), signer)
-    }
-}
-
-pub struct TlsClientConnectionBuilder(TlsClientStreamBuilder);
-
-impl TlsClientConnectionBuilder {
-    /// Client side identity for client auth in TLS (aka mutual TLS auth)
-    #[cfg(feature = "mtls")]
-    pub fn identity(&mut self, pkcs12: Pkcs12) {
-        self.0.identity(pkcs12);
-    }
-
-    /// Creates a new client connection.
-    ///
-    /// *Note* this has side affects of establishing the connection to the specified DNS server and
-    ///        starting the event_loop. Expect this to change in the future.
-    ///
-    /// # Arguments
-    ///
-    /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
-    pub fn build(
-        self,
-        name_server: SocketAddr,
-        dns_name: String,
-    ) -> ClientResult<TlsClientConnection> {
-        Ok(TlsClientConnection {
-            builder: self.0,
-            name_server,
-            dns_name,
-        })
     }
 }

--- a/tests/integration-tests/src/tls_client_connection.rs
+++ b/tests/integration-tests/src/tls_client_connection.rs
@@ -32,6 +32,10 @@ pub struct TlsClientConnection {
     dns_name: String,
 }
 
+#[cfg(all(
+    feature = "dns-over-openssl",
+    not(feature = "dns-over-rustls")
+))]
 impl TlsClientConnection {
     pub fn builder() -> TlsClientConnectionBuilder {
         TlsClientConnectionBuilder(TlsClientStreamBuilder::new())
@@ -60,6 +64,10 @@ impl ClientConnection for TlsClientConnection {
 pub struct TlsClientConnectionBuilder(TlsClientStreamBuilder);
 
 impl TlsClientConnectionBuilder {
+    #[cfg(all(
+        feature = "dns-over-openssl",
+        not(feature = "dns-over-rustls")
+    ))]
     /// Add a custom trusted peer certificate or certificate auhtority.
     ///
     /// If this is the 'client' then the 'server' must have it associated as it's `identity`, or have had the `identity` signed by this certificate.

--- a/tests/integration-tests/src/tls_client_connection.rs
+++ b/tests/integration-tests/src/tls_client_connection.rs
@@ -21,6 +21,7 @@ use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSen
 
 use trust_dns_rustls::TlsClientStream;
 use trust_dns_rustls::TlsClientStreamBuilder;
+use rustls::{Certificate, ClientConfig};
 
 /// Tls client connection
 ///
@@ -36,8 +37,8 @@ pub struct TlsClientConnection {
     not(feature = "dns-over-rustls")
 ))]
 impl TlsClientConnection {
-    pub fn builder() -> TlsClientConnectionBuilder {
-        TlsClientConnectionBuilder(TlsClientStreamBuilder::new())
+    pub fn builder(client_config: Arc<ClientConfig>) -> TlsClientConnectionBuilder {
+        TlsClientConnectionBuilder(TlsClientStreamBuilder::with_client_config(client_config))
     }
 }
 
@@ -63,17 +64,6 @@ impl ClientConnection for TlsClientConnection {
 pub struct TlsClientConnectionBuilder(TlsClientStreamBuilder);
 
 impl TlsClientConnectionBuilder {
-    #[cfg(all(
-        feature = "dns-over-openssl",
-        not(feature = "dns-over-rustls")
-    ))]
-    /// Add a custom trusted peer certificate or certificate auhtority.
-    ///
-    /// If this is the 'client' then the 'server' must have it associated as it's `identity`, or have had the `identity` signed by this certificate.
-    pub fn add_ca(&mut self, ca: Certificate) {
-        self.0.add_ca(ca);
-    }
-
     /// Client side identity for client auth in TLS (aka mutual TLS auth)
     #[cfg(feature = "mtls")]
     pub fn identity(&mut self, pkcs12: Pkcs12) {

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -214,9 +214,7 @@ fn lazy_tls_client(ipaddr: SocketAddr, dns_name: String, cert_der: Vec<u8>) -> T
     let mut config = ClientConfig::new();
     config.root_store.add(&trust_chain).expect("bad certificate");
 
-    let builder = TlsClientConnection::builder(Arc::new(config));
-
-    builder.build(ipaddr, dns_name).unwrap()
+    TlsClientConnection::new(ipaddr, dns_name, Arc::new(config))
 }
 
 fn client_thread_www<C: ClientConnection>(conn: C)

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -208,13 +208,14 @@ fn lazy_tcp_client(ipaddr: SocketAddr) -> TcpClientConnection {
     not(feature = "dns-over-rustls")
 ))]
 fn lazy_tls_client(ipaddr: SocketAddr, dns_name: String, cert_der: Vec<u8>) -> TlsClientConnection {
-    use rustls::Certificate;
-
-    let mut builder = TlsClientConnection::builder();
+    use rustls::{Certificate, ClientConfig};
 
     let trust_chain = Certificate(cert_der);
+    let mut config = ClientConfig::new();
+    config.root_store.add(&trust_chain).expect("bad certificate");
 
-    builder.add_ca(trust_chain);
+    let builder = TlsClientConnection::builder(Arc::new(config));
+
     builder.build(ipaddr, dns_name).unwrap()
 }
 


### PR DESCRIPTION
Based on the discussions in #618 

Since we cannot add CAs via `TlsStreamBuilder` and a `TlsStream` without any CA is unusable, I also remove the empty constructor of `TlsStreamBuilder`.

The `new_tls_stream` function in the `resolver` crate is also changed to reuse the `ClientConfig`.

Should we place any warnings somewhere as it breaks the API?

Closes #618 