### PR TITLE
maintain AsyncResolver in Resolver

### DIFF
--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -132,7 +132,7 @@ impl MdnsStream {
         // This set of futures collapses the next udp socket into a stream which can be used for
         //  sending and receiving udp packets.
         let stream = {
-            let handle = Handle::current();
+            let handle = Handle::default();
             let handle_clone = handle.clone();
 
             Box::new(
@@ -141,7 +141,8 @@ impl MdnsStream {
                         socket.map(|socket| {
                             UdpSocket::from_std(socket, &handle).expect("bad handle?")
                         })
-                    }).map(move |socket: Option<_>| {
+                    })
+                    .map(move |socket: Option<_>| {
                         let datagram =
                             socket.map(|socket| UdpStream::from_parts(socket, outbound_messages));
                         let multicast: Option<UdpSocket> =
@@ -460,11 +461,10 @@ pub mod tests {
             .name("test_one_shot_mdns:server".to_string())
             .spawn(move || {
                 let mut server_loop = Runtime::new().unwrap();
-                let mut timeout: Box<
-                    Future<Item = (), Error = tokio_timer::Error> + Send,
-                > = Box::new(future::lazy(|| {
-                    Delay::new(Instant::now() + Duration::from_millis(100))
-                }));
+                let mut timeout: Box<Future<Item = (), Error = tokio_timer::Error> + Send> =
+                    Box::new(future::lazy(|| {
+                        Delay::new(Instant::now() + Duration::from_millis(100))
+                    }));
 
                 // TTLs are 0 so that multicast test packets never leave the test host...
                 // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
@@ -521,7 +521,8 @@ pub mod tests {
                         .block_on(Delay::new(Instant::now() + Duration::from_millis(100)))
                         .unwrap();
                 }
-            }).unwrap();
+            })
+            .unwrap();
 
         // setup the client, which is going to run on the testing thread...
         let mut io_loop = Runtime::new().unwrap();
@@ -616,11 +617,10 @@ pub mod tests {
             .name("test_one_shot_mdns:server".to_string())
             .spawn(move || {
                 let mut io_loop = Runtime::new().unwrap();
-                let mut timeout: Box<
-                    Future<Item = (), Error = tokio_timer::Error> + Send,
-                > = Box::new(future::lazy(|| {
-                    Delay::new(Instant::now() + Duration::from_millis(100))
-                }));
+                let mut timeout: Box<Future<Item = (), Error = tokio_timer::Error> + Send> =
+                    Box::new(future::lazy(|| {
+                        Delay::new(Instant::now() + Duration::from_millis(100))
+                    }));
 
                 // TTLs are 0 so that multicast test packets never leave the test host...
                 // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
@@ -667,7 +667,8 @@ pub mod tests {
                         .block_on(Delay::new(Instant::now() + Duration::from_millis(100)))
                         .unwrap();
                 }
-            }).unwrap();
+            })
+            .unwrap();
 
         // setup the client, which is going to run on the testing thread...
         let mut io_loop = Runtime::new().unwrap();

--- a/crates/resolver/src/error.rs
+++ b/crates/resolver/src/error.rs
@@ -8,7 +8,7 @@
 //! Error types for the crate
 
 use failure::{Backtrace, Context, Fail};
-use std::{fmt, io, time::Instant};
+use std::{fmt, io, sync, time::Instant};
 use proto::error::{ProtoError, ProtoErrorKind};
 use proto::op::Query;
 
@@ -164,5 +164,11 @@ impl From<ResolveError> for io::Error {
             ResolveErrorKind::Timeout => io::Error::new(io::ErrorKind::TimedOut, e.compat()),
             _ => io::Error::new(io::ErrorKind::Other, e.compat()),
         }
+    }
+}
+
+impl<T> From<sync::PoisonError<sync::MutexGuard<'_, T>>> for ResolveError {
+    fn from(e: sync::PoisonError<sync::MutexGuard<'_, T>>) -> Self {
+        ResolveErrorKind::Msg(format!("lock was poisoned, this is non-recoverable: {}", e)).into()
     }
 }

--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -76,7 +76,7 @@ impl<T: RequestHandler> ServerFuture<T> {
     /// Register a UDP socket. Should be bound before calling this function.
     pub fn register_socket_std(&self, socket: std::net::UdpSocket) {
         self.register_socket(
-            tokio_udp::UdpSocket::from_std(socket, &Handle::current()).expect("bad handle?"),
+            tokio_udp::UdpSocket::from_std(socket, &Handle::default()).expect("bad handle?"),
         )
     }
 
@@ -155,7 +155,7 @@ impl<T: RequestHandler> ServerFuture<T> {
         timeout: Duration,
     ) -> io::Result<()> {
         self.register_listener(
-            tokio_tcp::TcpListener::from_std(listener, &Handle::current())?,
+            tokio_tcp::TcpListener::from_std(listener, &Handle::default())?,
             timeout,
         )
     }


### PR DESCRIPTION
When the synchronous Resolver is instantiated, it will create a Tokio Runtime for it to perform DNS queries. Due to the nature of parallel requests, there will be multiple TLS streams established. This might be something we want to improve in the future, but is beyond the scope of this PR.

fixes #650