### PR TITLE
Abstract tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,15 +873,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1057,7 +1057,7 @@ name = "toml"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1098,7 +1098,7 @@ dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-https 0.18.0-alpha.3",
  "trust-dns-proto 0.18.0-alpha.3",
@@ -1202,7 +1202,7 @@ dependencies = [
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1223,7 +1223,7 @@ dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1267,7 +1267,7 @@ dependencies = [
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1657,8 +1657,8 @@ dependencies = [
 "checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 "checksum security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
 "checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
-"checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
-"checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
+"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -354,7 +354,7 @@ dependencies = [
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -489,7 +489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -529,7 +529,7 @@ dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -554,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,7 +828,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1047,7 +1047,7 @@ dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1068,7 +1068,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1092,7 +1092,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "radix_trie 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1129,7 +1129,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1148,7 +1148,7 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1198,7 +1198,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1219,7 +1219,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1242,7 +1242,7 @@ name = "trust-dns-rustls"
 version = "0.18.0-alpha.3"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1263,7 +1263,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1288,7 +1288,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-client 0.18.0-alpha.3",
  "trust-dns-proto 0.18.0-alpha.3",
@@ -1389,7 +1389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1429,7 +1429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1612,7 +1612,7 @@ dependencies = [
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "1b9ad466a945c9c40f6f9a449c55675547e59bc75a2722d4689042ab3ae80c9c"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -805,13 +805,13 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1151,7 +1151,7 @@ dependencies = [
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-client 0.18.0-alpha.3",
@@ -1265,7 +1265,7 @@ dependencies = [
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1610,7 +1610,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
+"checksum libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7a8223ba845dde334ce739a90b554ad3ce75f888b968cc93a11176cad2e58f2"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "1b9ad466a945c9c40f6f9a449c55675547e59bc75a2722d4689042ab3ae80c9c"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
@@ -1650,7 +1650,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
-"checksum rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"
+"checksum rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64a656821bb6317a84b257737b7934f79c0dbb7eb694710475908280ebad3e64"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -74,7 +74,7 @@ path = "src/named.rs"
 chrono = "0.4"
 clap = "2.33"
 futures = "0.3.0"
-log = "0.4.8"
+log = "0.4.10"
 rustls = { version = "0.16", optional = true }
 tokio = { version = "0.2.1", features = ["rt-core", "rt-threaded", "time"] }
 trust-dns-client= { version = "0.18.0-alpha", path = "../crates/client" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -70,7 +70,7 @@ data-encoding = "2.1.0"
 failure = "0.1"
 futures = "0.3.0"
 lazy_static = "1.0"
-log = "0.4.8"
+log = "0.4.10"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 radix_trie = "0.1.6"
 rand = "0.7"

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -16,6 +16,7 @@ use crate::proto::xfer::{
     DnsHandle, DnsMultiplexer, DnsMultiplexerConnect, DnsMultiplexerSerialResponse, DnsRequest,
     DnsRequestOptions, DnsRequestSender, DnsResponse, DnsStreamHandle,
 };
+use crate::proto::TokioTime;
 use futures::{ready, Future, FutureExt};
 use log::debug;
 use rand;
@@ -146,7 +147,7 @@ where
 
 /// A future that resolves to an AsyncClient
 #[must_use = "futures do nothing unless polled"]
-pub struct AsyncClientConnect<F, S, R>(DnsExchangeConnect<F, S, R>)
+pub struct AsyncClientConnect<F, S, R>(DnsExchangeConnect<F, S, R, TokioTime>)
 where
     F: Future<Output = Result<S, ProtoError>> + 'static + Send + Unpin,
     S: DnsRequestSender<DnsResponseFuture = R> + 'static,
@@ -159,7 +160,7 @@ where
     S: DnsRequestSender<DnsResponseFuture = R> + 'static + Send + Unpin,
     R: Future<Output = Result<DnsResponse, ProtoError>> + 'static + Send + Unpin,
 {
-    type Output = Result<(AsyncClient<R>, DnsExchangeBackground<S, R>), ProtoError>;
+    type Output = Result<(AsyncClient<R>, DnsExchangeBackground<S, R, TokioTime>), ProtoError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let result = ready!(self.0.poll_unpin(cx));

--- a/crates/client/src/tcp/tcp_client_connection.rs
+++ b/crates/client/src/tcp/tcp_client_connection.rs
@@ -11,8 +11,10 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::proto::iocompat::Compat02As03;
 use crate::proto::tcp::{TcpClientConnect, TcpClientStream};
 use crate::proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
+use crate::proto::TokioTime;
 use tokio::net::TcpStream;
 
 use crate::client::ClientConnection;
@@ -60,14 +62,18 @@ impl TcpClientConnection {
 }
 
 impl ClientConnection for TcpClientConnection {
-    type Sender = DnsMultiplexer<TcpClientStream<TcpStream>, Signer>;
+    type Sender = DnsMultiplexer<TcpClientStream<Compat02As03<TcpStream>>, Signer>;
     type Response = <Self::Sender as DnsRequestSender>::DnsResponseFuture;
-    type SenderFuture =
-        DnsMultiplexerConnect<TcpClientConnect<TcpStream>, TcpClientStream<TcpStream>, Signer>;
+    type SenderFuture = DnsMultiplexerConnect<
+        TcpClientConnect<Compat02As03<TcpStream>>,
+        TcpClientStream<Compat02As03<TcpStream>>,
+        Signer,
+    >;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
-        let (tcp_client_stream, handle) =
-            TcpClientStream::<TcpStream>::with_timeout(self.name_server, self.timeout);
+        let (tcp_client_stream, handle) = TcpClientStream::<Compat02As03<TcpStream>>::with_timeout::<
+            TokioTime,
+        >(self.name_server, self.timeout);
         DnsMultiplexer::new(tcp_client_stream, handle, signer)
     }
 }

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -58,7 +58,7 @@ rustls = "0.16"
 tokio = { version = "0.2.1", features = ["tcp", "io-util", "rt-core"] }
 tokio-rustls = "0.12.1"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-time", "tokio-runtime"], default-features = false }
+trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-runtime"], default-features = false }
 trust-dns-rustls = { version = "0.18.0-alpha", path = "../rustls", default-features = false }
 typed-headers = "0.2"
 webpki-roots = { version = "0.18" }

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -58,7 +58,7 @@ rustls = "0.16"
 tokio = { version = "0.2.1", features = ["tcp", "io-util", "rt-core"] }
 tokio-rustls = "0.12.1"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-runtime"], default-features = false }
+trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-time", "tokio-runtime"], default-features = false }
 trust-dns-rustls = { version = "0.18.0-alpha", path = "../rustls", default-features = false }
 typed-headers = "0.2"
 webpki-roots = { version = "0.18" }

--- a/crates/native-tls/Cargo.toml
+++ b/crates/native-tls/Cargo.toml
@@ -52,7 +52,7 @@ native-tls = "0.2"
 tokio = "0.2.1"
 tokio-tls = "0.3.0"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-runtime"], default-features = false }
+trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-io", "tokio-runtime"], default-features = false }
 
 [dev-dependencies]
 

--- a/crates/native-tls/Cargo.toml
+++ b/crates/native-tls/Cargo.toml
@@ -52,7 +52,7 @@ native-tls = "0.2"
 tokio = "0.2.1"
 tokio-tls = "0.3.0"
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-io", "tokio-runtime"], default-features = false }
+trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-runtime"], default-features = false }
 
 [dev-dependencies]
 

--- a/crates/native-tls/src/tls_client_stream.rs
+++ b/crates/native-tls/src/tls_client_stream.rs
@@ -18,6 +18,7 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_tls::TlsStream as TokioTlsStream;
 
 use trust_dns_proto::error::ProtoError;
+use trust_dns_proto::iocompat::Compat02As03;
 use trust_dns_proto::tcp::TcpClientStream;
 use trust_dns_proto::xfer::BufDnsStreamHandle;
 
@@ -26,7 +27,7 @@ use crate::TlsStreamBuilder;
 /// TlsClientStream secure DNS over TCP stream
 ///
 /// See TlsClientStreamBuilder::new()
-pub type TlsClientStream = TcpClientStream<TokioTlsStream<TokioTcpStream>>;
+pub type TlsClientStream = TcpClientStream<Compat02As03<TokioTlsStream<TokioTcpStream>>>;
 
 /// Builder for TlsClientStream
 pub struct TlsClientStreamBuilder(TlsStreamBuilder);

--- a/crates/native-tls/src/tls_stream.rs
+++ b/crates/native-tls/src/tls_stream.rs
@@ -18,11 +18,12 @@ use native_tls::{Certificate, Identity, TlsConnector};
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio_tls::{TlsConnector as TokioTlsConnector, TlsStream as TokioTlsStream};
 
+use trust_dns_proto::iocompat::Compat02As03;
 use trust_dns_proto::tcp::TcpStream;
 use trust_dns_proto::xfer::{BufStreamHandle, SerialMessage};
 
 /// A TlsStream counterpart to the TcpStream which embeds a secure TlsStream
-pub type TlsStream = TcpStream<TokioTlsStream<TokioTcpStream>>;
+pub type TlsStream = TcpStream<Compat02As03<TokioTlsStream<TokioTcpStream>>>;
 
 fn tls_new(certs: Vec<Certificate>, pkcs12: Option<Identity>) -> io::Result<TlsConnector> {
     let mut builder = TlsConnector::builder();
@@ -53,7 +54,8 @@ pub fn tls_from_stream(
     let (message_sender, outbound_messages) = unbounded();
     let message_sender = BufStreamHandle::new(message_sender);
 
-    let stream = TcpStream::from_stream_with_receiver(stream, peer_addr, outbound_messages);
+    let stream =
+        TcpStream::from_stream_with_receiver(Compat02As03(stream), peer_addr, outbound_messages);
 
     (stream, message_sender)
 }
@@ -170,7 +172,7 @@ impl TlsStreamBuilder {
             .await?;
 
         Ok(TcpStream::from_stream_with_receiver(
-            tls_connected,
+            Compat02As03(tls_connected),
             name_server,
             outbound_messages,
         ))

--- a/crates/openssl/src/tls_client_stream.rs
+++ b/crates/openssl/src/tls_client_stream.rs
@@ -18,13 +18,14 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_openssl::SslStream as TokioTlsStream;
 
 use trust_dns_proto::error::ProtoError;
+use trust_dns_proto::iocompat::Compat02As03;
 use trust_dns_proto::tcp::TcpClientStream;
 use trust_dns_proto::xfer::BufDnsStreamHandle;
 
 use super::TlsStreamBuilder;
 
 /// A Type definition for the TLS stream
-pub type TlsClientStream = TcpClientStream<TokioTlsStream<TokioTcpStream>>;
+pub type TlsClientStream = TcpClientStream<Compat02As03<TokioTlsStream<TokioTcpStream>>>;
 
 /// A Builder for the TlsClientStream
 pub struct TlsClientStreamBuilder(TlsStreamBuilder);

--- a/crates/openssl/src/tls_stream.rs
+++ b/crates/openssl/src/tls_stream.rs
@@ -20,6 +20,7 @@ use openssl::x509::{X509Ref, X509};
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio_openssl::{self, SslStream as TokioTlsStream};
 
+use trust_dns_proto::iocompat::Compat02As03;
 use trust_dns_proto::tcp::TcpStream;
 use trust_dns_proto::xfer::BufStreamHandle;
 
@@ -56,7 +57,7 @@ impl TlsIdentityExt for SslContextBuilder {
 }
 
 /// A TlsStream counterpart to the TcpStream which embeds a secure TlsStream
-pub type TlsStream = TcpStream<TokioTlsStream<TokioTcpStream>>;
+pub type TlsStream = TcpStream<Compat02As03<TokioTlsStream<TokioTcpStream>>>;
 
 fn new(certs: Vec<X509>, pkcs12: Option<ParsedPkcs12>) -> io::Result<SslConnector> {
     let mut tls = SslConnector::builder(SslMethod::tls()).map_err(|e| {
@@ -115,7 +116,7 @@ fn new(certs: Vec<X509>, pkcs12: Option<ParsedPkcs12>) -> io::Result<SslConnecto
 ///
 /// This is intended for use with a TlsListener and Incoming connections
 pub fn tls_stream_from_existing_tls_stream(
-    stream: TokioTlsStream<TokioTcpStream>,
+    stream: Compat02As03<TokioTlsStream<TokioTcpStream>>,
     peer_addr: SocketAddr,
 ) -> (TlsStream, BufStreamHandle) {
     let (message_sender, outbound_messages) = unbounded();
@@ -247,7 +248,11 @@ impl TlsStreamBuilder {
         //  sending and receiving tcp packets.
         let stream = Box::pin(
             connect_tls(tls_config, dns_name, name_server).map_ok(move |s| {
-                TcpStream::from_stream_with_receiver(s, name_server, outbound_messages)
+                TcpStream::from_stream_with_receiver(
+                    Compat02As03(s),
+                    name_server,
+                    outbound_messages,
+                )
             }),
         );
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -40,10 +40,8 @@ dnssec-openssl = ["dnssec", "openssl"]
 dnssec-ring = ["dnssec", "ring"]
 dnssec = ["data-encoding"]
 testing = []
-tokio-io = []
-tokio-runtime = [ "tokio/rt-core", "tokio/udp", "tokio/tcp" ]
-tokio-time = [ "tokio/time" ]
-default = ["tokio-runtime", "tokio-time", "tokio-io"]
+tokio-runtime = ["tokio/rt-core", "tokio/udp", "tokio/tcp", "tokio/time"]
+default = ["tokio-runtime"]
 
 serde-config = ["serde"]
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -63,7 +63,7 @@ failure = "0.1"
 futures = "0.3.0"
 idna = "0.2.0"
 lazy_static = "1.0"
-log = "0.4.8"
+log = "0.4.10"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 rand = "0.7"
 ring = { version = "0.16", optional = true, features = ["std"] }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -40,8 +40,10 @@ dnssec-openssl = ["dnssec", "openssl"]
 dnssec-ring = ["dnssec", "ring"]
 dnssec = ["data-encoding"]
 testing = []
+tokio-io = []
 tokio-runtime = [ "tokio/rt-core", "tokio/udp", "tokio/tcp" ]
-default = ["tokio-runtime"]
+tokio-time = [ "tokio/time" ]
+default = [ "tokio-runtime", "tokio-time", "tokio-io" ]
 
 serde-config = ["serde"]
 
@@ -70,7 +72,7 @@ ring = { version = "0.16", optional = true, features = ["std"] }
 serde = { version = "1.0", optional = true }
 smallvec = "1.0"
 socket2 = { version = "0.3.10" }
-tokio = { version = "0.2.1", features = ["time"] }
+tokio = { version = "0.2.1", optional = true }
 url = "2.1.0"
 
 [dev-dependencies]

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -23,8 +23,6 @@ use openssl::error::ErrorStack as SslErrorStack;
 use ring::error::Unspecified;
 
 use failure::{Backtrace, Context, Fail};
-use tokio::time::Elapsed;
-use tokio::time::Error as TimerError;
 
 /// An alias for results returned by functions of this crate
 pub type ProtoResult<T> = ::std::result::Result<T, ProtoError>;
@@ -275,18 +273,6 @@ impl From<Unspecified> for ProtoError {
 impl From<SslErrorStack> for ProtoError {
     fn from(e: SslErrorStack) -> ProtoError {
         e.context(ProtoErrorKind::SSL).into()
-    }
-}
-
-impl From<TimerError> for ProtoError {
-    fn from(e: TimerError) -> ProtoError {
-        e.context(ProtoErrorKind::Timer).into()
-    }
-}
-
-impl From<Elapsed> for ProtoError {
-    fn from(e: Elapsed) -> ProtoError {
-        e.context(ProtoErrorKind::Timeout).into()
     }
 }
 

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -53,7 +53,7 @@ pub mod op;
 pub mod rr;
 pub mod serialize;
 pub mod tcp;
-//#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "testing"))]
 pub mod tests;
 pub mod udp;
 pub mod xfer;
@@ -70,7 +70,7 @@ pub use crate::xfer::secure_dns_handle::SecureDnsHandle;
 #[doc(hidden)]
 pub use crate::xfer::{BufDnsStreamHandle, BufStreamHandle};
 
-#[cfg(feature = "tokio-io")]
+#[cfg(feature = "tokio-runtime")]
 #[doc(hidden)]
 pub mod iocompat {
     use std::io;
@@ -144,10 +144,10 @@ pub trait Time {
 }
 
 /// New type which is implemented using tokio::time::{Delay, Timeout}
-#[cfg(any(test, feature = "tokio-time"))]
+#[cfg(any(test, feature = "tokio-runtime"))]
 pub struct TokioTime;
 
-#[cfg(any(test, feature = "tokio-time"))]
+#[cfg(any(test, feature = "tokio-runtime"))]
 #[async_trait]
 impl Time for TokioTime {
     async fn delay_for(duration: Duration) -> () {

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -20,7 +20,7 @@ use futures::{Future, Stream, StreamExt, TryFutureExt};
 use log::warn;
 
 use crate::error::ProtoError;
-#[cfg(feature = "tokio-io")]
+#[cfg(feature = "tokio-runtime")]
 use crate::iocompat::AsyncIo02As03;
 use crate::tcp::{Connect, TcpStream};
 use crate::xfer::{DnsClientStream, SerialMessage};

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -17,11 +17,12 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::stream::{Fuse, Peekable, Stream, StreamExt};
-use futures::{ready, Future, FutureExt, TryFutureExt};
+use futures::{self, ready, Future, FutureExt};
 use log::debug;
 
 use crate::error::*;
 use crate::xfer::{BufStreamHandle, SerialMessage};
+use crate::Time;
 
 /// Trait for TCP connection
 #[async_trait]
@@ -30,7 +31,7 @@ where
     Self: Sized,
 {
     /// TcpSteam
-    type Transport: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send;
+    type Transport: futures::io::AsyncRead + futures::io::AsyncWrite + Send;
 
     /// connect to tcp
     async fn connect(addr: SocketAddr) -> io::Result<Self::Transport>;
@@ -118,7 +119,7 @@ impl<S: Connect + 'static> TcpStream<S> {
     ///
     /// * `name_server` - the IP and Port of the DNS server to connect to
     #[allow(clippy::new_ret_no_self, clippy::type_complexity)]
-    pub fn new<E>(
+    pub fn new<E, TE>(
         name_server: SocketAddr,
     ) -> (
         impl Future<Output = Result<TcpStream<S::Transport>, io::Error>> + Send,
@@ -126,8 +127,9 @@ impl<S: Connect + 'static> TcpStream<S> {
     )
     where
         E: FromProtoError,
+        TE: Time,
     {
-        Self::with_timeout(name_server, Duration::from_secs(5))
+        Self::with_timeout::<TE>(name_server, Duration::from_secs(5))
     }
 
     /// Creates a new future of the eventually establish a IO stream connection or fail trying
@@ -137,7 +139,7 @@ impl<S: Connect + 'static> TcpStream<S> {
     /// * `name_server` - the IP and Port of the DNS server to connect to
     /// * `timeout` - connection timeout
     #[allow(clippy::type_complexity)]
-    pub fn with_timeout(
+    pub fn with_timeout<TE: Time>(
         name_server: SocketAddr,
         timeout: Duration,
     ) -> (
@@ -148,49 +150,44 @@ impl<S: Connect + 'static> TcpStream<S> {
         let message_sender = BufStreamHandle::new(message_sender);
         // This set of futures collapses the next tcp socket into a stream which can be used for
         //  sending and receiving tcp packets.
-        let stream_fut = Self::connect(name_server, timeout, outbound_messages);
+        let stream_fut = Self::connect::<TE>(name_server, timeout, outbound_messages);
 
         (stream_fut, message_sender)
     }
 
-    async fn connect(
+    async fn connect<TE: Time>(
         name_server: SocketAddr,
         timeout: Duration,
         outbound_messages: UnboundedReceiver<SerialMessage>,
     ) -> Result<TcpStream<S::Transport>, io::Error> {
         let tcp = S::connect(name_server);
-        tokio::time::timeout(timeout, tcp)
-            .map_err(move |_| {
-                debug!("timed out connecting to: {}", name_server);
-                io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    format!("timed out connecting to: {}", name_server),
-                )
-            })
-            .map(
-                move |tcp_stream: Result<Result<S::Transport, io::Error>, _>| {
-                    tcp_stream
-                        .and_then(|tcp_stream| tcp_stream)
-                        .map(|tcp_stream| {
-                            debug!("TCP connection established to: {}", name_server);
-                            TcpStream {
-                                socket: tcp_stream,
-                                outbound_messages: outbound_messages.fuse().peekable(),
-                                send_state: None,
-                                read_state: ReadTcpState::LenBytes {
-                                    pos: 0,
-                                    bytes: [0u8; 2],
-                                },
-                                peer_addr: name_server,
-                            }
-                        })
-                },
-            )
-            .await
+        TE::timeout::<
+            Pin<Box<dyn Future<Output = Result<<S as Connect>::Transport, io::Error>> + Send>>,
+        >(timeout, tcp)
+        .map(
+            move |tcp_stream: Result<Result<S::Transport, io::Error>, _>| {
+                tcp_stream
+                    .and_then(|tcp_stream| tcp_stream)
+                    .map(|tcp_stream| {
+                        debug!("TCP connection established to: {}", name_server);
+                        TcpStream {
+                            socket: tcp_stream,
+                            outbound_messages: outbound_messages.fuse().peekable(),
+                            send_state: None,
+                            read_state: ReadTcpState::LenBytes {
+                                pos: 0,
+                                bytes: [0u8; 2],
+                            },
+                            peer_addr: name_server,
+                        }
+                    })
+            },
+        )
+        .await
     }
 }
 
-impl<S: tokio::io::AsyncRead + tokio::io::AsyncWrite> TcpStream<S> {
+impl<S: futures::io::AsyncRead + futures::io::AsyncWrite> TcpStream<S> {
     /// Initializes a TcpStream.
     ///
     /// This is intended for use with a TcpListener and Incoming.
@@ -227,7 +224,7 @@ impl<S: tokio::io::AsyncRead + tokio::io::AsyncWrite> TcpStream<S> {
     }
 }
 
-impl<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> Stream for TcpStream<S> {
+impl<S: futures::io::AsyncRead + futures::io::AsyncWrite + Unpin> Stream for TcpStream<S> {
     type Item = io::Result<SerialMessage>;
 
     #[allow(clippy::cognitive_complexity)]
@@ -450,20 +447,27 @@ mod tests {
     #[cfg(not(target_os = "linux"))]
     use std::net::Ipv6Addr;
     use std::net::{IpAddr, Ipv4Addr};
-    use tokio::{net::TcpStream as TokioTcpStream, runtime::Runtime};
+    use tokio::net::TcpStream as TokioTcpStream;
+    use tokio::runtime::Runtime;
+
+    use crate::iocompat::Compat02As03;
+    use crate::TokioTime;
 
     use crate::tests::tcp_stream_test;
     #[test]
     fn test_tcp_stream_ipv4() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_stream_test::<TokioTcpStream, Runtime>(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), io_loop)
+        tcp_stream_test::<Compat02As03<TokioTcpStream>, Runtime, TokioTime>(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            io_loop,
+        )
     }
 
     #[test]
     #[cfg(not(target_os = "linux"))] // ignored until Travis-CI fixes IPv6
     fn test_tcp_stream_ipv6() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_stream_test::<TokioTcpStream, Runtime>(
+        tcp_stream_test::<Compat02As03<TokioTcpStream>, Runtime, TokioTime>(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
             io_loop,
         )

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -4,7 +4,7 @@ use futures::stream::StreamExt;
 use log::debug;
 
 use crate::udp::{UdpClientStream, UdpSocket, UdpStream};
-use crate::Executor;
+use crate::{Executor, Time};
 
 /// Test next random udpsocket.
 pub fn next_random_socket_test<S: UdpSocket + Send + 'static, E: Executor>(mut exec: E) {
@@ -109,7 +109,7 @@ pub fn udp_stream_test<S: UdpSocket + Send + 'static, E: Executor>(
 
 /// Test udp_client_stream.
 #[allow(clippy::print_stdout)]
-pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor>(
+pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor, TE: Time>(
     server_addr: IpAddr,
     mut exec: E,
 ) {
@@ -207,7 +207,7 @@ pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor>(
     for i in 0..send_recv_times {
         // test once
         let response_future = exec.block_on(future::lazy(|cx| {
-            stream.send_message(DnsRequest::new(query.clone(), Default::default()), cx)
+            stream.send_message::<TE>(DnsRequest::new(query.clone(), Default::default()), cx)
         }));
         println!("client sending request {}", i);
         let response = match exec.block_on(response_future) {

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -355,7 +355,7 @@ where
         }
 
         // store a Timeout for this message before sending
-        let timeout: TE::Delay = TE::delay_for(self.timeout_duration);
+        let timeout = TE::delay_for(self.timeout_duration);
 
         let (complete, receiver) = oneshot::channel();
 

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -11,6 +11,7 @@ use std::borrow::Borrow;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::{self, Display};
+use std::marker::Unpin;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -23,7 +24,6 @@ use log::{debug, warn};
 use rand;
 use rand::distributions::{Distribution, Standard};
 use smallvec::SmallVec;
-use tokio::{self, time::Delay};
 
 use crate::error::*;
 use crate::op::{Message, MessageFinalizer, OpCode};
@@ -32,6 +32,7 @@ use crate::xfer::{
     SerialMessage,
 };
 use crate::DnsStreamHandle;
+use crate::Time;
 
 const QOS_MAX_RECEIVE_MSGS: usize = 100; // max number of messages to receive from the UDP socket
 
@@ -45,7 +46,7 @@ struct ActiveRequest {
     //  expecting more than one response
     // TODO: change the completion above to a Stream, and don't hold messages...
     responses: SmallVec<[Message; 1]>,
-    timeout: Delay,
+    timeout: Box<dyn Future<Output = ()> + Send + Unpin>,
 }
 
 impl ActiveRequest {
@@ -53,7 +54,7 @@ impl ActiveRequest {
         completion: oneshot::Sender<Result<DnsResponse, ProtoError>>,
         request_id: u16,
         request_options: DnsRequestOptions,
-        timeout: Delay,
+        timeout: Box<dyn Future<Output = ()> + Send + Unpin>,
     ) -> Self {
         ActiveRequest {
             completion,
@@ -308,7 +309,11 @@ where
 {
     type DnsResponseFuture = DnsMultiplexerSerialResponse;
 
-    fn send_message(&mut self, request: DnsRequest, cx: &mut Context) -> Self::DnsResponseFuture {
+    fn send_message<TE: Time>(
+        &mut self,
+        request: DnsRequest,
+        cx: &mut Context,
+    ) -> Self::DnsResponseFuture {
         if self.is_shutdown {
             panic!("can not send messages after stream is shutdown")
         }
@@ -350,12 +355,13 @@ where
         }
 
         // store a Timeout for this message before sending
-        let timeout = tokio::time::delay_for(self.timeout_duration);
+        let timeout: TE::Delay = TE::delay_for(self.timeout_duration);
 
         let (complete, receiver) = oneshot::channel();
 
         // send the message
-        let active_request = ActiveRequest::new(complete, request.id(), request_options, timeout);
+        let active_request =
+            ActiveRequest::new(complete, request.id(), request_options, Box::new(timeout));
 
         match request.to_vec() {
             Ok(buffer) => {
@@ -385,7 +391,7 @@ where
         DnsMultiplexerSerialResponseInner::Completion(receiver).into()
     }
 
-    fn error_response(error: ProtoError) -> Self::DnsResponseFuture {
+    fn error_response<TE: Time>(error: ProtoError) -> Self::DnsResponseFuture {
         DnsMultiplexerSerialResponseInner::Err(Some(error)).into()
     }
 

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -15,6 +15,7 @@ use futures::{ready, Future, Stream};
 use log::{debug, warn};
 
 use crate::error::*;
+use crate::Time;
 
 mod dns_exchange;
 pub mod dns_handle;
@@ -161,10 +162,14 @@ pub trait DnsRequestSender: Stream<Item = Result<(), ProtoError>> + Send + Unpin
     /// # Return
     ///
     /// A future which will resolve to a SerialMessage response
-    fn send_message(&mut self, message: DnsRequest, cx: &mut Context) -> Self::DnsResponseFuture;
+    fn send_message<TE: Time>(
+        &mut self,
+        message: DnsRequest,
+        cx: &mut Context,
+    ) -> Self::DnsResponseFuture;
 
     /// Constructs an error response
-    fn error_response(error: ProtoError) -> Self::DnsResponseFuture;
+    fn error_response<TE: Time>(error: ProtoError) -> Self::DnsResponseFuture;
 
     /// Allows the upstream user to inform the underling stream that it should shutdown.
     ///

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -56,7 +56,7 @@ serde-config = ["serde", "trust-dns-proto/serde-config"]
 # enables experimental the mDNS (multicast) feature
 mdns = ["trust-dns-proto/mdns"]
 
-tokio-runtime = ["tokio/rt-core", "trust-dns-proto/tokio-runtime", "trust-dns-proto/tokio-time"]
+tokio-runtime = ["tokio/rt-core", "trust-dns-proto/tokio-runtime"]
 
 [lib]
 name = "trust_dns_resolver"

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -67,7 +67,7 @@ cfg-if = "0.1.9"
 failure = "0.1"
 futures = "0.3.0"
 lazy_static = "1.0"
-log = "0.4.8"
+log = "0.4.10"
 lru-cache = "0.1.2"
 resolv-conf = { version = "0.6.0", features = ["system"] }
 rustls = {version  = "0.16", optional = true}

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -56,7 +56,7 @@ serde-config = ["serde", "trust-dns-proto/serde-config"]
 # enables experimental the mDNS (multicast) feature
 mdns = ["trust-dns-proto/mdns"]
 
-tokio-runtime = ["tokio/rt-core", "trust-dns-proto/tokio-runtime"]
+tokio-runtime = ["tokio/rt-core", "trust-dns-proto/tokio-runtime", "trust-dns-proto/tokio-time"]
 
 [lib]
 name = "trust_dns_resolver"

--- a/crates/rustls/Cargo.toml
+++ b/crates/rustls/Cargo.toml
@@ -53,7 +53,7 @@ rustls = "0.16"
 tokio = { version = "0.2.1", features = ["tcp", "io-util"] }
 tokio-rustls = { version = "0.12.1", features = ["early-data"] }
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-io", "tokio-runtime"], default-features = false }
+trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-runtime"], default-features = false }
 webpki = "0.21"
 
 [dev-dependencies]

--- a/crates/rustls/Cargo.toml
+++ b/crates/rustls/Cargo.toml
@@ -53,7 +53,7 @@ rustls = "0.16"
 tokio = { version = "0.2.1", features = ["tcp", "io-util"] }
 tokio-rustls = { version = "0.12.1", features = ["early-data"] }
 # disables default features, i.e. openssl...
-trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-runtime"], default-features = false }
+trust-dns-proto = { version = "0.18.0-alpha", path = "../proto", features = ["tokio-io", "tokio-runtime"], default-features = false }
 webpki = "0.21"
 
 [dev-dependencies]

--- a/crates/rustls/Cargo.toml
+++ b/crates/rustls/Cargo.toml
@@ -48,7 +48,7 @@ path = "src/lib.rs"
 
 [dependencies]
 futures = "0.3.0"
-log = "0.4.8"
+log = "0.4.10"
 rustls = "0.16"
 tokio = { version = "0.2.1", features = ["tcp", "io-util"] }
 tokio-rustls = { version = "0.12.1", features = ["early-data"] }

--- a/crates/rustls/src/tls_client_stream.rs
+++ b/crates/rustls/src/tls_client_stream.rs
@@ -16,13 +16,15 @@ use rustls::ClientConfig;
 use tokio::net::TcpStream as TokioTcpStream;
 
 use trust_dns_proto::error::ProtoError;
+use trust_dns_proto::iocompat::Compat02As03;
 use trust_dns_proto::tcp::TcpClientStream;
 use trust_dns_proto::xfer::BufDnsStreamHandle;
 
 use crate::tls_stream::tls_connect;
 
 /// Type of TlsClientStream used with Rustls
-pub type TlsClientStream = TcpClientStream<tokio_rustls::client::TlsStream<TokioTcpStream>>;
+pub type TlsClientStream =
+    TcpClientStream<Compat02As03<tokio_rustls::client::TlsStream<TokioTcpStream>>>;
 
 /// Creates a new TlsStream to the specified name_server
 ///

--- a/crates/rustls/src/tls_stream.rs
+++ b/crates/rustls/src/tls_stream.rs
@@ -20,6 +20,7 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_rustls::TlsConnector;
 use webpki::{DNSName, DNSNameRef};
 
+use trust_dns_proto::iocompat::Compat02As03;
 use trust_dns_proto::tcp::TcpStream;
 use trust_dns_proto::xfer::{BufStreamHandle, SerialMessage};
 
@@ -35,7 +36,7 @@ pub type TlsStream<S> = TcpStream<S>;
 /// Initializes a TlsStream with an existing tokio_tls::TlsStream.
 ///
 /// This is intended for use with a TlsListener and Incoming connections
-pub fn tls_from_stream<S: tokio::io::AsyncRead + tokio::io::AsyncWrite>(
+pub fn tls_from_stream<S: futures::io::AsyncRead + futures::io::AsyncWrite>(
     stream: S,
     peer_addr: SocketAddr,
 ) -> (TlsStream<S>, BufStreamHandle) {
@@ -78,7 +79,12 @@ pub fn tls_connect(
     dns_name: String,
     client_config: Arc<ClientConfig>,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsStream<TokioTlsClientStream>, io::Error>> + Send>>,
+    Pin<
+        Box<
+            dyn Future<Output = Result<TlsStream<Compat02As03<TokioTlsClientStream>>, io::Error>>
+                + Send,
+        >,
+    >,
     BufStreamHandle,
 ) {
     let (message_sender, outbound_messages) = unbounded();
@@ -104,7 +110,7 @@ async fn connect_tls(
     name_server: SocketAddr,
     dns_name: String,
     outbound_messages: UnboundedReceiver<SerialMessage>,
-) -> io::Result<TcpStream<TokioTlsClientStream>> {
+) -> io::Result<TcpStream<Compat02As03<TokioTlsClientStream>>> {
     let tcp = TokioTcpStream::connect(&name_server).await?;
 
     let dns_name = DNSNameRef::try_from_ascii_str(&dns_name)
@@ -122,7 +128,7 @@ async fn connect_tls(
         .await?;
 
     Ok(TcpStream::from_stream_with_receiver(
-        s,
+        Compat02As03(s),
         name_server,
         outbound_messages,
     ))

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -82,7 +82,7 @@ log = "0.4.10"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 rusqlite = { version = "0.21.0", features = ["bundled"], optional = true }
 rustls = { version = "0.16", optional = true }
-serde = { version = "1.0.102", features = ["derive"] }
+serde = { version = "1.0.104", features = ["derive"] }
 time = "0.1"
 tokio = { version = "0.2.1", features = ["stream", "tcp", "udp"] }
 tokio-openssl = { version = "0.4.0", optional = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -78,7 +78,7 @@ failure = "0.1"
 futures = "0.3.0"
 h2 = { version = "0.2.0", features = ["stream"], optional = true }
 http = { version = "0.2", optional = true }
-log = "0.4.8"
+log = "0.4.10"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 rusqlite = { version = "0.20.0", features = ["bundled"], optional = true }
 rustls = { version = "0.16", optional = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -80,7 +80,7 @@ h2 = { version = "0.2.0", features = ["stream"], optional = true }
 http = { version = "0.2", optional = true }
 log = "0.4.10"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
-rusqlite = { version = "0.20.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.21.0", features = ["bundled"], optional = true }
 rustls = { version = "0.16", optional = true }
 serde = { version = "1.0.102", features = ["derive"] }
 time = "0.1"

--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -21,6 +21,7 @@ use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
 
 use proto::error::ProtoError;
+use proto::iocompat::Compat02As03;
 use proto::op::Edns;
 use proto::serialize::binary::{BinDecodable, BinDecoder};
 use proto::tcp::TcpStream;
@@ -141,7 +142,8 @@ impl<T: RequestHandler> ServerFuture<T> {
                     let src_addr = tcp_stream.peer_addr().unwrap();
                     debug!("accepted request from: {}", src_addr);
                     // take the created stream...
-                    let (buf_stream, stream_handle) = TcpStream::from_stream(tcp_stream, src_addr);
+                    let (buf_stream, stream_handle) =
+                        TcpStream::from_stream(Compat02As03(tcp_stream), src_addr);
                     let mut timeout_stream = TimeoutStream::new(buf_stream, timeout);
                     //let request_stream = RequestStream::new(timeout_stream, stream_handle);
 

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -71,7 +71,7 @@ sqlite = ["trust-dns-server/sqlite"]
 chrono = "0.4"
 env_logger = "0.7"
 lazy_static = "1.0"
-log = "0.4.8"
+log = "0.4.10"
 futures = "0.3.1"
 openssl = { version = "0.10", features = ["v102", "v110"] }
 rand = "0.7"

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -75,7 +75,7 @@ log = "0.4.10"
 futures = "0.3.1"
 openssl = { version = "0.10", features = ["v102", "v110"] }
 rand = "0.7"
-rusqlite = { version = "0.20.0", features = ["bundled"] }
+rusqlite = { version = "0.21.0", features = ["bundled"] }
 rustls = { version = "0.16" }
 tokio = { version = "0.2.1", features = ["time", "rt-core"] }
 trust-dns-client= { version = "0.18.0-alpha", path = "../../crates/client" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -54,5 +54,5 @@ trust-dns-client= { version = "0.18.0-alpha", features = ["dnssec-openssl"], pat
 trust-dns-proto = { version = "0.18.0-alpha", features = ["dnssec-openssl"], path = "../crates/proto" }
 trust-dns-resolver = { version = "0.18.0-alpha", features = ["dnssec-openssl"], path = "../crates/resolver" }
 env_logger = "0.7"
-log = "0.4.8"
+log = "0.4.10"
 openssl = { version = "0.10", features = ["v102", "v110"] }


### PR DESCRIPTION
 [trust-dns-proto] Make tokio* optional
   
1. Move from tokio::io::{AsyncRead, AsyncWrite} to futures::io::{AsyncRead, AsyncWrite} and provide a helper struct Compat02As03 for the conversion.
2. Abstract tokio::time::{Delay, Timeout}.
3. Modify the other crates which are impacted by the above two changes.