### PR TITLE
Remove extra "/" that causes issue with dummy parsers

### DIFF
--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -159,7 +159,7 @@ pub enum RData {
     ///     /                   EXCHANGE                    /
     ///     /                                               /
     ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
-    ////
+    ///
     /// where:
     ///
     /// PREFERENCE      A 16 bit integer which specifies the preference given to
@@ -312,7 +312,7 @@ pub enum RData {
     /// RNAME           A <domain-name> which specifies the mailbox of the
     ///                 person responsible for this zone.
     ///
-    //// SERIAL          The unsigned 32 bit version number of the original copy
+    /// SERIAL          The unsigned 32 bit version number of the original copy
     ///                 of the zone.  Zone transfers preserve this value.  This
     ///                 value wraps and should be compared using sequence space
     ///                 arithmetic.


### PR DESCRIPTION
While this should be something that shouldn't cause troubles, the IntelliJ Rust plugin parser is unable to interpret any code after a comment line that contains 4 instead of 3 characters.

I have of course raised the issue with the IntelliJ-Rust plugin project ([here](https://github.com/intellij-rust/intellij-rust/issues/3379)), but given it's a typo, I thought: why not fix it?

BTW: I have done a quick "grep -r" on the repo and I couldn't find any other occurence of this.