### PR TITLE
Introduce Unknown algorithm enum variant

### DIFF
--- a/crates/client/src/rr/dnssec/key_format.rs
+++ b/crates/client/src/rr/dnssec/key_format.rs
@@ -42,6 +42,9 @@ impl KeyFormat {
         let password = password.as_bytes();
 
         match algorithm {
+            Algorithm::Unknown(v) => { 
+                Err(format!("unknown algorithm: {}", v).into())
+            }
             #[cfg(feature = "openssl")]
             e @ Algorithm::RSASHA1 | e @ Algorithm::RSASHA1NSEC3SHA1 => {
                 Err(format!("unsupported Algorithm (insecure): {:?}", e).into())
@@ -142,6 +145,9 @@ impl KeyFormat {
         // generate the key
         #[allow(unused)]
         let key_pair: KeyPair<Private> = match algorithm {
+            Algorithm::Unknown(v) => {
+                return Err(format!("unknown algorithm: {}", v).into())
+            }
             #[cfg(feature = "openssl")]
             e @ Algorithm::RSASHA1 | e @ Algorithm::RSASHA1NSEC3SHA1 => {
                 return Err(format!("unsupported Algorithm (insecure): {:?}", e).into())

--- a/crates/client/src/rr/dnssec/keypair.rs
+++ b/crates/client/src/rr/dnssec/keypair.rs
@@ -445,6 +445,9 @@ impl KeyPair<Private> {
     /// RSA keys are hardcoded to 2048bits at the moment. Other keys have predefined sizes.
     pub fn generate(algorithm: Algorithm) -> DnsSecResult<Self> {
         match algorithm {
+            Algorithm::Unknown(_) => { 
+                Err(DnsSecErrorKind::Message("unknown algorithm").into())
+            }
             #[cfg(feature = "openssl")]
             Algorithm::RSASHA1
             | Algorithm::RSASHA1NSEC3SHA1
@@ -479,6 +482,9 @@ impl KeyPair<Private> {
     #[cfg(feature = "ring")]
     pub fn generate_pkcs8(algorithm: Algorithm) -> DnsSecResult<Vec<u8>> {
         match algorithm {
+            Algorithm::Unknown(_) => { 
+                Err(DnsSecErrorKind::Message("unknown algorithm").into())
+            }
             #[cfg(feature = "openssl")]
             Algorithm::RSASHA1
             | Algorithm::RSASHA1NSEC3SHA1

--- a/crates/proto/src/rr/dnssec/digest_type.rs
+++ b/crates/proto/src/rr/dnssec/digest_type.rs
@@ -144,6 +144,8 @@ impl From<Algorithm> for DigestType {
             Algorithm::RSASHA512 => DigestType::SHA512,
             Algorithm::ECDSAP384SHA384 => DigestType::SHA384,
             Algorithm::ED25519 => DigestType::ED25519,
+
+            Algorithm::Unknown(_) => DigestType::SHA512,
         }
     }
 }

--- a/crates/proto/src/rr/dnssec/public_key.rs
+++ b/crates/proto/src/rr/dnssec/public_key.rs
@@ -459,7 +459,6 @@ impl<'k> PublicKeyEnum<'k> {
             | Algorithm::RSASHA1NSEC3SHA1
             | Algorithm::RSASHA256
             | Algorithm::RSASHA512 => Ok(PublicKeyEnum::Rsa(Rsa::from_public_bytes(public_key)?)),
-            #[cfg(not(feature = "ring"))]
             _ => Err("public key algorithm not supported".into()),
         }
     }

--- a/util/src/bind_dnskey_to_pem.rs
+++ b/util/src/bind_dnskey_to_pem.rs
@@ -87,8 +87,10 @@ pub fn main() {
             .unwrap_or_else(|| panic!("bad algorithm format, expected '# STR': {}", next_line)),
     ).unwrap_or_else(|_| panic!("bad algorithm format, expected '# STR': {}", next_line));
 
-    let algorithm = Algorithm::from_u8(algorithm_num)
-        .unwrap_or_else(|_| panic!("unsupported algorithm: {}", next_line));
+    let algorithm = match Algorithm::from_u8(algorithm_num) {
+        Algorithm::Unknown(v) => panic!("unsupported algorithm {}: {}", v, next_line),
+        a => a,
+    };
 
     let pem_bytes = match algorithm {
         Algorithm::RSASHA256 => read_rsa(lines),

--- a/util/src/get_root_ksks.rs
+++ b/util/src/get_root_ksks.rs
@@ -55,9 +55,10 @@ pub fn main() {
                     Algorithm::RSASHA1
                     | Algorithm::RSASHA1NSEC3SHA1
                     | Algorithm::RSASHA256
-                    | Algorithm::RSASHA512 => "rsa",
-                    Algorithm::ECDSAP256SHA256 | Algorithm::ECDSAP384SHA384 => "ecdsa",
-                    Algorithm::ED25519 => "ed25519",
+                    | Algorithm::RSASHA512 => String::from("rsa"),
+                    Algorithm::ECDSAP256SHA256 | Algorithm::ECDSAP384SHA384 => String::from("ecdsa"),
+                    Algorithm::ED25519 => String::from("ed25519"),
+                    Algorithm::Unknown(v) => format!("unknown_{}",v),
                 };
 
                 let mut path = PathBuf::from("/tmp");


### PR DESCRIPTION
The [DNSSEC algorithm type spec](https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml) specifies type numbers that we do not currently handle and may expand unforeseeably in the future given the reserved identifier range. 

Introducing an `Unknown` variant to the Algorithm enum ensures that any logic using it is required to handle these future cases. 

Additionally, it fixes a bug in which the client fails to parse a response an RRSIG record containing a currently valid enum type number (253, reserved for private algorithms). 