### PR TITLE
Generate meaningfull EdnsCodes from EdnsOptions

### DIFF
--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -468,7 +468,7 @@ impl<'a> From<&'a EdnsOption> for EdnsCode {
             EdnsOption::DHU(..) => EdnsCode::DHU,
             #[cfg(feature = "dnssec")]
             EdnsOption::N3U(..) => EdnsCode::N3U,
-            EdnsOption::Unknown(code, _) => EdnsCode::Unknown(code),
+            EdnsOption::Unknown(code, _) => code.into(),
         }
     }
 }


### PR DESCRIPTION
My use case is setting and potentially overwriting EDNS options in parsed Messages.

This is an example for an EDNS section:

```rust
Edns { rcode_high: 0, version: 0, dnssec_ok: false, max_payload: 4096,
  options: OPT { options: {Padding: Unknown(12, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])} } }
```
And here is how I try to modify the Padding option:

```rust
msg.edns_mut().set_option(
    EdnsOption::from((
        EdnsCode::Padding,
        &[1,2,3,4][..]
    ))
)
```

This is the result before my patch. Notice how there are two padding entries, but with the two different keys of `EdnsCode::Padding` and `EdnsCode::Unknown(12)`.

```rust
Edns { rcode_high: 0, version: 0, dnssec_ok: false, max_payload: 4096,
  options: OPT { options: {Padding: Unknown(12, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), Unknown(12): Unknown(12, [1, 2, 3, 4])} } }
```

This is what I want to get and what happens with this PR merged:

```rust
Edns { rcode_high: 0, version: 0, dnssec_ok: false, max_payload: 4096,
  options: OPT { options: {Padding: Unknown(12, [1, 2, 3, 4])} } }
```

Before this commit the `From<&'a EdnsOption> for EdnsCode` implementation
always created `Ednscode::Unknown` entries. This is a problem, because the
`OPT` type is keyed by an `EdnsCode` value, but `EdnsCode::Unknown(12)` and
`EdnsCode::Padding` are not compared as equal.

This change improves the situation by always creating the meaningfull
`EdnsCode` variants instead of `EdnsCode::Unknown`.

I don't know if this fully fixes the problem. While `EdnsCode::Unknown(12)` and `EdnsCode::Padding` are differently structured they should probably compare as equal, since they logically represent the same thing. So it might be necessary to change the `Eq` implementation to ensure that `EdnsCode::Padding == EdnsCode::Unknown(12)` is true.
