### PR TITLE
Enforce udp sockets always close

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -227,14 +227,15 @@
 //! let mut runtime = Runtime::new().unwrap();
 //!
 //! // We need a connection, TCP and UDP are supported by DNS servers
-//! let (stream, handle) = UdpClientStream::new(([8,8,8,8], 53).into());
+//! //   (tcp construction is slightly different as it needs a multiplexer)
+//! let stream = UdpClientStream::new(([8,8,8,8], 53).into());
 //!
 //! // Create a new client, the bg is a background future which handles
 //! //   the multiplexing of the DNS requests to the server.
 //! //   the client is a handle to an unbounded queue for sending requests via the
 //! //   background. The background must be scheduled to run before the client can
 //! //   send any dns requests
-//! let (bg, mut client) = ClientFuture::new(stream, handle, None);
+//! let (bg, mut client) = ClientFuture::connect(stream);
 //!
 //! // run the background task
 //! runtime.spawn(bg);

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -255,7 +255,6 @@ extern crate chrono;
 extern crate data_encoding;
 #[macro_use]
 extern crate data_encoding_macro;
-#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate futures;

--- a/crates/client/src/udp/udp_client_connection.rs
+++ b/crates/client/src/udp/udp_client_connection.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use proto::udp::{UdpClientConnect, UdpClientStream};
-use proto::xfer::{DnsRequestSender};
+use proto::xfer::DnsRequestSender;
 
 use client::ClientConnection;
 use error::*;
@@ -44,16 +44,14 @@ impl UdpClientConnection {
 }
 
 impl ClientConnection for UdpClientConnection {
-    type Sender = UdpClientStream;
+    type Sender = UdpClientStream<Signer>;
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
-    type SenderFuture = UdpClientConnect;
+    type SenderFuture = UdpClientConnect<Signer>;
 
     fn new_stream(
         &self,
-        // FIXME: apply signer...
-        _signer: Option<Arc<Signer>>,
+        signer: Option<Arc<Signer>>,
     ) -> Self::SenderFuture {
-        // FIXME: apply signer
-        UdpClientStream::with_timeout(self.name_server, self.timeout)
+        UdpClientStream::with_timeout_and_signer(self.name_server, self.timeout, signer)
     }
 }

--- a/crates/client/src/udp/udp_client_connection.rs
+++ b/crates/client/src/udp/udp_client_connection.rs
@@ -9,9 +9,10 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use proto::udp::{UdpClientConnect, UdpClientStream};
-use proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
+use proto::xfer::{DnsRequestSender};
 
 use client::ClientConnection;
 use error::*;
@@ -23,29 +24,36 @@ use rr::dnssec::Signer;
 #[derive(Clone)]
 pub struct UdpClientConnection {
     name_server: SocketAddr,
+    timeout: Duration,
 }
 
 impl UdpClientConnection {
-    /// Creates a new client connection.
-    ///
-    /// *Note* this has side affects of binding the socket to 0.0.0.0 and starting the listening
-    ///        event_loop. Expect this to change in the future.
+    /// Creates a new client connection. With a default timeout of 5 seconds
     ///
     /// # Arguments
     ///
     /// * `name_server` - address of the name server to use for queries
     pub fn new(name_server: SocketAddr) -> ClientResult<Self> {
-        Ok(UdpClientConnection { name_server })
+        Self::with_timeout(name_server, Duration::from_secs(5))
+    }
+
+    /// Allows a custom timeout
+    pub fn with_timeout(name_server: SocketAddr, timeout: Duration) -> ClientResult<Self> {
+        Ok(UdpClientConnection {name_server, timeout})
     }
 }
 
 impl ClientConnection for UdpClientConnection {
-    type Sender = DnsMultiplexer<UdpClientStream, Signer>;
+    type Sender = UdpClientStream;
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
-    type SenderFuture = DnsMultiplexerConnect<UdpClientConnect, UdpClientStream, Signer>;
+    type SenderFuture = UdpClientConnect;
 
-    fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
-        let (udp_client_stream, handle) = UdpClientStream::new(self.name_server);
-        DnsMultiplexer::new(udp_client_stream, handle, signer)
+    fn new_stream(
+        &self,
+        // FIXME: apply signer...
+        _signer: Option<Arc<Signer>>,
+    ) -> Self::SenderFuture {
+        // FIXME: apply signer
+        UdpClientStream::with_timeout(self.name_server, self.timeout)
     }
 }

--- a/crates/https/src/lib.rs
+++ b/crates/https/src/lib.rs
@@ -16,7 +16,6 @@ extern crate h2;
 extern crate http;
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate failure;
 extern crate rustls;
 extern crate tokio_executor;

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -16,7 +16,6 @@ extern crate byteorder;
 extern crate data_encoding;
 #[cfg(test)]
 extern crate env_logger;
-#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate futures;

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -659,7 +659,7 @@ impl Deref for Message {
 ///
 /// An example of this is a SIG0 signer, which needs the final form of the message,
 ///  but then needs to attach additional data to the body of the message.
-pub trait MessageFinalizer: Send {
+pub trait MessageFinalizer: Send + Sync + 'static {
     /// The message taken in should be processed and then return [`Record`]s which should be
     ///  appended to the additional section of the message.
     ///

--- a/crates/proto/src/udp/mod.rs
+++ b/crates/proto/src/udp/mod.rs
@@ -19,5 +19,5 @@
 mod udp_client_stream;
 mod udp_stream;
 
-pub use self::udp_client_stream::{UdpClientConnect, UdpClientStream};
+pub use self::udp_client_stream::{UdpClientConnect, UdpClientStream, UdpResponse};
 pub use self::udp_stream::UdpStream;

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -178,7 +178,10 @@ impl Future for NextRandomUdpSocket {
 
             // TODO: allow TTL to be adjusted...
             match tokio_udp::UdpSocket::bind(&zero_addr) {
-                Ok(socket) => return Ok(Async::Ready(socket)),
+                Ok(socket) => {
+                    debug!("created socket: {:?}", socket);
+                    return Ok(Async::Ready(socket));
+                }
                 Err(err) => debug!("unable to bind port, attempt: {}: {}", attempt, err),
             }
         }
@@ -236,7 +239,8 @@ fn udp_stream_test(server_addr: IpAddr) {
             }
 
             panic!("timeout");
-        }).unwrap();
+        })
+        .unwrap();
 
     let server = std::net::UdpSocket::bind(SocketAddr::new(server_addr, 0)).unwrap();
     server
@@ -268,7 +272,8 @@ fn udp_stream_test(server_addr: IpAddr) {
                     len
                 );
             }
-        }).unwrap();
+        })
+        .unwrap();
 
     // setup the client, which is going to run on the testing thread...
     let mut io_loop = Runtime::new().unwrap();

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -21,7 +21,6 @@ use xfer::{BufStreamHandle, SerialMessage};
 /// A UDP stream of DNS binary packets
 #[must_use = "futures do nothing unless polled"]
 pub struct UdpStream {
-    // FIXME: change UdpStream to always select a new Socket for every request
     socket: tokio_udp::UdpSocket,
     outbound_messages: Peekable<Fuse<UnboundedReceiver<SerialMessage>>>,
 }
@@ -51,7 +50,7 @@ impl UdpStream {
 
         // TODO: allow the bind address to be specified...
         // constructs a future for getting the next randomly bound port to a UdpSocket
-        let next_socket = Self::next_bound_local_address(&name_server);
+        let next_socket = NextRandomUdpSocket::new(&name_server);
 
         // This set of futures collapses the next udp socket into a stream which can be used for
         //  sending and receiving udp packets.
@@ -96,18 +95,6 @@ impl UdpStream {
         UdpStream {
             socket: socket,
             outbound_messages: outbound_messages.fuse().peekable(),
-        }
-    }
-
-    /// Creates a future for randomly binding to a local socket address for client connections.
-    fn next_bound_local_address(name_server: &SocketAddr) -> NextRandomUdpSocket {
-        let zero_addr: IpAddr = match *name_server {
-            SocketAddr::V4(..) => IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            SocketAddr::V6(..) => IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
-        };
-
-        NextRandomUdpSocket {
-            bind_address: zero_addr,
         }
     }
 }
@@ -156,8 +143,22 @@ impl Stream for UdpStream {
 }
 
 #[must_use = "futures do nothing unless polled"]
-struct NextRandomUdpSocket {
+pub(crate) struct NextRandomUdpSocket {
     bind_address: IpAddr,
+}
+
+impl NextRandomUdpSocket {
+    /// Creates a future for randomly binding to a local socket address for client connections.
+    pub(crate) fn new(name_server: &SocketAddr) -> NextRandomUdpSocket {
+        let zero_addr: IpAddr = match *name_server {
+            SocketAddr::V4(..) => IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            SocketAddr::V6(..) => IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+        };
+
+        NextRandomUdpSocket {
+            bind_address: zero_addr,
+        }
+    }
 }
 
 impl Future for NextRandomUdpSocket {

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -144,7 +144,7 @@ where
         signer: Option<Arc<MF>>,
     ) -> DnsMultiplexerConnect<F, S, MF>
     where
-        F: Future<Item = Future<Item = S, Error = ProtoError>, Error = ProtoError> + Send + 'static,
+        F: Future<Item = S, Error = ProtoError> + Send + 'static,
     {
         Self::with_timeout(stream, stream_handle, Duration::from_secs(5), signer)
     }

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -128,7 +128,7 @@ where
 impl<S, MF> DnsMultiplexer<S, MF, Box<DnsStreamHandle>>
 where
     S: DnsClientStream + 'static,
-    MF: MessageFinalizer + Send + Sync + 'static,
+    MF: MessageFinalizer,
 {
     /// Spawns a new DnsMultiplexer Stream. This uses a default timeout of 5 seconds for all requests.
     ///

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -144,7 +144,7 @@ where
         signer: Option<Arc<MF>>,
     ) -> DnsMultiplexerConnect<F, S, MF>
     where
-        F: Future<Item = S, Error = ProtoError> + Send + 'static,
+        F: Future<Item = Future<Item = S, Error = ProtoError>, Error = ProtoError> + Send + 'static,
     {
         Self::with_timeout(stream, stream_handle, Duration::from_secs(5), signer)
     }

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -308,11 +308,9 @@ where
             let future;
             match self {
                 OneshotDnsResponseReceiver::Receiver(ref mut receiver) => {
-                    future = try_ready!(
-                        receiver
-                            .poll()
-                            .map_err(|_| ProtoError::from("receiver was canceled"))
-                    );
+                    future = try_ready!(receiver
+                        .poll()
+                        .map_err(|_| ProtoError::from("receiver was canceled")));
                 }
                 OneshotDnsResponseReceiver::Received(ref mut future) => return future.poll(),
                 OneshotDnsResponseReceiver::Err(err) => {

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -169,7 +169,6 @@
 #[cfg(feature = "dns-over-tls")]
 #[macro_use]
 extern crate cfg_if;
-#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate futures;

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -279,7 +279,7 @@ impl ConnectionHandleConnect {
                 socket_addr,
                 timeout,
             } => {
-                let (stream, handle) = UdpClientStream::with_timeout(socket_addr, timeout);
+                let stream = UdpClientStream::with_timeout(socket_addr, timeout);
                 let (stream, handle) = DnsExchange::connect(stream);
 
                 let stream = stream.and_then(|stream| stream).map_err(|e| {

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -24,7 +24,7 @@ use proto::error::{ProtoError, ProtoResult};
 use proto::multicast::{MdnsClientStream, MdnsQueryType, MDNS_IPV4};
 use proto::op::{Edns, NoopMessageFinalizer, ResponseCode};
 use proto::tcp::TcpClientStream;
-use proto::udp::UdpClientStream;
+use proto::udp::{UdpResponse, UdpClientStream};
 use proto::xfer::{
     self, BufDnsRequestStreamHandle, DnsExchange, DnsHandle, DnsMultiplexer,
     DnsMultiplexerSerialResponse, DnsRequest, DnsResponse,
@@ -279,23 +279,16 @@ impl ConnectionHandleConnect {
                 socket_addr,
                 timeout,
             } => {
-                let (stream, handle) = UdpClientStream::new(socket_addr);
-                // TODO: need config for Signer...
-                let dns_conn = DnsMultiplexer::with_timeout(
-                    stream,
-                    handle,
-                    timeout,
-                    NoopMessageFinalizer::new(),
-                );
+                let (stream, handle) = UdpClientStream::with_timeout(socket_addr, timeout);
+                let (stream, handle) = DnsExchange::connect(stream);
 
-                let (stream, handle) = DnsExchange::connect(dns_conn);
                 let stream = stream.and_then(|stream| stream).map_err(|e| {
                     debug!("udp connection shutting down: {}", e);
                 });
                 let handle = BufDnsRequestStreamHandle::new(handle);
 
                 DefaultExecutor::current().spawn(Box::new(stream))?;
-                Ok(ConnectionHandleConnected::UdpOrTcp(handle))
+                Ok(ConnectionHandleConnected::Udp(handle))
             }
             Tcp {
                 socket_addr,
@@ -317,7 +310,7 @@ impl ConnectionHandleConnect {
                 let handle = BufDnsRequestStreamHandle::new(handle);
 
                 DefaultExecutor::current().spawn(Box::new(stream))?;
-                Ok(ConnectionHandleConnected::UdpOrTcp(handle))
+                Ok(ConnectionHandleConnected::Tcp(handle))
             }
             #[cfg(feature = "dns-over-tls")]
             Tls {
@@ -340,7 +333,7 @@ impl ConnectionHandleConnect {
                 let handle = BufDnsRequestStreamHandle::new(handle);
 
                 DefaultExecutor::current().spawn(Box::new(stream))?;
-                Ok(ConnectionHandleConnected::UdpOrTcp(handle))
+                Ok(ConnectionHandleConnected::Tcp(handle))
             }
             #[cfg(feature = "dns-over-https")]
             Https {
@@ -380,7 +373,7 @@ impl ConnectionHandleConnect {
                 let handle = BufDnsRequestStreamHandle::new(handle);
 
                 DefaultExecutor::current().spawn(Box::new(stream))?;
-                Ok(ConnectionHandleConnected::UdpOrTcp(handle))
+                Ok(ConnectionHandleConnected::Tcp(handle))
             }
         }
     }
@@ -389,7 +382,8 @@ impl ConnectionHandleConnect {
 /// A representation of an established connection
 #[derive(Clone)]
 enum ConnectionHandleConnected {
-    UdpOrTcp(xfer::BufDnsRequestStreamHandle<DnsMultiplexerSerialResponse>),
+    Udp(xfer::BufDnsRequestStreamHandle<UdpResponse>),
+    Tcp(xfer::BufDnsRequestStreamHandle<DnsMultiplexerSerialResponse>),
     #[cfg(feature = "dns-over-https")]
     Https(xfer::BufDnsRequestStreamHandle<trust_dns_https::HttpsSerialResponse>),
 }
@@ -399,8 +393,11 @@ impl DnsHandle for ConnectionHandleConnected {
 
     fn send<R: Into<DnsRequest>>(&mut self, request: R) -> ConnectionHandleResponseInner {
         match self {
-            ConnectionHandleConnected::UdpOrTcp(ref mut conn) => {
-                return ConnectionHandleResponseInner::UdpOrTcp(conn.send(request))
+            ConnectionHandleConnected::Udp(ref mut conn) => {
+                return ConnectionHandleResponseInner::Udp(conn.send(request))
+            }
+            ConnectionHandleConnected::Tcp(ref mut conn) => {
+                return ConnectionHandleResponseInner::Tcp(conn.send(request))
             }
             #[cfg(feature = "dns-over-https")]
             ConnectionHandleConnected::Https(ref mut https) => {
@@ -457,7 +454,8 @@ enum ConnectionHandleResponseInner {
         conn: ConnectionHandle,
         request: Option<DnsRequest>,
     },
-    UdpOrTcp(xfer::OneshotDnsResponseReceiver<DnsMultiplexerSerialResponse>),
+    Udp(xfer::OneshotDnsResponseReceiver<UdpResponse>),
+    Tcp(xfer::OneshotDnsResponseReceiver<DnsMultiplexerSerialResponse>),
     #[cfg(feature = "dns-over-https")]
     Https(xfer::OneshotDnsResponseReceiver<trust_dns_https::HttpsSerialResponse>),
     Error(ProtoError),
@@ -481,7 +479,8 @@ impl Future for ConnectionHandleResponseInner {
                     Ok(mut c) => c.send(request.take().expect("already sent request?")),
                     Err(e) => Error(ProtoError::from(e)),
                 },
-                UdpOrTcp(ref mut resp) => return resp.poll(),
+                Udp(ref mut resp) => return resp.poll(),
+                Tcp(ref mut resp) => return resp.poll(),
                 #[cfg(feature = "dns-over-https")]
                 Https(ref mut https) => return https.poll(),
                 Error(ref e) => return Err(e.clone()),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -30,7 +30,6 @@
 extern crate bytes;
 extern crate chrono;
 extern crate env_logger;
-#[macro_use]
 extern crate failure;
 extern crate futures;
 #[macro_use]

--- a/crates/server/tests/z_named_tests.rs
+++ b/crates/server/tests/z_named_tests.rs
@@ -190,8 +190,8 @@ fn test_server_continues_on_bad_data_udp() {
     named_test_harness("example.toml", |port, _, _| {
         let mut io_loop = Runtime::new().unwrap();
         let addr: SocketAddr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), port);
-        let (stream, sender) = UdpClientStream::new(addr);
-        let (bg, mut client) = ClientFuture::new(Box::new(stream), sender, None);
+        let stream = UdpClientStream::new(addr);
+        let (bg, mut client) = ClientFuture::connect(stream);
 
         io_loop.spawn(bg);
 
@@ -207,8 +207,8 @@ fn test_server_continues_on_bad_data_udp() {
 
         // just tests that multiple queries work
         let addr: SocketAddr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), port);
-        let (stream, sender) = UdpClientStream::new(addr);
-        let (bg, mut client) = ClientFuture::new(stream, sender, None);
+        let stream = UdpClientStream::new(addr);
+        let (bg, mut client) = ClientFuture::connect(stream);
         io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -60,8 +60,8 @@ fn test_query_nonet() {
 fn test_query_udp_ipv4() {
     let mut io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let (stream, sender) = UdpClientStream::new(addr);
-    let (bg, mut client) = ClientFuture::new(stream, sender, None);
+    let stream = UdpClientStream::new(addr);
+    let (bg, mut client) = ClientFuture::connect(stream);
     io_loop.spawn(bg);
 
     // TODO: timeouts on these requests so that the test doesn't hang
@@ -78,8 +78,8 @@ fn test_query_udp_ipv6() {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = UdpClientStream::new(addr);
-    let (bg, mut client) = ClientFuture::new(stream, sender, None);
+    let stream = UdpClientStream::new(addr);
+    let (bg, mut client) = ClientFuture::connect(stream);
     io_loop.spawn(bg);
 
     // TODO: timeouts on these requests so that the test doesn't hang
@@ -914,9 +914,8 @@ fn test_timeout_query_udp() {
         .next()
         .unwrap();
 
-    let (stream, sender) = UdpClientStream::new(addr);
-    let (bg, client) =
-        ClientFuture::with_timeout(stream, sender, std::time::Duration::from_millis(1), None);
+    let stream = UdpClientStream::with_timeout(addr, std::time::Duration::from_millis(1));
+    let (bg, client) = ClientFuture::connect(stream);
     io_loop.spawn(bg);
     test_timeout_query(client, io_loop);
 }

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -158,6 +158,9 @@ fn test_secure_query_example<CC>(client: SecureSyncClient<CC>)
 where
     CC: ClientConnection,
 {
+    // extern crate env_logger;
+    // env_logger::try_init().ok();
+
     let name = Name::from_str("www.example.com").unwrap();
     let response = client.secure_query(&name, DNSClass::IN, RecordType::A);
 

--- a/tests/integration-tests/tests/secure_client_handle_tests.rs
+++ b/tests/integration-tests/tests/secure_client_handle_tests.rs
@@ -21,9 +21,9 @@ use trust_dns::rr::dnssec::TrustAnchor;
 use trust_dns::rr::Name;
 use trust_dns::rr::{DNSClass, RData, RecordType};
 use trust_dns::tcp::TcpClientStream;
-use trust_dns::udp::UdpClientStream;
 
-use trust_dns_proto::xfer::DnsMultiplexerSerialResponse;
+use trust_dns_proto::udp::{UdpClientStream, UdpResponse};
+use trust_dns_proto::xfer::{SecureDnsHandle, DnsMultiplexerSerialResponse};
 use trust_dns_server::authority::Catalog;
 
 use trust_dns_integration::authority::create_secure_example;
@@ -251,7 +251,7 @@ where
 fn with_udp<F>(test: F)
 where
     F: Fn(
-        SecureClientHandle<MemoizeClientHandle<BasicClientHandle<DnsMultiplexerSerialResponse>>>,
+        SecureDnsHandle<MemoizeClientHandle<BasicClientHandle<UdpResponse>>>,
         Runtime,
     ),
 {
@@ -273,8 +273,8 @@ where
 
     let mut io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let (stream, sender) = UdpClientStream::new(addr);
-    let (bg, client) = ClientFuture::new(stream, sender, None);
+    let stream = UdpClientStream::new(addr);
+    let (bg, client) = ClientFuture::connect(stream);
     let client = MemoizeClientHandle::new(client);
     let secure_client = SecureClientHandle::new(client);
 


### PR DESCRIPTION
fixes: #633 

This change makes UdpClientStream much more like HttpsClientStream, in that it is already multiplexed. All UdpSockets are now bound to the Future handling the UDP request. In this way, when the Future goes away on the request, the UdpSocket will be closed. This will enforce proper semantics in regards to cache poisoning attacks, better than the method before.