### PR TITLE
Partially eliminate use of `extern crate`

### DIFF
--- a/crates/client/benches/lower_name_benches.rs
+++ b/crates/client/benches/lower_name_benches.rs
@@ -8,8 +8,6 @@
 #![feature(test)]
 
 extern crate test;
-extern crate trust_dns_client;
-extern crate trust_dns_proto;
 
 use std::str::FromStr;
 

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -17,8 +17,10 @@ use std::sync::Arc;
 use futures::Future;
 use tokio::runtime::current_thread::Runtime;
 
-use proto::error::ProtoError;
-use proto::xfer::{DnsRequestSender, DnsResponse};
+use trust_dns_proto::{
+    error::ProtoError,
+    xfer::{DnsRequestSender, DnsResponse},
+};
 
 #[cfg(feature = "dnssec")]
 use crate::client::SecureClientHandle;

--- a/crates/client/src/client/client_connection.rs
+++ b/crates/client/src/client/client_connection.rs
@@ -17,8 +17,10 @@ use std::sync::Arc;
 
 use futures::Future;
 
-use proto::error::ProtoError;
-use proto::xfer::{DnsRequestSender, DnsResponse};
+use trust_dns_proto::{
+    error::ProtoError,
+    xfer::{DnsRequestSender, DnsResponse},
+};
 
 use crate::rr::dnssec::Signer;
 

--- a/crates/client/src/client/client_future.rs
+++ b/crates/client/src/client/client_future.rs
@@ -10,13 +10,14 @@ use std::sync::Arc;
 use std::task::Context;
 use std::time::Duration;
 
-use futures::{Future, FutureExt, Poll};
-use proto::error::ProtoError;
-use proto::xfer::{
+use crate::proto::error::ProtoError;
+use crate::proto::xfer::{
     BufDnsRequestStreamHandle, DnsClientStream, DnsExchange, DnsExchangeConnect, DnsHandle,
     DnsMultiplexer, DnsMultiplexerConnect, DnsMultiplexerSerialResponse, DnsRequest,
     DnsRequestOptions, DnsRequestSender, DnsResponse, DnsStreamHandle, OneshotDnsResponseReceiver,
 };
+use futures::{ready, Future, FutureExt, Poll};
+use log::{debug, warn};
 use rand;
 
 use crate::error::*;

--- a/crates/client/src/client/memoize_client_handle.rs
+++ b/crates/client/src/client/memoize_client_handle.rs
@@ -10,8 +10,10 @@ use std::sync::Arc;
 
 use futures::lock::Mutex;
 use futures::Future;
-use proto::error::ProtoError;
-use proto::xfer::{DnsHandle, DnsRequest, DnsResponse};
+use trust_dns_proto::{
+    error::ProtoError,
+    xfer::{DnsHandle, DnsRequest, DnsResponse},
+};
 
 use crate::client::rc_future::{rc_future, RcFuture};
 use crate::client::ClientHandle;
@@ -93,8 +95,10 @@ mod test {
 
     use futures::lock::Mutex;
     use futures::*;
-    use proto::error::ProtoError;
-    use proto::xfer::{DnsHandle, DnsRequest, DnsResponse};
+    use trust_dns_proto::{
+        error::ProtoError,
+        xfer::{DnsHandle, DnsRequest, DnsResponse},
+    };
 
     use crate::client::*;
     use crate::op::*;

--- a/crates/client/src/client/mod.rs
+++ b/crates/client/src/client/mod.rs
@@ -34,17 +34,17 @@ pub use self::memoize_client_handle::MemoizeClientHandle;
 
 /// This is an alias for [`trust_dns_proto::StreamHandle`]
 #[deprecated(note = "use [`trust_dns_proto::StreamHandle`] instead")]
-pub use proto::StreamHandle;
+pub use trust_dns_proto::StreamHandle;
 
 /// This is an alias for [`trust_dns_proto::DnsStreamHandle`]
 #[deprecated(note = "use [`trust_dns_proto::DnsStreamHandle`] instead")]
-pub use proto::DnsStreamHandle as ClientStreamHandle;
+pub use trust_dns_proto::DnsStreamHandle as ClientStreamHandle;
 
 /// This is an alias for [`trust_dns_proto::RetryDnsHandle`]
 #[deprecated(note = "use [`trust_dns_proto::RetryDnsHandle`] instead")]
-pub use proto::RetryDnsHandle as RetryClientHandle;
+pub use trust_dns_proto::RetryDnsHandle as RetryClientHandle;
 
 /// This is an alias for [`trust_dns_proto::SecureDnsHandle`]
 #[cfg(feature = "dnssec")]
 #[deprecated(note = "use [`trust_dns_proto::SecureDnsHandle`] instead")]
-pub use proto::SecureDnsHandle as SecureClientHandle;
+pub use trust_dns_proto::SecureDnsHandle as SecureClientHandle;

--- a/crates/client/src/error/client_error.rs
+++ b/crates/client/src/error/client_error.rs
@@ -20,7 +20,7 @@ use std::{fmt, io};
 
 use failure::{Backtrace, Context, Fail};
 use futures::channel::mpsc::SendError;
-use proto::error::{ProtoError, ProtoErrorKind};
+use trust_dns_proto::error::{ProtoError, ProtoErrorKind};
 
 use crate::error::{DnsSecError, DnsSecErrorKind};
 

--- a/crates/client/src/error/dnssec_error.rs
+++ b/crates/client/src/error/dnssec_error.rs
@@ -26,9 +26,9 @@ use self::not_openssl::SslErrorStack;
 use self::not_ring::{KeyRejected, Unspecified};
 #[cfg(feature = "openssl")]
 use openssl::error::ErrorStack as SslErrorStack;
-use proto::error::{ProtoError, ProtoErrorKind};
 #[cfg(feature = "ring")]
 use ring::error::{KeyRejected, Unspecified};
+use trust_dns_proto::error::{ProtoError, ProtoErrorKind};
 
 /// An alias for dnssec results returned by functions of this crate
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/crates/client/src/error/parse_error.rs
+++ b/crates/client/src/error/parse_error.rs
@@ -20,7 +20,7 @@
 use std::{fmt, io};
 
 use failure::{Backtrace, Context, Fail};
-use proto::error::{ProtoError, ProtoErrorKind};
+use trust_dns_proto::error::{ProtoError, ProtoErrorKind};
 
 use super::LexerError;
 use crate::serialize::txt::Token;

--- a/crates/client/src/https_client_connection.rs
+++ b/crates/client/src/https_client_connection.rs
@@ -10,9 +10,9 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use proto::xfer::DnsRequestSender;
 use rustls::{Certificate, ClientConfig};
 use trust_dns_https::{HttpsClientConnect, HttpsClientStream, HttpsClientStreamBuilder};
+use trust_dns_proto::xfer::DnsRequestSender;
 
 use crate::client::ClientConnection;
 use crate::rr::dnssec::Signer;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -58,12 +58,6 @@
 //! trust-dns-client = { version = "*", default-features = false }
 //! ```
 //!
-//! Extern the crate into your program or library:
-//!
-//! ```rust
-//! extern crate trust_dns_client;
-//! ```
-//!
 //! ## Objects
 //!
 //! There are two variations of implementations of the Client. The `SyncClient`, a synchronous client, and the `ClientFuture`, a Tokio async client. `SyncClient` is an implementation of the `Client` trait, there is another implementation, `SecureSyncClient`, which validates DNSSec records. For these basic examples we'll only look at the `SyncClient`
@@ -133,10 +127,6 @@
 
 //!
 //! ```rust,no_run
-//! # extern crate chrono;
-//! # extern crate openssl;
-//! # extern crate trust_dns_client;
-//!
 //! use std::fs::File;
 //! use std::io::Read;
 //! use std::net::Ipv4Addr;
@@ -217,10 +207,6 @@
 //! The below example uses a single threaded tokio runtime example for the client. Tokio can get much more complex with multiple runtimes on many threads. This example is meant to show basic usage, the Tokio documentation should be reviewed for more advanced usage.
 //!
 //! ```rust
-//! # extern crate tokio;
-//! # extern crate tokio_net;
-//! # extern crate trust_dns_client;
-//!
 //! use std::net::{Ipv4Addr, SocketAddr};
 //! use std::str::FromStr;
 //! use tokio_net::udp::UdpSocket;
@@ -261,39 +247,6 @@
 //! }
 //! ```
 
-extern crate chrono;
-extern crate data_encoding;
-extern crate failure;
-#[macro_use]
-extern crate futures;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-#[cfg(feature = "native-tls")]
-extern crate native_tls;
-#[cfg(feature = "openssl")]
-extern crate openssl;
-extern crate radix_trie;
-extern crate rand;
-#[cfg(feature = "ring")]
-extern crate ring;
-#[cfg(feature = "dns-over-https-rustls")]
-extern crate rustls;
-#[cfg(feature = "serde-config")]
-extern crate serde;
-extern crate tokio;
-extern crate tokio_net;
-#[cfg(feature = "tokio-openssl")]
-extern crate tokio_openssl;
-#[cfg(feature = "tokio-tls")]
-extern crate tokio_tls;
-#[cfg(feature = "dns-over-https")]
-extern crate trust_dns_https;
-pub extern crate trust_dns_proto as proto;
-#[cfg(feature = "dns-over-https")]
-extern crate webpki;
-
 pub mod client;
 pub mod error;
 #[cfg(feature = "mdns")]
@@ -307,6 +260,8 @@ pub mod udp;
 // TODO: consider removing tcp/udp/https modules...
 #[cfg(feature = "dns-over-https")]
 mod https_client_connection;
+
+pub use trust_dns_proto as proto;
 
 /// The https module which contains all https related connection types
 #[cfg(feature = "dns-over-https")]

--- a/crates/client/src/multicast/mdns_client_connection.rs
+++ b/crates/client/src/multicast/mdns_client_connection.rs
@@ -10,8 +10,10 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
-use proto::multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType, MDNS_IPV4, MDNS_IPV6};
-use proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
+use crate::proto::{
+    multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType, MDNS_IPV4, MDNS_IPV6},
+    xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender},
+};
 
 use crate::client::ClientConnection;
 use crate::rr::dnssec::Signer;

--- a/crates/client/src/multicast/mod.rs
+++ b/crates/client/src/multicast/mod.rs
@@ -8,7 +8,7 @@
 //! UDP protocol related components for DNS
 
 mod mdns_client_connection;
-use proto::multicast;
+use crate::proto::multicast;
 
 pub use self::mdns_client_connection::MdnsClientConnection;
 pub use self::multicast::{MdnsClientStream, MdnsQueryType, MdnsStream, MDNS_IPV4, MDNS_IPV6};

--- a/crates/client/src/op/lower_query.rs
+++ b/crates/client/src/op/lower_query.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::{self, Display};
 
-use proto::error::*;
+use crate::proto::error::*;
 
 use crate::op::Query;
 use crate::rr::{DNSClass, LowerName, RecordType};

--- a/crates/client/src/op/mod.rs
+++ b/crates/client/src/op/mod.rs
@@ -13,7 +13,7 @@ pub mod update_message;
 
 pub use self::lower_query::LowerQuery;
 pub use self::update_message::UpdateMessage;
-pub use proto::op::{
-    Edns, Header, Message, MessageFinalizer, MessageType, OpCode, Query, ResponseCode,
+pub use crate::proto::{
+    op::{Edns, Header, Message, MessageFinalizer, MessageType, OpCode, Query, ResponseCode},
+    xfer::DnsResponse,
 };
-pub use proto::xfer::DnsResponse;

--- a/crates/client/src/rr/dnssec/mod.rs
+++ b/crates/client/src/rr/dnssec/mod.rs
@@ -21,7 +21,7 @@ mod key_format;
 mod keypair;
 mod signer;
 
-use proto::rr::dnssec;
+use crate::proto::rr::dnssec;
 
 pub use self::dnssec::tbs;
 pub use self::dnssec::Algorithm;

--- a/crates/client/src/rr/dnssec/signer.rs
+++ b/crates/client/src/rr/dnssec/signer.rs
@@ -9,9 +9,9 @@
 #[cfg(any(feature = "openssl", feature = "ring"))]
 use chrono::Duration;
 
-use proto::error::{ProtoErrorKind, ProtoResult};
+use crate::proto::error::{ProtoErrorKind, ProtoResult};
 #[cfg(feature = "dnssec")]
-use proto::rr::dnssec::{tbs, TBS};
+use crate::proto::rr::dnssec::{tbs, TBS};
 
 #[cfg(feature = "dnssec")]
 use crate::error::DnsSecResult;
@@ -518,7 +518,7 @@ impl Signer {
 impl MessageFinalizer for Signer {
     #[cfg(any(feature = "openssl", feature = "ring"))]
     fn finalize_message(&self, message: &Message, current_time: u32) -> ProtoResult<Vec<Record>> {
-        debug!("signing message: {:?}", message);
+        log::debug!("signing message: {:?}", message);
         let key_tag: u16 = self.calculate_key_tag()?;
 
         // this is based on RFCs 2535, 2931 and 3007
@@ -577,10 +577,9 @@ impl MessageFinalizer for Signer {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
-    extern crate openssl;
-    use self::openssl::bn::BigNum;
-    use self::openssl::pkey::Private;
-    use self::openssl::rsa::Rsa;
+    use openssl::bn::BigNum;
+    use openssl::pkey::Private;
+    use openssl::rsa::Rsa;
 
     use crate::op::{Message, Query};
     use crate::rr::dnssec::*;
@@ -777,8 +776,7 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
     #[allow(clippy::module_inception)]
     #[cfg(test)]
     mod tests {
-        extern crate openssl;
-        use self::openssl::rsa::Rsa;
+        use openssl::rsa::Rsa;
 
         use crate::rr::dnssec::tbs::*;
         use crate::rr::dnssec::*;

--- a/crates/client/src/rr/lower_name.rs
+++ b/crates/client/src/rr/lower_name.rs
@@ -14,7 +14,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::Index;
 use std::str::FromStr;
 
-use proto::error::*;
+use crate::proto::error::*;
 #[cfg(feature = "serde-config")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/crates/client/src/rr/mod.rs
+++ b/crates/client/src/rr/mod.rs
@@ -21,12 +21,12 @@ mod lower_name;
 mod rr_key;
 pub mod zone;
 
-use proto::rr;
-pub use proto::rr::dns_class;
-pub use proto::rr::domain;
-pub use proto::rr::record_data;
-pub use proto::rr::record_type;
-pub use proto::rr::resource;
+use crate::proto::rr;
+pub use crate::proto::rr::dns_class;
+pub use crate::proto::rr::domain;
+pub use crate::proto::rr::record_data;
+pub use crate::proto::rr::record_type;
+pub use crate::proto::rr::resource;
 
 pub use self::dns_class::DNSClass;
 pub use self::lower_name::LowerName;
@@ -41,6 +41,6 @@ pub use self::rr_key::RrKey;
 
 /// All record data structures and related serialization methods
 pub mod rdata {
-    pub use proto::rr::dnssec::rdata::*;
-    pub use proto::rr::rdata::*;
+    pub use crate::proto::rr::dnssec::rdata::*;
+    pub use crate::proto::rr::rdata::*;
 }

--- a/crates/client/src/rr/zone.rs
+++ b/crates/client/src/rr/zone.rs
@@ -1,9 +1,10 @@
 //! Reserved Zone and related information
 
-pub use proto::rr::domain::usage::*;
-use proto::rr::domain::{Label, Name};
-use proto::serialize::binary::BinEncodable;
+pub use crate::proto::rr::domain::usage::*;
+use crate::proto::rr::domain::{Label, Name};
+use crate::proto::serialize::binary::BinEncodable;
 
+use lazy_static::lazy_static;
 use radix_trie::{Trie, TrieKey};
 
 // Reserved reverse IPs

--- a/crates/client/src/serialize/binary/mod.rs
+++ b/crates/client/src/serialize/binary/mod.rs
@@ -16,7 +16,7 @@
 
 //! Binary serialization types
 
-use proto::serialize::binary;
+use crate::proto::serialize::binary;
 
 #[deprecated(note = "use [`trust_dns_client::serialize::binary::StreamHandle`] instead")]
 pub use self::binary::BinDecodable as BinSerializable;

--- a/crates/client/src/serialize/txt/rdata_parsers/caa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/caa.rs
@@ -16,8 +16,10 @@
 
 //! mail exchange, email, record
 
-use proto::rr::rdata::caa;
-use proto::rr::rdata::caa::{Property, Value};
+use log::warn;
+
+use crate::proto::rr::rdata::caa;
+use crate::proto::rr::rdata::caa::{Property, Value};
 
 use crate::error::*;
 use crate::rr::rdata::CAA;

--- a/crates/client/src/serialize/txt/rdata_parsers/sshfp.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/sshfp.rs
@@ -7,6 +7,7 @@
 
 //! SSHFP records for SSH public key fingerprints
 use data_encoding::{Encoding, Specification};
+use lazy_static::lazy_static;
 
 use crate::error::*;
 use crate::rr::rdata::SSHFP;

--- a/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
@@ -8,6 +8,7 @@
 
 //! tlsa records for storing TLS authentication records
 use data_encoding::{Encoding, Specification};
+use lazy_static::lazy_static;
 
 use crate::error::*;
 use crate::rr::rdata::tlsa::CertUsage;

--- a/crates/client/src/tcp/mod.rs
+++ b/crates/client/src/tcp/mod.rs
@@ -17,7 +17,7 @@
 //! TCP protocol related components for DNS
 
 mod tcp_client_connection;
-use proto::tcp;
+use crate::proto::tcp;
 
 pub use self::tcp::TcpClientStream;
 pub use self::tcp::TcpStream;

--- a/crates/client/src/tcp/tcp_client_connection.rs
+++ b/crates/client/src/tcp/tcp_client_connection.rs
@@ -11,8 +11,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use proto::tcp::{TcpClientConnect, TcpClientStream};
-use proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
+use crate::proto::tcp::{TcpClientConnect, TcpClientStream};
+use crate::proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
 use tokio_net::tcp::TcpStream;
 
 use crate::client::ClientConnection;

--- a/crates/client/src/udp/mod.rs
+++ b/crates/client/src/udp/mod.rs
@@ -17,7 +17,7 @@
 //! UDP protocol related components for DNS
 
 mod udp_client_connection;
-use proto::udp;
+use crate::proto::udp;
 
 pub use self::udp::UdpClientStream;
 pub use self::udp::UdpStream;

--- a/crates/client/src/udp/udp_client_connection.rs
+++ b/crates/client/src/udp/udp_client_connection.rs
@@ -11,8 +11,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use proto::udp::{UdpClientConnect, UdpClientStream};
-use proto::xfer::DnsRequestSender;
+use crate::proto::udp::{UdpClientConnect, UdpClientStream};
+use crate::proto::xfer::DnsRequestSender;
 
 use crate::client::ClientConnection;
 use crate::error::*;

--- a/crates/proto/benches/lib.rs
+++ b/crates/proto/benches/lib.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 
 extern crate test;
-extern crate trust_dns_proto;
 
 use trust_dns_proto::op::{Header, Message, MessageType, OpCode, ResponseCode};
 use trust_dns_proto::rr::Record;

--- a/crates/proto/benches/name_benches.rs
+++ b/crates/proto/benches/name_benches.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 
 extern crate test;
-extern crate trust_dns_proto;
 
 use std::cmp::Ordering;
 

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -16,39 +16,6 @@
 
 //! Trust-DNS Protocol library
 
-extern crate async_trait;
-#[cfg(feature = "dnssec")]
-extern crate data_encoding;
-#[macro_use]
-extern crate enum_as_inner;
-#[cfg(test)]
-extern crate env_logger;
-extern crate failure;
-extern crate futures;
-extern crate idna;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-#[cfg(feature = "openssl")]
-extern crate openssl;
-extern crate rand;
-#[cfg(feature = "ring")]
-extern crate ring;
-#[cfg(feature = "serde-config")]
-extern crate serde;
-extern crate smallvec;
-extern crate socket2;
-#[cfg(test)]
-extern crate tokio;
-extern crate tokio_executor;
-extern crate tokio_io;
-#[cfg(feature = "tokio-compat")]
-extern crate tokio_net;
-extern crate tokio_sync;
-extern crate tokio_timer;
-extern crate url;
-
 macro_rules! try_ready_stream {
     ($e:expr) => {{
         match $e {

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -18,6 +18,8 @@ use futures::lock::Mutex;
 use futures::ready;
 use futures::stream::{Stream, StreamExt};
 use futures::{Future, FutureExt, Poll, TryFutureExt};
+use lazy_static::lazy_static;
+use log::{debug, trace};
 use rand;
 use rand::distributions::{uniform::Uniform, Distribution};
 use socket2::{self, Socket};

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -21,6 +21,8 @@ use std::mem;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use log::debug;
+
 use super::{Edns, Header, MessageType, OpCode, Query, ResponseCode};
 use crate::error::*;
 use crate::rr::{Record, RecordType};

--- a/crates/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -226,7 +226,7 @@ impl DNSKEY {
                 .emit(&mut encoder)
                 .and_then(|_| emit(&mut encoder, self))
             {
-                warn!("error serializing dnskey: {}", e);
+                log::warn!("error serializing dnskey: {}", e);
                 return Err(format!("error serializing dnskey: {}", e).into());
             }
         }

--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -29,6 +29,9 @@ pub mod sig;
 
 use std::str::FromStr;
 
+use enum_as_inner::EnumAsInner;
+use log::debug;
+
 use crate::error::*;
 use crate::rr::rdata::null;
 use crate::rr::rdata::NULL;

--- a/crates/proto/src/rr/dnssec/supported_algorithm.rs
+++ b/crates/proto/src/rr/dnssec/supported_algorithm.rs
@@ -20,6 +20,8 @@ use std::convert::From;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+use log::warn;
+
 use crate::error::*;
 use crate::rr::dnssec::Algorithm;
 use crate::serialize::binary::{BinEncodable, BinEncoder};

--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -20,6 +20,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc as Rc;
 
 use idna;
+use log::debug;
 
 use crate::error::*;
 

--- a/crates/proto/src/rr/domain/usage.rs
+++ b/crates/proto/src/rr/domain/usage.rs
@@ -11,6 +11,8 @@
 
 use std::ops::Deref;
 
+use lazy_static::lazy_static;
+
 use crate::rr::domain::Name;
 
 lazy_static! {

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -18,6 +18,8 @@
 
 use std::collections::HashMap;
 
+use log::warn;
+
 use crate::error::*;
 use crate::serialize::binary::*;
 

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -21,6 +21,9 @@ use std::cmp::Ordering;
 use std::convert::From;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use enum_as_inner::EnumAsInner;
+use log::{debug, warn};
+
 use super::domain::Name;
 use super::rdata;
 use super::rdata::{CAA, MX, NAPTR, NULL, OPENPGPKEY, OPT, SOA, SRV, SSHFP, TLSA, TXT};

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -8,6 +8,8 @@ use std::iter::Chain;
 use std::slice::Iter;
 use std::vec;
 
+use log::info;
+
 use crate::rr::{DNSClass, Name, RData, Record, RecordType};
 
 #[cfg(feature = "dnssec")]

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::{Future, Poll, Stream, StreamExt, TryFutureExt};
+use log::warn;
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use crate::error::ProtoError;

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::stream::{Fuse, Peekable, Stream, StreamExt};
 use futures::{ready, Future, FutureExt, Poll, TryFutureExt};
+use log::debug;
 use tokio_timer::Timeout;
 
 use crate::error::*;

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -15,6 +15,7 @@ use std::task::Context;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use futures::{Future, Poll, Stream};
+use log::{debug, warn};
 use tokio_timer::timeout::{Elapsed, Timeout};
 
 use crate::error::ProtoError;

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -17,6 +17,7 @@ use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::lock::Mutex;
 use futures::stream::{Fuse, Peekable, Stream, StreamExt};
 use futures::{ready, Future, Poll, TryFutureExt};
+use log::debug;
 use rand;
 use rand::distributions::{uniform::Uniform, Distribution};
 

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -13,6 +13,7 @@ use std::task::Context;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::stream::{Peekable, Stream, StreamExt};
 use futures::{Future, FutureExt, Poll};
+use log::{debug, warn};
 
 use crate::error::*;
 use crate::xfer::{

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 use futures::channel::mpsc::UnboundedSender;
 use futures::channel::oneshot;
 use futures::future::{Future, FutureExt, TryFutureExt};
+use log::debug;
 use rand;
 
 use crate::error::*;

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use futures::channel::oneshot;
 use futures::stream::{Stream, StreamExt};
 use futures::{ready, Future, FutureExt, Poll};
+use log::{debug, warn};
 use rand;
 use rand::distributions::{Distribution, Standard};
 use smallvec::SmallVec;

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -12,6 +12,7 @@ use std::task::Context;
 use futures::channel::mpsc::{TrySendError, UnboundedSender};
 use futures::channel::oneshot::{self, Receiver, Sender};
 use futures::{ready, Future, Poll, Stream};
+use log::{debug, warn};
 
 use crate::error::*;
 use crate::op::Message;

--- a/crates/proto/src/xfer/secure_dns_handle.rs
+++ b/crates/proto/src/xfer/secure_dns_handle.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use futures::future;
 use futures::{Future, FutureExt, TryFutureExt};
+use log::debug;
 
 use crate::error::*;
 use crate::op::{OpCode, Query};

--- a/util/src/bind_dnskey_to_pem.rs
+++ b/util/src/bind_dnskey_to_pem.rs
@@ -5,20 +5,13 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-extern crate clap;
-extern crate data_encoding;
-extern crate env_logger;
-#[macro_use]
-extern crate log;
-extern crate openssl;
-extern crate trust_dns_client;
-
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Lines, Write};
 use std::str::FromStr;
 
 use clap::{App, Arg, ArgMatches};
 use data_encoding::BASE64;
+use log::info;
 use openssl::bn::BigNum;
 use openssl::rsa::Rsa;
 

--- a/util/src/get_root_ksks.rs
+++ b/util/src/get_root_ksks.rs
@@ -5,20 +5,13 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-#[macro_use]
-extern crate clap;
-extern crate data_encoding;
-extern crate env_logger;
-extern crate openssl;
-extern crate trust_dns_client;
-extern crate trust_dns_proto;
-extern crate trust_dns_resolver;
-
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
 
-use clap::ArgMatches;
+use clap::{
+    app_from_crate, crate_authors, crate_description, crate_name, crate_version, ArgMatches,
+};
 
 use trust_dns_client::rr::dnssec::Algorithm;
 use trust_dns_proto::rr::dnssec::rdata::DNSSECRData;

--- a/util/src/pem_to_public_dnskey.rs
+++ b/util/src/pem_to_public_dnskey.rs
@@ -4,17 +4,11 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-extern crate clap;
-extern crate env_logger;
-#[macro_use]
-extern crate log;
-extern crate openssl;
-extern crate trust_dns_client;
-
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Write};
 
 use clap::{App, Arg, ArgMatches};
+use log::info;
 use openssl::pkey::PKey;
 
 use trust_dns_client::rr::dnssec::{KeyPair, Public};


### PR DESCRIPTION
This eliminates the use of `extern crate` for the `proto` and `client`
crates, as well as the `util` directory, including a reference in the
`client` top-level API docs.

---

I hope to come around to provide patches to get rid of `extern crate`
in the rest of the codebase as well, but I'm not sure when I'll get
around to it. This branch has been sitting here for a while, so I
decided I should send out what I have, even if it's not complete.

I'll either update this PR with further `extern crate` patches, or, in
case it gets merged before I get around to do that, open a new PR.