### PR TITLE
Add accessors for the CAA `KeyValue` type

### DIFF
--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -663,6 +663,16 @@ impl KeyValue {
             value: value.into(),
         }
     }
+
+    /// Gets a reference to the key of the pair.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Gets a reference to the value of the pair.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
 }
 
 /// Read the binary CAA format


### PR DESCRIPTION
These are needed to get at the KeyValue pair's contents outside of
the `trust-dns-proto` crate.