### PR TITLE
[trust-dns-proto] abstract udpSocket

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -79,8 +79,9 @@ rustls = { version = "0.15", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 tokio = "^0.1.15"
 tokio-tcp = "^0.1"
+tokio-udp = "^0.1"
 trust-dns-https = {version = "0.3.0", path = "../https", optional = true }
-trust-dns-proto = {version = "0.7.3", path = "../proto", features = ["dnssec"]}
+trust-dns-proto = {version = "0.7.5", path = "../proto", features = ["dnssec"]}
 untrusted = { version = "^0.6", optional = true }
 webpki = { version = "0.19", optional = true }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -211,10 +211,12 @@
 //!
 //! ```rust
 //! # extern crate tokio;
+//! # extern crate tokio_udp;
 //! # extern crate trust_dns;
 //!
 //! use std::net::{Ipv4Addr, SocketAddr};
 //! use std::str::FromStr;
+//! use tokio_udp::UdpSocket;
 //! use tokio::runtime::current_thread::Runtime;
 //!
 //! use trust_dns::udp::UdpClientStream;
@@ -228,7 +230,7 @@
 //!
 //! // We need a connection, TCP and UDP are supported by DNS servers
 //! //   (tcp construction is slightly different as it needs a multiplexer)
-//! let stream = UdpClientStream::new(([8,8,8,8], 53).into());
+//! let stream = UdpClientStream::<UdpSocket>::new(([8,8,8,8], 53).into());
 //!
 //! // Create a new client, the bg is a background future which handles
 //! //   the multiplexing of the DNS requests to the server.
@@ -281,6 +283,7 @@ extern crate tokio_openssl;
 extern crate tokio_tcp;
 #[cfg(feature = "tokio-tls")]
 extern crate tokio_tls;
+extern crate tokio_udp;
 #[cfg(feature = "dns-over-https")]
 extern crate trust_dns_https;
 pub extern crate trust_dns_proto as proto;

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -57,7 +57,7 @@ tokio-reactor = "0.1"
 tokio-rustls = "0.9"
 tokio-tcp = "0.1"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.7.4", path = "../proto", features = ["tokio-compat"], default-features = false }
+trust-dns-proto = { version = "0.7.5", path = "../proto", features = ["tokio-compat"], default-features = false }
 trust-dns-rustls = { version = "0.6.0", path = "../rustls", default-features = false }
 typed-headers = "0.1"
 webpki-roots = { version = "0.16" }

--- a/crates/native-tls/Cargo.toml
+++ b/crates/native-tls/Cargo.toml
@@ -49,7 +49,7 @@ native-tls = "0.2"
 tokio-tcp = "0.1"
 tokio-tls = "0.2"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.7.4", path = "../proto", features = ["tokio-compat"], default-features = false }
+trust-dns-proto = { version = "0.7.5", path = "../proto", features = ["tokio-compat"], default-features = false }
 
 [dev-dependencies]
 tokio = "0.1.15"

--- a/crates/openssl/Cargo.toml
+++ b/crates/openssl/Cargo.toml
@@ -46,7 +46,7 @@ futures = "0.1.28"
 openssl = { version = "0.10", features = ["v102", "v110"] }
 tokio-openssl = "0.3"
 tokio-tcp = "0.1"
-trust-dns-proto = { version = "0.7.3", path = "../proto", features = ["openssl"] }
+trust-dns-proto = { version = "0.7.5", path = "../proto", features = ["openssl"] }
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["v102", "v110"] }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust-dns-proto"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2018"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
@@ -39,7 +39,7 @@ codecov = { repository = "bluejekyll/trust-dns", branch = "master", service = "g
 dnssec-openssl = ["dnssec", "openssl"]
 dnssec-ring = ["dnssec", "ring", "untrusted"]
 dnssec = ["data-encoding"]
-tokio-compat = ["tokio-tcp", "tokio-reactor"]
+tokio-compat = ["tokio-reactor", "tokio-tcp", "tokio-udp"]
 default = ["tokio-compat"]
 
 serde-config = ["serde"]
@@ -74,7 +74,7 @@ tokio-io = "^0.1"
 tokio-reactor = { version = "^0.1", optional = true}
 tokio-tcp = { version = "^0.1", optional = true }
 tokio-timer = "0.2.10"
-tokio-udp = "^0.1"
+tokio-udp = { version = "^0.1", optional = true }
 untrusted = { version = "^0.6", optional = true }
 url = "1.6.0"
 

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -43,6 +43,7 @@ extern crate tokio_io;
 #[cfg(feature = "tokio-compat")]
 extern crate tokio_tcp;
 extern crate tokio_timer;
+#[cfg(feature = "tokio-compat")]
 extern crate tokio_udp;
 #[cfg(feature = "ring")]
 extern crate untrusted;

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -39,7 +39,7 @@ pub struct MdnsStream {
     /// Multicast address used for mDNS queries
     multicast_addr: SocketAddr,
     /// This is used for sending and (directly) receiving messages
-    datagram: Option<UdpStream>,
+    datagram: Option<UdpStream<UdpSocket>>,
     /// In one-shot multicast, this will not join the multicast group
     multicast: Option<UdpSocket>,
 }

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -72,10 +72,11 @@ smallvec = "^0.6"
 tokio = { version = "^0.1.15", optional = true }
 tokio-executor = "^0.1.7"
 tokio-tcp = "^0.1"
+tokio-udp = "^0.1"
 trust-dns-https = { version = "0.3.0", path = "../https", optional = true }
 trust-dns-native-tls = { version = "0.6.0", path = "../native-tls", optional = true }
 trust-dns-openssl = { version = "0.6.0", path = "../openssl", optional = true }
-trust-dns-proto = { version = "0.7.3", path = "../proto" }
+trust-dns-proto = { version = "0.7.5", path = "../proto" }
 trust-dns-rustls = { version = "0.6.0", path = "../rustls", optional = true }
 webpki-roots = { version = "^0.16", optional = true }
 

--- a/crates/resolver/src/hosts.rs
+++ b/crates/resolver/src/hosts.rs
@@ -63,7 +63,7 @@ impl Hosts {
             .or_insert_with(LookupType::default);
 
         let new_lookup = {
-            let mut old_lookup = match record_type {
+            let old_lookup = match record_type {
                 RecordType::A => lookup_type.a.get_or_insert_with(|| {
                     let query = Query::query(name.clone(), record_type);
                     Lookup::new_with_max_ttl(query, Arc::new(vec![]))

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -203,6 +203,7 @@ extern crate smallvec;
 extern crate tokio;
 extern crate tokio_executor;
 extern crate tokio_tcp;
+extern crate tokio_udp;
 #[cfg(feature = "dns-over-https")]
 extern crate trust_dns_https;
 #[cfg(feature = "dns-over-native-tls")]

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -16,9 +16,9 @@ use proto::op::ResponseCode;
 use proto::xfer::{DnsHandle, DnsRequest, DnsResponse};
 
 use config::{ResolverConfig, ResolverOpts};
-use name_server::{NameServer, ConnectionHandle, ConnectionProvider, StandardConnection};
 #[cfg(feature = "mdns")]
 use name_server;
+use name_server::{ConnectionHandle, ConnectionProvider, NameServer, StandardConnection};
 
 /// A pool of NameServers
 ///
@@ -56,7 +56,8 @@ impl<C: DnsHandle + 'static, P: ConnectionProvider<ConnHandle = C> + 'static> Na
                     *options,
                     conn_provider.clone(),
                 )
-            }).collect();
+            })
+            .collect();
 
         let stream_conns: Vec<NameServer<C, P>> = config
             .name_servers()
@@ -68,7 +69,8 @@ impl<C: DnsHandle + 'static, P: ConnectionProvider<ConnHandle = C> + 'static> Na
                     *options,
                     conn_provider.clone(),
                 )
-            }).collect();
+            })
+            .collect();
 
         NameServerPool {
             datagram_conns: Arc::new(Mutex::new(datagram_conns)),
@@ -231,7 +233,7 @@ where
                         // TODO: restrict this size to a maximum # of NameServers to try
                         // get a stable view for trying all connections
                         //   we split into chunks of the number of parallel requests to issue
-                        let mut conns: Vec<NameServer<C, P>> = conns.clone();
+                        let conns: Vec<NameServer<C, P>> = conns.clone();
                         let request = request.take();
                         let request = request.expect("bad state, message should never be None");
                         let request_loop = request.clone();
@@ -385,8 +387,8 @@ mod tests {
     use proto::xfer::{DnsHandle, DnsRequestOptions};
 
     use super::*;
-    use config::Protocol;
     use config::NameServerConfig;
+    use config::Protocol;
 
     #[ignore]
     // because of there is a real connection that needs a reasonable timeout
@@ -423,7 +425,8 @@ mod tests {
                     .block_on(pool.lookup(
                         Query::query(name.clone(), RecordType::A),
                         DnsRequestOptions::default()
-                    )).is_err(),
+                    ))
+                    .is_err(),
                 "iter: {}",
                 i
             );
@@ -435,7 +438,8 @@ mod tests {
                     .block_on(pool.lookup(
                         Query::query(name.clone(), RecordType::A),
                         DnsRequestOptions::default()
-                    )).is_ok(),
+                    ))
+                    .is_ok(),
                 "iter: {}",
                 i
             );

--- a/crates/rustls/Cargo.toml
+++ b/crates/rustls/Cargo.toml
@@ -50,7 +50,7 @@ rustls = "0.15"
 tokio-rustls = "0.9"
 tokio-tcp = "^0.1"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.7.4", path = "../proto", features = ["tokio-compat"], default-features = false }
+trust-dns-proto = { version = "0.7.5", path = "../proto", features = ["tokio-compat"], default-features = false }
 webpki = "0.19"
 
 [dev-dependencies]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -101,7 +101,7 @@ tokio-udp = "0.1"
 toml = "0.5"
 trust-dns = { version = "0.16.0", path = "../client" }
 trust-dns-https = { version = "0.3.0", path = "../https", optional = true }
-trust-dns-proto = { version = "0.7.3", path = "../proto" }
+trust-dns-proto = { version = "0.7.5", path = "../proto" }
 trust-dns-openssl = { version = "0.6.0", path = "../openssl", optional = true }
 trust-dns-resolver = { version = "0.11.0", path = "../resolver", features = ["serde-config"], optional = true }
 trust-dns-rustls = { version = "0.6.0", path = "../rustls", optional = true }

--- a/crates/server/benches/comparison_benches.rs
+++ b/crates/server/benches/comparison_benches.rs
@@ -4,6 +4,7 @@ extern crate futures;
 extern crate test;
 extern crate tokio;
 extern crate tokio_tcp;
+extern crate tokio_udp;
 
 extern crate trust_dns;
 extern crate trust_dns_proto;
@@ -24,6 +25,7 @@ use futures::Future;
 use test::Bencher;
 use tokio::runtime::current_thread::Runtime;
 use tokio_tcp::TcpStream;
+use tokio_tcp::UdpSocket;
 
 use trust_dns::client::*;
 use trust_dns::op::*;
@@ -61,7 +63,7 @@ fn wrap_process(named: Child, server_port: u16) -> NamedProcess {
             .unwrap()
             .next()
             .unwrap();
-        let stream = UdpClientStream::new(addr);
+        let stream = UdpClientStream::<UdpSocket>::new(addr);
         let (bg, mut client) = ClientFuture::connect(stream);
         io_loop.spawn(bg);
 
@@ -158,7 +160,7 @@ fn trust_dns_udp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr);
+    let stream = UdpClientStream::<UdpSocket>::new(addr);
     bench(b, stream);
 
     // cleaning up the named process
@@ -175,7 +177,7 @@ fn trust_dns_udp_bench_prof(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr);
+    let stream = UdpClientStream::<UdpSocket>::new(addr);
     bench(b, stream);
 }
 
@@ -244,7 +246,7 @@ fn bind_udp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr);
+    let stream = UdpClientStream::<UdpSocket>::new(addr);
     bench(b, stream);
 
     // cleaning up the named process

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -634,7 +634,7 @@ impl InMemoryAuthority {
         }
 
         // sign all record_sets, as of 0.12.1 this includes DNSKEY
-        for mut rr_set_orig in records.values_mut() {
+        for rr_set_orig in records.values_mut() {
             // because the rrset is an Arc, it must be cloned before mutated
             let rr_set = Arc::make_mut(rr_set_orig);
             Self::sign_rrset(rr_set, secure_keys, minimum_ttl, self.class)?;

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -779,7 +779,7 @@ impl SqliteAuthority {
                 DNSClass::NONE => {
                     info!("deleting specific record: {:?}", rr);
                     // NONE     rrset    rr       Delete an RR from an RRset
-                    if let Some(mut rrset) = self.records_mut().get_mut(&rr_key) {
+                    if let Some(rrset) = self.records_mut().get_mut(&rr_key) {
                         // b/c this is an Arc, we need to clone, then remove, and replace the node.
                         let mut rrset_clone: RecordSet = RecordSet::clone(&*rrset);
                         let deleted = rrset_clone.remove(rr, serial);

--- a/crates/server/tests/z_named_tests.rs
+++ b/crates/server/tests/z_named_tests.rs
@@ -12,6 +12,7 @@ extern crate futures;
 extern crate log;
 extern crate tokio;
 extern crate tokio_tcp;
+extern crate tokio_udp;
 extern crate trust_dns;
 extern crate trust_dns_proto;
 extern crate trust_dns_server;
@@ -27,6 +28,7 @@ use std::str::FromStr;
 
 use tokio::runtime::current_thread::Runtime;
 use tokio_tcp::TcpStream as TokioTcpStream;
+use tokio_udp::UdpSocket as TokioUdpSocket;
 
 use trust_dns::client::*;
 use trust_dns::op::ResponseCode;
@@ -192,7 +194,7 @@ fn test_server_continues_on_bad_data_udp() {
     named_test_harness("example.toml", |port, _, _| {
         let mut io_loop = Runtime::new().unwrap();
         let addr: SocketAddr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), port);
-        let stream = UdpClientStream::new(addr);
+        let stream = UdpClientStream::<TokioUdpSocket>::new(addr);
         let (bg, mut client) = ClientFuture::connect(stream);
 
         io_loop.spawn(bg);
@@ -209,7 +211,7 @@ fn test_server_continues_on_bad_data_udp() {
 
         // just tests that multiple queries work
         let addr: SocketAddr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), port);
-        let stream = UdpClientStream::new(addr);
+        let stream = UdpClientStream::<TokioUdpSocket>::new(addr);
         let (bg, mut client) = ClientFuture::connect(stream);
         io_loop.spawn(bg);
 

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -7,6 +7,7 @@ extern crate openssl;
 extern crate rustls;
 extern crate tokio;
 extern crate tokio_tcp;
+extern crate tokio_udp;
 extern crate trust_dns;
 #[cfg(feature = "dns-over-https")]
 extern crate trust_dns_https;
@@ -25,6 +26,7 @@ use chrono::Duration;
 use futures::Future;
 use tokio::runtime::current_thread::Runtime;
 use tokio_tcp::TcpStream as TokioTcpStream;
+use tokio_udp::UdpSocket as TokioUdpSocket;
 
 use trust_dns::client::{BasicClientHandle, ClientFuture, ClientHandle};
 use trust_dns::error::ClientErrorKind;
@@ -66,7 +68,7 @@ fn test_query_nonet() {
 fn test_query_udp_ipv4() {
     let mut io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let stream = UdpClientStream::new(addr);
+    let stream = UdpClientStream::<TokioUdpSocket>::new(addr);
     let (bg, mut client) = ClientFuture::connect(stream);
     io_loop.spawn(bg);
 
@@ -84,7 +86,7 @@ fn test_query_udp_ipv6() {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr);
+    let stream = UdpClientStream::<TokioUdpSocket>::new(addr);
     let (bg, mut client) = ClientFuture::connect(stream);
     io_loop.spawn(bg);
 
@@ -926,7 +928,8 @@ fn test_timeout_query_udp() {
         .next()
         .unwrap();
 
-    let stream = UdpClientStream::with_timeout(addr, std::time::Duration::from_millis(1));
+    let stream =
+        UdpClientStream::<TokioUdpSocket>::with_timeout(addr, std::time::Duration::from_millis(1));
     let (bg, client) = ClientFuture::connect(stream);
     io_loop.spawn(bg);
     test_timeout_query(client, io_loop);

--- a/tests/integration-tests/tests/secure_client_handle_tests.rs
+++ b/tests/integration-tests/tests/secure_client_handle_tests.rs
@@ -3,6 +3,7 @@
 extern crate futures;
 extern crate tokio;
 extern crate tokio_tcp;
+extern crate tokio_udp;
 extern crate trust_dns;
 extern crate trust_dns_integration;
 extern crate trust_dns_proto;
@@ -14,6 +15,7 @@ use std::sync::{Arc, Mutex};
 
 use tokio::runtime::current_thread::Runtime;
 use tokio_tcp::TcpStream as TokioTcpStream;
+use tokio_udp::UdpSocket as TokioUdpSocket;
 
 use trust_dns::client::{
     BasicClientHandle, ClientFuture, ClientHandle, MemoizeClientHandle, SecureClientHandle,
@@ -254,7 +256,10 @@ where
 
 fn with_udp<F>(test: F)
 where
-    F: Fn(SecureDnsHandle<MemoizeClientHandle<BasicClientHandle<UdpResponse>>>, Runtime),
+    F: Fn(
+        SecureDnsHandle<MemoizeClientHandle<BasicClientHandle<UdpResponse<TokioUdpSocket>>>>,
+        Runtime,
+    ),
 {
     let succeeded = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let succeeded_clone = succeeded.clone();

--- a/tests/integration-tests/tests/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/sqlite_authority_tests.rs
@@ -889,7 +889,7 @@ fn test_zone_signing() {
             continue;
         }
 
-        let mut inner_results = authority
+        let inner_results = authority
             .lookup(
                 &authority.origin(),
                 RecordType::AXFR,


### PR DESCRIPTION
- Abstract trust_dns_proto::UdpStream and related types
- Make tokio-udp as optional dependencies
- Run rustfmt on the files modifed
- Fix clippy errors