### PR TITLE
Deserialize default resolv opts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.idea/
 
 *.swp
 

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -499,6 +499,7 @@ impl Default for LookupIpStrategy {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize))]
 #[allow(dead_code)] // TODO: remove after all params are supported
+#[serde(default)]
 pub struct ResolverOpts {
     /// Sets the number of dots that must appear (unless it's a final dot representing the root)
     ///  that must appear before a query is assumed to include the TLD. The default is one, which

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -497,9 +497,8 @@ impl Default for LookupIpStrategy {
 
 /// Configuration for the Resolver
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize), serde(default))]
 #[allow(dead_code)] // TODO: remove after all params are supported
-#[serde(default)]
 pub struct ResolverOpts {
     /// Sets the number of dots that must appear (unless it's a final dot representing the root)
     ///  that must appear before a query is assumed to include the TLD. The default is one, which


### PR DESCRIPTION
In order to specify in the config file only those parameters that need to be overidden.