### PR TITLE
Set minimum tokio-timer version to 0.2.6

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -69,7 +69,7 @@ tokio-executor = "^0.1"
 tokio-io = "^0.1"
 tokio-reactor = "^0.1"
 tokio-tcp = "^0.1"
-tokio-timer = "^0.2"
+tokio-timer = "^0.2.6"
 tokio-udp = "^0.1"
 untrusted = { version = "^0.6", optional = true }
 url = "1.6.0"


### PR DESCRIPTION
Just sets min version of tokio-time to avoid problems for people who likes to cache deps:
https://github.com/actix/actix/issues/177

Uses https://github.com/bluejekyll/trust-dns/blob/master/crates/proto/src/tcp/tcp_stream.rs#L20 which has been added since 0.2.6 if I'm not mistaken