### PR TITLE
Add `valid_until` method for specific resolver lookup results

### DIFF
--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -417,6 +417,11 @@ macro_rules! lookup_type {
             pub fn query(&self) -> &Query {
                 self.0.query()
             }
+
+            /// Returns the `Instant` at which this result is no longer valid.
+            pub fn valid_until(&self) -> Instant {
+                self.0.valid_until()
+            }
         }
 
         impl From<Lookup> for $l {


### PR DESCRIPTION
----

This appeared to be an omission to me; its was when trying to construct `ResolveErrorKind::NoRecordsFound` given a lookup result, which contains a `valid_until` field when I noticed the specialized lookup results don't have this method.