### PR TITLE
deny all audit warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,9 +140,7 @@ matrix:
         - cargo install cargo-audit
         - cargo check
       script:
-        # --ignore ref: https://github.com/crossbeam-rs/crossbeam/issues/401
-        # tokio -> tokio-threadpool -> crossbeam-deque -> crossbeam-epoch -> memoffset
-        - cargo audit --ignore RUSTSEC-2019-0011
+        - cargo audit --deny-warnings
 
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
fixes: #887

adds the --deny-warnings flag to cargo audit