### PR TITLE
Allow parsing DNSSEC record types

### DIFF
--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -27,6 +27,8 @@ pub mod nsec3;
 pub mod nsec3param;
 pub mod sig;
 
+use std::str::FromStr;
+
 use crate::error::*;
 use crate::rr::rdata::null;
 use crate::rr::rdata::NULL;
@@ -68,6 +70,24 @@ pub enum DNSSECRecordType {
     SIG,
     /// Unknown or not yet supported DNSSec record type
     Unknown(u16),
+}
+
+impl FromStr for DNSSECRecordType {
+    type Err = ProtoError;
+
+    fn from_str(str: &str) -> ProtoResult<Self> {
+        match str {
+            "DNSKEY" => Ok(DNSSECRecordType::DNSKEY),
+            "DS" => Ok(DNSSECRecordType::DS),
+            "KEY" => Ok(DNSSECRecordType::KEY),
+            "NSEC" => Ok(DNSSECRecordType::NSEC),
+            "NSEC3" => Ok(DNSSECRecordType::NSEC3),
+            "NSEC3PARAM" => Ok(DNSSECRecordType::NSEC3PARAM),
+            "RRSIG" => Ok(DNSSECRecordType::RRSIG),
+            "SIG" => Ok(DNSSECRecordType::SIG),
+            _ => Err(ProtoErrorKind::UnknownRecordTypeStr(str.to_string()).into()),
+        }
+    }
 }
 
 impl From<u16> for DNSSECRecordType {


### PR DESCRIPTION
This now delegates the missing DNSSEC record type names in `RecordType::from_str()` to the newly added `FromStr` implementation for `DNSSECRecordType`.

A basic unit test doing a round-trip test of all names is included.

----

I'm not totally sure if this is the right way to go about this, but I figured since `DNSSECRecordType` can be converted to `&static str`, the corresponding `FromStr` implementation is probably desired as well, plus it seems in line with how `impl From<u16> for RecordType` is handled.