### PR TITLE
Allow for custom rustls::ClientConfig to be passed to the Resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,7 @@ dependencies = [
  "trust-dns-proto 0.18.0-alpha.1",
  "trust-dns-rustls 0.18.0-alpha.1",
  "trust-dns-server 0.18.0-alpha.1",
+ "webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -90,3 +90,4 @@ env_logger = "0.7"
 native-tls = "0.2"
 trust-dns-native-tls = { version = "0.18.0-alpha", path = "../crates/native-tls" }
 trust-dns-https = { version = "0.18.0-alpha", path = "../crates/https" }
+webpki-roots = { version = "^0.18" }

--- a/crates/client/src/https_client_connection.rs
+++ b/crates/client/src/https_client_connection.rs
@@ -54,7 +54,7 @@ impl ClientConnection for HttpsClientConnection {
     ) -> Self::SenderFuture {
         // TODO: maybe signer needs to be applied in https...
         let https_builder =
-            HttpsClientStreamBuilder::with_client_config(self.client_config.clone());
+            HttpsClientStreamBuilder::with_client_config(Arc::new(self.client_config.clone()));
         https_builder.build(self.name_server, self.dns_name.clone())
     }
 }

--- a/crates/https/src/https_client_stream.rs
+++ b/crates/https/src/https_client_stream.rs
@@ -541,6 +541,7 @@ mod tests {
         let mut client_config = ClientConfig::new();
         client_config.root_store = root_store;
         client_config.versions = versions;
+        client_config.alpn_protocols.push(ALPN_H2.to_vec());
 
         let https_builder = HttpsClientStreamBuilder::with_client_config(Arc::new(client_config));
         let connect = https_builder.build(cloudflare, "cloudflare-dns.com".to_string());

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -231,6 +231,8 @@ where
         socket_addr: *MDNS_IPV4,
         protocol: Protocol::Mdns,
         tls_dns_name: None,
+        #[cfg(feature = "dns-over-rustls")]
+        tls_config: None,
     };
     NameServer::new_with_provider(config, options, conn_provider)
 }
@@ -260,6 +262,8 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         };
         let mut io_loop = Runtime::new().unwrap();
         let name_server = future::lazy(|_| {
@@ -286,6 +290,8 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 252),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         };
         let mut io_loop = Runtime::new().unwrap();
         let name_server =

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -53,11 +53,16 @@ impl<C: DnsHandle + 'static, P: ConnectionProvider<ConnHandle = C> + 'static> Na
             .iter()
             .filter(|ns_config| ns_config.protocol.is_datagram())
             .map(|ns_config| {
-                NameServer::<C, P>::new_with_provider(
-                    ns_config.clone(),
-                    *options,
-                    conn_provider.clone(),
-                )
+                #[cfg(feature = "dns-over-rustls")]
+                let ns_config = {
+                    let mut ns_config = ns_config.clone();
+                    ns_config.tls_config = config.client_config().clone();
+                    ns_config
+                };
+                #[cfg(not(feature = "dns-over-rustls"))]
+                let ns_config = { ns_config.clone() };
+
+                NameServer::<C, P>::new_with_provider(ns_config, *options, conn_provider.clone())
             })
             .collect();
 
@@ -66,11 +71,16 @@ impl<C: DnsHandle + 'static, P: ConnectionProvider<ConnHandle = C> + 'static> Na
             .iter()
             .filter(|ns_config| ns_config.protocol.is_stream())
             .map(|ns_config| {
-                NameServer::<C, P>::new_with_provider(
-                    ns_config.clone(),
-                    *options,
-                    conn_provider.clone(),
-                )
+                #[cfg(feature = "dns-over-rustls")]
+                let ns_config = {
+                    let mut ns_config = ns_config.clone();
+                    ns_config.tls_config = config.client_config().clone();
+                    ns_config
+                };
+                #[cfg(not(feature = "dns-over-rustls"))]
+                let ns_config = { ns_config.clone() };
+
+                NameServer::<C, P>::new_with_provider(ns_config, *options, conn_provider.clone())
             })
             .collect();
 

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -341,12 +341,16 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 253),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         };
 
         let config2 = NameServerConfig {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         };
 
         let mut resolver_config = ResolverConfig::new();

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -64,11 +64,15 @@ fn into_resolver_config(
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         });
         nameservers.push(NameServerConfig {
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         });
     }
     if nameservers.is_empty() {
@@ -115,11 +119,15 @@ mod tests {
                 socket_addr: addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
+                #[cfg(feature = "dns-over-rustls")]
+                tls_config: None,
             },
             NameServerConfig {
                 socket_addr: addr,
                 protocol: Protocol::Tcp,
                 tls_dns_name: None,
+                #[cfg(feature = "dns-over-rustls")]
+                tls_config: None,
             },
         ]
     }

--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -32,11 +32,15 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         });
         name_servers.push(NameServerConfig {
             socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         });
     }
     Ok(name_servers)

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -24,6 +24,8 @@ use trust_dns_rustls::{tls_client_connect, TlsClientStream};
 
 use crate::config::TlsClientConfig;
 
+const ALPN_H2: &[u8] = b"h2";
+
 lazy_static! {
     // using the mozilla default root store
     pub(crate) static ref CLIENT_CONFIG: Arc<ClientConfig> = {
@@ -34,6 +36,7 @@ lazy_static! {
         let mut client_config = ClientConfig::new();
         client_config.root_store = root_store;
         client_config.versions = versions;
+        client_config.alpn_protocols.push(ALPN_H2.to_vec());
 
         Arc::new(client_config)
     };

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -13,7 +13,7 @@ mod dns_over_rustls;
 
 cfg_if! {
     if #[cfg(feature = "dns-over-rustls")] {
-        pub(crate) use self::dns_over_rustls::new_tls_stream;
+        pub(crate) use self::dns_over_rustls::{new_tls_stream, CLIENT_CONFIG};
     } else if #[cfg(feature = "dns-over-native-tls")] {
         pub(crate) use self::dns_over_native_tls::new_tls_stream;
     } else if #[cfg(feature = "dns-over-openssl")] {

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -132,6 +132,8 @@ fn test_query_https() {
     use rustls::{ClientConfig, ProtocolVersion, RootCertStore};
     use trust_dns_https::HttpsClientStreamBuilder;
 
+    const ALPN_H2: &[u8] = b"h2";
+
     let mut io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("1.1.1.1", 443).to_socket_addrs().unwrap().next().unwrap();
 
@@ -143,6 +145,7 @@ fn test_query_https() {
     let mut client_config = ClientConfig::new();
     client_config.root_store = root_store;
     client_config.versions = versions;
+    client_config.alpn_protocols.push(ALPN_H2.to_vec());
 
     let https_builder = HttpsClientStreamBuilder::with_client_config(Arc::new(client_config));
     let (bg, mut client) =

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -144,7 +144,7 @@ fn test_query_https() {
     client_config.root_store = root_store;
     client_config.versions = versions;
 
-    let https_builder = HttpsClientStreamBuilder::with_client_config(client_config);
+    let https_builder = HttpsClientStreamBuilder::with_client_config(Arc::new(client_config));
     let (bg, mut client) =
         ClientFuture::connect(https_builder.build(addr, "cloudflare-dns.com".to_string()));
     io_loop.spawn(bg);

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -73,6 +73,8 @@ fn mock_nameserver_on_send<O: OnSend + Unpin>(
             socket_addr: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            #[cfg(any(feature = "dns-over-rustls", feature = "dns-over-https-rustls"))]
+            tls_config: None,
         },
         options,
         client,


### PR DESCRIPTION
Currently the `trust-dns-resolver` uses a hardcoded `rustls::ClientConfig` when built with the `dns-over-rustls` feature. This makes it impossible to change the accepted root certificates and other properties of the TLS client.

This PR adds a new field to the `NameServerConfig` to optionally pass a `rustls::ClientConfig` which gets used instead. The `webpki-roots` store is used as the default fallback so existing implementations should work as before.

A new type `TlsClientConfig` was added as a wrapper for `rustls::ClientConfig` which doesn't implement the `Debug`, `Eq` & `PartialEq` traits. This might become obsolete if rustls can provide the trait implementations one day.

The custom `rustls:ClientConfig` can be set via a `set_tls_client_config `method which exists both on `trust-dns-resolver::NameServerConfigGroup` and `trust-dns-resolver::ResolverConf`.