### PR TITLE
Disable the backtrace feature from failure when possible

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -40,6 +40,7 @@ appveyor = { repository = "bluejekyll/trust-dns", branch = "master", service = "
 codecov = { repository = "bluejekyll/trust-dns", branch = "master", service = "github" }
 
 [features]
+default = ["failure-backtrace"]
 # TODO: the rustls and openssl crates are not deps... should we change that to make them easier to use?
 #  or change this to also be external?
 dns-over-https-openssl = ["dns-over-https", "dns-over-openssl"]
@@ -56,6 +57,8 @@ dnssec = []
 
 serde-config = ["serde"]
 
+failure-backtrace = ["failure/backtrace"]
+
 # enables experimental the mDNS (multicast) feature
 mdns = ["trust-dns-proto/mdns"]
 
@@ -67,7 +70,7 @@ path = "src/lib.rs"
 chrono = "^0.4"
 data-encoding = "2.1.0"
 data-encoding-macro = "0.1.7"
-failure = "0.1"
+failure = { version = "0.1", default-features = false }
 futures = "^0.1.28"
 lazy_static = "^1.0"
 log = "^0.4.8"

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -34,7 +34,9 @@ travis-ci = { repository = "bluejekyll/trust-dns" }
 appveyor = { repository = "bluejekyll/trust-dns", branch = "master", service = "github" }
 codecov = { repository = "bluejekyll/trust-dns", branch = "master", service = "github" }
 
-#[features]
+[features]
+default = ["failure-backtrace"]
+failure-backtrace = ["failure/backtrace"]
 
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
 # mtls = ["tls"]
@@ -46,7 +48,7 @@ path = "src/lib.rs"
 [dependencies]
 bytes = "0.4"
 data-encoding = "2.1.0"
-failure = "0.1"
+failure = { version = "0.1", default-features = false }
 futures = "0.1.28"
 h2 = "0.1"
 http = "0.1"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -40,12 +40,14 @@ dnssec-openssl = ["dnssec", "openssl"]
 dnssec-ring = ["dnssec", "ring"]
 dnssec = ["data-encoding"]
 tokio-compat = ["tokio-reactor", "tokio-tcp", "tokio-udp"]
-default = ["tokio-compat"]
+default = ["tokio-compat", "failure-backtrace"]
 
 serde-config = ["serde"]
 
 # enables experimental the mDNS (multicast) feature
 mdns = ["socket2/reuseport"]
+
+failure-backtrace = ["failure/backtrace"]
 
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
 # mtls = ["tls"]
@@ -57,7 +59,7 @@ path = "src/lib.rs"
 [dependencies]
 data-encoding = { version = "2.1.0", optional = true }
 enum-as-inner = "0.2"
-failure = "0.1"
+failure = { version = "0.1", default-features = false }
 futures = "^0.1.28"
 idna = "^0.2.0"
 lazy_static = "^1.0"

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -35,7 +35,7 @@ appveyor = { repository = "bluejekyll/trust-dns", branch = "master", service = "
 codecov = { repository = "bluejekyll/trust-dns", branch = "master", service = "github" }
 
 [features]
-default = ["tokio"]
+default = ["tokio", "failure-backtrace"]
 dns-over-native-tls = ["dns-over-tls", "trust-dns-native-tls"]
 # DNS over TLS with OpenSSL currently needs a good way to set default CAs, use rustls or native-tls
 dns-over-openssl = ["dns-over-tls", "trust-dns-openssl"]
@@ -54,13 +54,15 @@ serde-config = ["serde", "trust-dns-proto/serde-config"]
 
 mdns = ["trust-dns-proto/mdns"]
 
+failure-backtrace = ["failure/backtrace"]
+
 [lib]
 name = "trust_dns_resolver"
 path = "src/lib.rs"
 
 [dependencies]
 cfg-if = "0.1"
-failure = "0.1"
+failure = { version = "0.1", default-features = false }
 futures = "^0.1.28"
 lazy_static = "^1.0"
 log = "^0.4.8"


### PR DESCRIPTION
One of the most common C dependencies I come across in Rust projects is `libbacktrace`, which is the default backtrace implementation for the `backtrace` crate, which is a dependency of `failure` when default features are enabled.

Not all projects need backtraces, and in many environments C dependencies make building and deployment harder.

It's not possible for a crate that depends on, e.g., `trust-dns-resolver` to _remove_ the `backtrace` feature from `failure`, because features are strictly additive.

This PR turns off default features for `failure` on the proto, client, resolver and https crates, allowing crates that depend on these crates to switch off the `backtrace` feature if they want to, eliminating the C dependency.

I didn't turn off default features for the `server` crate because it already depends on `backtrace` directly.