### PR TITLE
only enable socket2/reuseport for mDNS

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -43,7 +43,7 @@ dnssec = ["data-encoding"]
 serde-config = ["serde"]
 
 # enables experimental the mDNS (multicast) feature
-mdns = []
+mdns = ["socket2/reuseport"]
 
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
 # mtls = ["tls"]
@@ -66,7 +66,7 @@ rand = "0.6"
 ring = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true }
 smallvec = "^0.6"
-socket2 = { version = "^0.3.9", features = ["reuseport"] }
+socket2 = { version = "^0.3.9" }
 tokio-executor = "0.1.7"
 tokio-io = "^0.1"
 tokio-reactor = "^0.1"


### PR DESCRIPTION
Fixes: #778 