### PR TITLE
Usage apt-get install pkg-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ presume that the trust-dns repos have already been synced to the local system:
   # note for openssl that a minimum version of 1.0.2 is required for TLS, 
   #  if this is an issue, TLS can be disabled (on the client), see below.
   $ apt-get install openssl
-  $ apt-get install libssl-dev
+  $ apt-get install libssl-dev pkg-config
 ```
 
 ## Testing


### PR DESCRIPTION
To build `trust-dns` on my Ubuntu system, I needed to install `pkg-config`. 
This is also mentioned at https://crates.io/crates/openssl/0.9.20.

I propose to update the README with instructions to `apt-get install pkg-config`.