### PR TITLE
update ring to 0.14

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -74,7 +74,7 @@ log = "^0.4.1"
 openssl = { version = "^0.10", features = ["v102", "v110"], optional = true }
 radix_trie = "0.1.2"
 rand = "0.6"
-ring = { version = "0.13", features = ["rsa_signing"], optional = true }
+ring = { version = "0.14", features = ["rsa_signing"], optional = true }
 rustls = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true }
 tokio = "^0.1.6"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -61,7 +61,7 @@ lazy_static = "^1.0"
 log = "^0.4.1"
 openssl = { version = "^0.10", features = ["v102", "v110"], optional = true }
 rand = "0.6"
-ring = { version = "0.13.2", features = ["rsa_signing"], optional = true }
+ring = { version = "0.14", features = ["rsa_signing"], optional = true }
 serde = { version = "1.0", optional = true }
 smallvec = "^0.6"
 socket2 = { version = "^0.3.4", features = ["reuseport"] }


### PR DESCRIPTION
This updates ring to 0.14. I'm not aware of any other breaking changes that affect this crate since I can't find any changelog on the ring crate. So going to give this a run to see if anything breaks when the CI runs a build. 