### PR TITLE
Create a parser state

### DIFF
--- a/crates/client/src/serialize/txt/master.rs
+++ b/crates/client/src/serialize/txt/master.rs
@@ -411,7 +411,7 @@ impl ParserFields {
     }
 
     fn set_current_name(&mut self, name: Name) {
-        self.origin = Some(name)
+        self.current_name = Some(name)
     }
 
     //Sets current name to origin


### PR DESCRIPTION
Create a parser state object to try and reduce complexity of parsing function.

Original idea was to address #718 , but it seems like original `ttl` handling was actually RFC-compliant, so the only result of it is rathrer questionable refactoring.

Please feel free to close this MR, if it's not what you were looking for.