### PR TITLE
Add resolver methods for SOA and NS records

### DIFF
--- a/crates/resolver/src/async_resolver/mod.rs
+++ b/crates/resolver/src/async_resolver/mod.rs
@@ -321,6 +321,8 @@ impl AsyncResolver {
     lookup_fn!(ipv4_lookup, lookup::Ipv4LookupFuture, RecordType::A);
     lookup_fn!(ipv6_lookup, lookup::Ipv6LookupFuture, RecordType::AAAA);
     lookup_fn!(mx_lookup, lookup::MxLookupFuture, RecordType::MX);
+    lookup_fn!(ns_lookup, lookup::NsLookupFuture, RecordType::NS);
+    lookup_fn!(soa_lookup, lookup::SoaLookupFuture, RecordType::SOA);
     #[deprecated(note = "use lookup_srv instead, this interface is not ideal")]
     lookup_fn!(srv_lookup, lookup::SrvLookupFuture, RecordType::SRV);
     lookup_fn!(txt_lookup, lookup::TxtLookupFuture, RecordType::TXT);

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -532,6 +532,22 @@ lookup_type!(
     RData::TXT,
     rdata::TXT
 );
+lookup_type!(
+    SoaLookup,
+    SoaLookupIter,
+    SoaLookupIntoIter,
+    SoaLookupFuture,
+    RData::SOA,
+    rdata::SOA
+);
+lookup_type!(
+    NsLookup,
+    NsLookupIter,
+    NsLookupIntoIter,
+    NsLookupFuture,
+    RData::NS,
+    Name
+);
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -163,6 +163,8 @@ impl Resolver {
     lookup_fn!(ipv4_lookup, lookup::Ipv4Lookup);
     lookup_fn!(ipv6_lookup, lookup::Ipv6Lookup);
     lookup_fn!(mx_lookup, lookup::MxLookup);
+    lookup_fn!(ns_lookup, lookup::NsLookup);
+    lookup_fn!(soa_lookup, lookup::SoaLookup);
     #[deprecated(note = "use lookup_srv instead, this interface is not ideal")]
     lookup_fn!(srv_lookup, lookup::SrvLookup);
     lookup_fn!(txt_lookup, lookup::TxtLookup);


### PR DESCRIPTION
These are useful if you want to use the resolver to retrieve:

- The domain master address, to know where to send DNS UPDATE
  messages to.
- The authoritative nameservers for a domain, to monitor them for the
  propagation of an update.

----

@blujekyll: I know you are busy on PR #849, so don't feel obliged to
handle my PRs; I can rebase them when #849 has landed.