### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,6 @@ dependencies = [
 name = "trust-dns-proto"
 version = "0.7.5"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-as-inner 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -55,7 +55,6 @@ name = "trust_dns_proto"
 path = "src/lib.rs"
 
 [dependencies]
-byteorder = "^1.2"
 data-encoding = { version = "2.1.0", optional = true }
 enum-as-inner = "0.2"
 failure = "0.1"

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -11,7 +11,6 @@
 
 //! Trust-DNS Protocol library
 
-extern crate byteorder;
 #[cfg(feature = "dnssec")]
 extern crate data_encoding;
 #[macro_use]

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use byteorder::{ByteOrder, NetworkEndian};
 use crate::error::{ProtoError, ProtoErrorKind, ProtoResult};
 use crate::serialize::binary::Restrict;
 
@@ -193,7 +192,7 @@ impl<'a> BinDecoder<'a> {
     ///
     /// Return the u16 from the buffer
     pub fn read_u16(&mut self) -> ProtoResult<Restrict<u16>> {
-        Ok(self.read_slice(2)?.map(|s| NetworkEndian::read_u16(s)))
+        Ok(self.read_slice(2)?.map(|s| u16::from_be_bytes([s[0], s[1]])))
     }
 
     /// Reads the next four bytes into i32.
@@ -205,7 +204,7 @@ impl<'a> BinDecoder<'a> {
     ///
     /// Return the i32 from the buffer
     pub fn read_i32(&mut self) -> ProtoResult<Restrict<i32>> {
-        Ok(self.read_slice(4)?.map(|s| NetworkEndian::read_i32(s)))
+        Ok(self.read_slice(4)?.map(|s| i32::from_be_bytes([s[0], s[1], s[2], s[3]])))
     }
 
     /// Reads the next four bytes into u32.
@@ -217,7 +216,7 @@ impl<'a> BinDecoder<'a> {
     ///
     /// Return the u32 from the buffer
     pub fn read_u32(&mut self) -> ProtoResult<Restrict<u32>> {
-        Ok(self.read_slice(4)?.map(|s| NetworkEndian::read_u32(s)))
+        Ok(self.read_slice(4)?.map(|s| u32::from_be_bytes([s[0], s[1], s[2], s[3]])))
     }
 }
 

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -15,8 +15,6 @@
  */
 use std::marker::PhantomData;
 
-use byteorder::{ByteOrder, NetworkEndian};
-
 use crate::error::{ProtoErrorKind, ProtoResult};
 
 use super::BinEncodable;
@@ -312,29 +310,17 @@ impl<'a> BinEncoder<'a> {
 
     /// Writes a u16 in network byte order to the buffer
     pub fn emit_u16(&mut self, data: u16) -> ProtoResult<()> {
-        let mut bytes = [0; 2];
-        {
-            NetworkEndian::write_u16(&mut bytes, data);
-        }
-        self.write_slice(&bytes)
+        self.write_slice(&data.to_be_bytes())
     }
 
     /// Writes an i32 in network byte order to the buffer
     pub fn emit_i32(&mut self, data: i32) -> ProtoResult<()> {
-        let mut bytes = [0; 4];
-        {
-            NetworkEndian::write_i32(&mut bytes, data);
-        }
-        self.write_slice(&bytes)
+        self.write_slice(&data.to_be_bytes())
     }
 
     /// Writes an u32 in network byte order to the buffer
     pub fn emit_u32(&mut self, data: u32) -> ProtoResult<()> {
-        let mut bytes = [0; 4];
-        {
-            NetworkEndian::write_u32(&mut bytes, data);
-        }
-        self.write_slice(&bytes)
+        self.write_slice(&data.to_be_bytes())
     }
 
     fn write_slice(&mut self, data: &[u8]) -> ProtoResult<()> {


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is not strictly needed since the `stdlib`-implementations went stable in 1.32. Dropping a dependency is worth the small change IMHO.