### PR TITLE
Address #705

### DIFF
--- a/crates/client/src/serialize/txt/master.rs
+++ b/crates/client/src/serialize/txt/master.rs
@@ -361,7 +361,7 @@ impl Parser {
                 set.insert(record, 0);
             }
         }
-        return Ok(());
+        Ok(())
     }
 
     /// parses the string following the rules from:

--- a/crates/client/src/serialize/txt/master.rs
+++ b/crates/client/src/serialize/txt/master.rs
@@ -234,13 +234,13 @@ impl Parser {
                     //  tokens to pass into the processor
                     match t {
                         Token::EOL => {
-                            self.flush_record(
+                            Self::flush_record(
                                 record_parts,
-                                &mut origin,
-                                &mut current_name,
-                                &mut rtype,
+                                &origin,
+                                &current_name,
+                                rtype,
                                 &mut ttl,
-                                &mut class,
+                                class,
                                 &mut records,
                             )?;
                             State::StartLine
@@ -264,13 +264,13 @@ impl Parser {
 
         //Extra flush at the end for the case of missing endline
         if let State::Record(record_parts) = state {
-            self.flush_record(
+            Self::flush_record(
                 record_parts,
-                &mut origin,
-                &mut current_name,
-                &mut rtype,
+                &origin,
+                &current_name,
+                rtype,
                 &mut ttl,
-                &mut class,
+                class,
                 &mut records,
             )?;
         }
@@ -284,13 +284,12 @@ impl Parser {
     }
 
     fn flush_record(
-        &self,
         record_parts: Vec<String>,
-        origin: &mut Option<Name>,
-        current_name: &mut Option<Name>,
-        rtype: &mut Option<RecordType>,
+        origin: &Option<Name>,
+        current_name: &Option<Name>,
+        rtype: Option<RecordType>,
         ttl: &mut Option<u32>,
-        class: &mut Option<DNSClass>,
+        class: Option<DNSClass>,
         records: &mut BTreeMap<RrKey, RecordSet>,
     ) -> ParseResult<()> {
         // call out to parsers for difference record types

--- a/crates/server/tests/named_test_configs/default/nonewline.zone
+++ b/crates/server/tests/named_test_configs/default/nonewline.zone
@@ -1,0 +1,13 @@
+; replace the trust-dns.org with your own name
+$TTL 3D
+@               IN      SOA     trust-dns.org. root.trust-dns.org. (
+                                199609203       ; Serial
+                                28800   ; Refresh
+                                7200    ; Retry
+                                604800  ; Expire
+                                86400)  ; Minimum TTL
+
+nonewline.              A        127.0.0.1
+                        AAAA     ::1
+
+ensure.nonewline.       A        127.0.0.1


### PR DESCRIPTION
Add additional record flush in a lexer.

It will be useful if no newline was encountered and we still have a
record pending in a state object.

Added test to ensure that last is parsed correctly

Fixes: #705 