### PR TITLE
lock prevent the resolver to do concurrent requests

### DIFF
--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -146,7 +146,7 @@ impl<C: DnsHandle + 'static, P: ConnectionProvider<ConnHandle = C> + 'static> Na
             // get a stable view for trying all connections
             //   we split into chunks of the number of parallel requests to issue
             conns.clone()
-         };
+        };
             
         let request_loop = request.clone();
 


### PR DESCRIPTION
the lock on conns was preventing to make concurrent requests, in this fix i added the lock inside a scope so as soon the scope is done the conn will be dropped and the mutex will be unlocked.