### PR TITLE
add endpoint name to server DoH

### DIFF
--- a/crates/server/src/config/dnssec.rs
+++ b/crates/server/src/config/dnssec.rs
@@ -195,6 +195,7 @@ impl Default for PrivateKeyType {
 #[derive(Deserialize, PartialEq, Debug)]
 pub struct TlsCertConfig {
     path: String,
+    endpoint_name: String,
     cert_type: Option<CertType>,
     password: Option<String>,
     private_key: Option<String>,
@@ -205,6 +206,11 @@ impl TlsCertConfig {
     /// path to the pkcs12 der formated certificate file
     pub fn get_path(&self) -> &Path {
         Path::new(&self.path)
+    }
+
+    /// return the DNS name of the certificate hosted at the TLS endpoint
+    pub fn get_endpoint_name(&self) -> &str {
+        &self.endpoint_name
     }
 
     /// Returns the format type of the certificate file

--- a/crates/server/src/named.rs
+++ b/crates/server/src/named.rs
@@ -546,7 +546,8 @@ fn config_https(
 
     for https_listener in https_listeners {
         info!(
-            "loading cert for DNS over TLS: {:?}",
+            "loading cert for DNS over TLS named {} from {:?}",
+            tls_cert_config.get_endpoint_name(),
             tls_cert_config.get_path()
         );
         // TODO: see about modifying native_tls to impl Clone for Pkcs12
@@ -555,12 +556,11 @@ fn config_https(
 
         info!("listening for HTTPS on {:?}", https_listener);
         server
-            // FIXME: need to passthrough the DNS authority name
             .register_https_listener(
                 https_listener,
                 config.get_tcp_request_timeout(),
                 tls_cert,
-                "ns.example.com".to_string(),
+                tls_cert_config.get_endpoint_name().to_string(),
             )
             .expect("could not register TLS listener");
     }

--- a/crates/server/tests/config_tests.rs
+++ b/crates/server/tests/config_tests.rs
@@ -244,7 +244,7 @@ fn test_parse_tls() {
     assert_eq!(config.get_tls_cert(), None);
 
     let config: Config = "
-tls_cert = { path = \"path/to/some.pkcs12\" }
+tls_cert = { path = \"path/to/some.pkcs12\", endpoint_name = \"ns.example.com\" }
 tls_listen_port = 8853
   "
     .parse()

--- a/crates/server/tests/named_test_configs/dns_over_https.toml
+++ b/crates/server/tests/named_test_configs/dns_over_https.toml
@@ -1,6 +1,6 @@
 listen_addrs_ipv4 = ["0.0.0.0"]
 
-tls_cert = { path = "sec/example.cert.pem", cert_type = "pem", private_key = "sec/example.key" }
+tls_cert = { path = "sec/example.cert.pem", endpoint_name = "ns.example.com", cert_type = "pem", private_key = "sec/example.key" }
 
 [[zones]]
 zone = "example.com"

--- a/crates/server/tests/named_test_configs/dns_over_tls.toml
+++ b/crates/server/tests/named_test_configs/dns_over_tls.toml
@@ -1,6 +1,6 @@
 listen_addrs_ipv4 = ["0.0.0.0"]
 
-tls_cert = { path = "sec/example.p12", password = "mypass" }
+tls_cert = { path = "sec/example.p12", endpoint_name = "ns.example.com", password = "mypass" }
 
 [[zones]]
 zone = "example.com"

--- a/crates/server/tests/named_test_configs/dns_over_tls_rustls_and_openssl.toml
+++ b/crates/server/tests/named_test_configs/dns_over_tls_rustls_and_openssl.toml
@@ -1,6 +1,7 @@
 listen_addrs_ipv4 = ["0.0.0.0"]
 
-tls_cert = { path = "sec/example.cert.pem", cert_type = "pem", private_key = "sec/example.key" }
+# endpoint 
+tls_cert = { path = "sec/example.cert.pem", endpoint_name = "ns.example.com", cert_type = "pem", private_key = "sec/example.key" }
 
 [[zones]]
 zone = "example.com"


### PR DESCRIPTION
this was hardcoded to ns.example.com before