### PR TITLE
[trust-dns-resolver] Abstract resolver

### DIFF
--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -73,7 +73,7 @@ resolv-conf = { version = "0.6.0", features = ["system"] }
 rustls = {version  = "0.16", optional = true}
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.0"
-tokio = "0.2.1"
+tokio = { version = "0.2.1", optional = true }
 tokio-tls = { version = "0.3.0", optional = true }
 tokio-openssl = { version = "0.4.0", optional = true }
 tokio-rustls = { version = "0.12.1", optional = true }

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate futures;
+#[cfg(feature = "tokio-runtime")]
 extern crate tokio;
 extern crate trust_dns_resolver;
 

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -5,13 +5,14 @@
 
 extern crate env_logger;
 extern crate futures;
+#[cfg(feature = "tokio-runtime")]
 extern crate tokio;
 extern crate trust_dns_resolver;
 
 #[cfg(feature = "tokio-runtime")]
 fn main() {
     use tokio::runtime::Runtime;
-    use trust_dns_resolver::AsyncResolver;
+    use trust_dns_resolver::TokioAsyncResolver;
 
     env_logger::init();
 
@@ -23,7 +24,7 @@ fn main() {
         #[cfg(any(unix, windows))]
         {
             // use the system resolver configuration
-            AsyncResolver::from_system_conf(runtime.handle().clone())
+            TokioAsyncResolver::from_system_conf(runtime.handle().clone())
         }
 
         // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/src/dns_sd.rs
+++ b/crates/resolver/src/dns_sd.rs
@@ -156,6 +156,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::*;
+    use crate::TokioAsyncResolver;
 
     use super::*;
 
@@ -163,7 +164,7 @@ mod tests {
     #[ignore]
     fn test_list_services() {
         let mut io_loop = Runtime::new().unwrap();
-        let resolver = AsyncResolver::new(
+        let resolver = TokioAsyncResolver::new(
             ResolverConfig::default(),
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv6thenIpv4,

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -36,14 +36,14 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::AsyncResolver;
+    use crate::TokioAsyncResolver;
 
     fn https_test(config: ResolverConfig) {
         //env_logger::try_init().ok();
         let mut io_loop = Runtime::new().unwrap();
 
         let resolver =
-            AsyncResolver::new(config, ResolverOpts::default(), io_loop.handle().clone());
+            TokioAsyncResolver::new(config, ResolverOpts::default(), io_loop.handle().clone());
         let resolver = io_loop
             .block_on(resolver)
             .expect("failed to create resolver");

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -96,7 +96,7 @@
 //! # {
 //! use std::net::*;
 //! use tokio::runtime::Runtime;
-//! use trust_dns_resolver::AsyncResolver;
+//! use trust_dns_resolver::TokioAsyncResolver;
 //! use trust_dns_resolver::config::*;
 //!
 //! // We need a Tokio Runtime to run the resolver
@@ -104,7 +104,7 @@
 //! let mut io_loop = Runtime::new().unwrap();
 //!
 //! // Construct a new Resolver with default configuration options
-//! let resolver = AsyncResolver::new(
+//! let resolver = TokioAsyncResolver::new(
 //!     ResolverConfig::default(),
 //!     ResolverOpts::default(),
 //!     io_loop.handle().clone(),
@@ -209,6 +209,7 @@ extern crate resolv_conf;
 #[macro_use]
 extern crate serde;
 extern crate smallvec;
+#[cfg(feature = "tokio-runtime")]
 extern crate tokio;
 #[cfg(feature = "dns-over-https")]
 extern crate trust_dns_https;

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -87,10 +87,9 @@ pub trait RuntimeProvider: Clone + 'static {
 
 /// A type defines the Handle which can spawn future.
 pub trait Spawn {
-    fn spawn_bg(
-        &mut self,
-        future: Pin<Box<dyn Future<Output = Result<(), ProtoError>> + Send + 'static>>,
-    );
+    fn spawn_bg<F>(&mut self, future: F)
+    where
+        F: Future<Output = Result<(), ProtoError>> + Send + 'static;
 }
 
 /// Standard connection implements the default mechanism for creating new Connections
@@ -512,15 +511,15 @@ where
 }
 
 #[cfg(feature = "tokio-runtime")]
-pub mod default_runtime {
+pub mod tokio_runtime {
     use super::*;
     use tokio::net::UdpSocket as TokioUdpSocket;
 
     impl Spawn for tokio::runtime::Handle {
-        fn spawn_bg(
-            &mut self,
-            future: Pin<Box<dyn Future<Output = Result<(), ProtoError>> + Send + 'static>>,
-        ) {
+        fn spawn_bg<F>(&mut self, future: F)
+        where
+            F: Future<Output = Result<(), ProtoError>> + Send + 'static,
+        {
             let _join = self.spawn(future);
         }
     }

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -5,13 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{ready, Future, FutureExt};
+use futures::io::{AsyncRead, AsyncWrite};
+use futures::ready;
+use futures::{Future, FutureExt};
+#[cfg(feature = "tokio-runtime")]
 use tokio::net::TcpStream as TokioTcpStream;
-use tokio::net::UdpSocket as TokioUdpSocket;
-use tokio::{self, runtime::Handle};
 #[cfg(all(
     feature = "dns-over-openssl",
     not(feature = "dns-over-rustls"),
@@ -25,22 +27,33 @@ use tokio_tls::TlsStream as TokioTlsStream;
 
 use proto;
 use proto::error::ProtoError;
-use proto::iocompat::AsyncIo02As03;
+
+#[cfg(feature = "tokio-runtime")]
+use proto::{iocompat::AsyncIo02As03, TokioTime};
+
 #[cfg(feature = "mdns")]
 use proto::multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType};
+
 use proto::op::NoopMessageFinalizer;
-use proto::tcp::{TcpClientConnect, TcpClientStream};
-use proto::udp::{UdpClientConnect, UdpClientStream, UdpResponse};
+
+use proto::udp::UdpClientStream;
+use proto::udp::UdpResponse;
 use proto::xfer::{
-    DnsExchange, DnsExchangeBackground, DnsExchangeConnect, DnsExchangeSend, DnsHandle,
-    DnsMultiplexer, DnsMultiplexerConnect, DnsMultiplexerSerialResponse, DnsRequest, DnsResponse,
+    DnsExchange, DnsExchangeSend, DnsHandle, DnsMultiplexerSerialResponse, DnsRequest, DnsResponse,
 };
-use proto::TokioTime;
+
+use proto::xfer::{DnsExchangeBackground, DnsMultiplexer};
+
+use proto::{
+    tcp::Connect, tcp::TcpClientConnect, tcp::TcpClientStream, udp::UdpClientConnect,
+    udp::UdpSocket, xfer::DnsExchangeConnect, xfer::DnsMultiplexerConnect, Time,
+};
 
 #[cfg(feature = "dns-over-https")]
 use trust_dns_https::{self, HttpsClientConnect, HttpsClientResponse, HttpsClientStream};
 
-use crate::config::{NameServerConfig, Protocol, ResolverOpts};
+use crate::config::Protocol;
+use crate::config::{NameServerConfig, ResolverOpts};
 
 /// A type to allow for custom ConnectionProviders. Needed mainly for mocking purposes.
 ///
@@ -57,27 +70,45 @@ pub trait ConnectionProvider: 'static + Clone + Send + Sync + Unpin {
         -> Self::FutureConn;
 }
 
-fn spawn_bg<F: Future<Output = Result<(), ProtoError>> + Send + 'static>(
-    spawner: &Handle,
-    background: F,
-) {
-    // TODO: maybe do something with this in the future?
-    let _join = spawner.spawn(background);
+/// A type defines runtime.
+pub trait RuntimeProvider: Clone + 'static {
+    /// Handle to the executor;
+    type Handle: Clone + Send + Spawn + Sync + Unpin;
+
+    /// TcpStream
+    type Tcp: AsyncRead + AsyncWrite + Connect + Send + Unpin;
+
+    /// Timer
+    type Timer: Send + Time + Unpin;
+
+    /// UdpSocket
+    type Udp: Send + UdpSocket;
+}
+
+/// A type defines the Handle which can spawn future.
+pub trait Spawn {
+    fn spawn_bg(
+        &mut self,
+        future: Pin<Box<dyn Future<Output = Result<(), ProtoError>> + Send + 'static>>,
+    );
 }
 
 /// Standard connection implements the default mechanism for creating new Connections
 #[derive(Clone)]
-pub struct TokioConnectionProvider(Handle);
+pub struct GenericConnectionProvider<R: RuntimeProvider>(R::Handle);
 
-impl TokioConnectionProvider {
-    pub(crate) fn new(runtime: Handle) -> Self {
-        Self(runtime)
+impl<R: RuntimeProvider> GenericConnectionProvider<R> {
+    pub fn new(handle: R::Handle) -> Self {
+        Self(handle)
     }
 }
 
-impl ConnectionProvider for TokioConnectionProvider {
-    type Conn = TokioConnection;
-    type FutureConn = TokioConnectionFuture;
+impl<R: RuntimeProvider> ConnectionProvider for GenericConnectionProvider<R>
+where
+    <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
+{
+    type Conn = GenericConnection;
+    type FutureConn = ConnectionFuture<R>;
 
     /// Constructs an initial constructor for the ConnectionHandle to be used to establish a
     ///   future connection.
@@ -88,10 +119,8 @@ impl ConnectionProvider for TokioConnectionProvider {
     ) -> Self::FutureConn {
         let dns_connect = match config.protocol {
             Protocol::Udp => {
-                let stream = UdpClientStream::<TokioUdpSocket>::with_timeout(
-                    config.socket_addr,
-                    options.timeout,
-                );
+                let stream =
+                    UdpClientStream::<R::Udp>::with_timeout(config.socket_addr, options.timeout);
                 let exchange = DnsExchange::connect(stream);
                 ConnectionConnect::Udp(exchange)
             }
@@ -100,10 +129,7 @@ impl ConnectionProvider for TokioConnectionProvider {
                 let timeout = options.timeout;
 
                 let (stream, handle) =
-                    TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::with_timeout::<TokioTime>(
-                        socket_addr,
-                        timeout,
-                    );
+                    TcpClientStream::<R::Tcp>::with_timeout::<R::Timer>(socket_addr, timeout);
                 // TODO: need config for Signer...
                 let dns_conn = DnsMultiplexer::with_timeout(
                     stream,
@@ -170,7 +196,7 @@ impl ConnectionProvider for TokioConnectionProvider {
             }
         };
 
-        TokioConnectionFuture {
+        ConnectionFuture {
             connect: dns_connect,
             spawner: self.0.clone(),
         }
@@ -179,25 +205,31 @@ impl ConnectionProvider for TokioConnectionProvider {
 
 /// The variants of all supported connections for the Resolver
 #[allow(clippy::large_enum_variant, clippy::type_complexity)]
-pub(crate) enum ConnectionConnect {
+pub(crate) enum ConnectionConnect<R: RuntimeProvider>
+where
+    <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
+{
     Udp(
         DnsExchangeConnect<
-            UdpClientConnect<TokioUdpSocket>,
-            UdpClientStream<TokioUdpSocket>,
+            UdpClientConnect<R::Udp>,
+            UdpClientStream<R::Udp>,
             UdpResponse,
-            TokioTime,
+            R::Timer,
         >,
     ),
     Tcp(
         DnsExchangeConnect<
             DnsMultiplexerConnect<
-                TcpClientConnect<AsyncIo02As03<TokioTcpStream>>,
-                TcpClientStream<AsyncIo02As03<TokioTcpStream>>,
+                TcpClientConnect<<<R as RuntimeProvider>::Tcp as Connect>::Transport>,
+                TcpClientStream<<<R as RuntimeProvider>::Tcp as Connect>::Transport>,
                 NoopMessageFinalizer,
             >,
-            DnsMultiplexer<TcpClientStream<AsyncIo02As03<TokioTcpStream>>, NoopMessageFinalizer>,
+            DnsMultiplexer<
+                TcpClientStream<<<R as RuntimeProvider>::Tcp as Connect>::Transport>,
+                NoopMessageFinalizer,
+            >,
             DnsMultiplexerSerialResponse,
-            TokioTime,
+            R::Timer,
         >,
     ),
     #[cfg(feature = "dns-over-tls")]
@@ -243,61 +275,67 @@ pub(crate) enum ConnectionConnect {
 
 /// Resolves to a new Connection
 #[must_use = "futures do nothing unless polled"]
-pub struct TokioConnectionFuture {
-    connect: ConnectionConnect,
-    spawner: Handle,
+pub struct ConnectionFuture<R: RuntimeProvider>
+where
+    <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
+{
+    connect: ConnectionConnect<R>,
+    spawner: R::Handle,
 }
 
-impl Future for TokioConnectionFuture {
-    type Output = Result<TokioConnection, ProtoError>;
+impl<R: RuntimeProvider> Future for ConnectionFuture<R>
+where
+    <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
+{
+    type Output = Result<GenericConnection, ProtoError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let (connection, bg) = match &mut self.connect {
             ConnectionConnect::Udp(ref mut conn) => {
                 let (conn, bg) = ready!(conn.poll_unpin(cx))?;
-                let conn = TokioConnection(ConnectionConnected::Udp(conn));
-                let bg = ConnectionBackground(ConnectionBackgroundInner::Udp(bg));
+                let conn = GenericConnection(ConnectionConnected::Udp(conn));
+                let bg = ConnectionBackground::<R>(ConnectionBackgroundInner::Udp(bg));
                 (conn, bg)
             }
             ConnectionConnect::Tcp(ref mut conn) => {
                 let (conn, bg) = ready!(conn.poll_unpin(cx))?;
-                let conn = TokioConnection(ConnectionConnected::Tcp(conn));
-                let bg = ConnectionBackground(ConnectionBackgroundInner::Tcp(bg));
+                let conn = GenericConnection(ConnectionConnected::Tcp(conn));
+                let bg = ConnectionBackground::<R>(ConnectionBackgroundInner::Tcp(bg));
                 (conn, bg)
             }
             #[cfg(feature = "dns-over-tls")]
             ConnectionConnect::Tls(ref mut conn) => {
                 let (conn, bg) = ready!(conn.poll_unpin(cx))?;
-                let conn = TokioConnection(ConnectionConnected::Tls(conn));
-                let bg = ConnectionBackground(ConnectionBackgroundInner::Tls(bg));
+                let conn = GenericConnection(ConnectionConnected::Tls(conn));
+                let bg = ConnectionBackground::<R>(ConnectionBackgroundInner::Tls(bg));
                 (conn, bg)
             }
             #[cfg(feature = "dns-over-https")]
             ConnectionConnect::Https(ref mut conn) => {
                 let (conn, bg) = ready!(conn.poll_unpin(cx))?;
-                let conn = TokioConnection(ConnectionConnected::Https(conn));
-                let bg = ConnectionBackground(ConnectionBackgroundInner::Https(bg));
+                let conn = GenericConnection(ConnectionConnected::Https(conn));
+                let bg = ConnectionBackground::<R>(ConnectionBackgroundInner::Https(bg));
                 (conn, bg)
             }
             #[cfg(feature = "mdns")]
             ConnectionConnect::Mdns(ref mut conn) => {
                 let (conn, bg) = ready!(conn.poll_unpin(cx))?;
-                let conn = TokioConnection(ConnectionConnected::Mdns(conn));
-                let bg = ConnectionBackground(ConnectionBackgroundInner::Mdns(bg));
+                let conn = GenericConnection(ConnectionConnected::Mdns(conn));
+                let bg = ConnectionBackground::<R>(ConnectionBackgroundInner::Mdns(bg));
                 (conn, bg)
             }
         };
-
-        spawn_bg(&self.spawner, bg);
+        self.spawner.spawn_bg(Box::pin(bg));
+        //spawn_bg(&self.spawner, bg);
         Poll::Ready(Ok(connection))
     }
 }
 
 /// A connected DNS handle
 #[derive(Clone)]
-pub struct TokioConnection(ConnectionConnected);
+pub struct GenericConnection(ConnectionConnected);
 
-impl DnsHandle for TokioConnection {
+impl DnsHandle for GenericConnection {
     type Response = ConnectionResponse;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response {
@@ -394,9 +432,14 @@ impl Future for ConnectionResponse {
 
 /// A background task for driving the DNS protocol of the connection
 #[must_use = "futures do nothing unless polled"]
-pub struct ConnectionBackground(ConnectionBackgroundInner);
+pub struct ConnectionBackground<R: RuntimeProvider>(ConnectionBackgroundInner<R>)
+where
+    <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin;
 
-impl Future for ConnectionBackground {
+impl<R: RuntimeProvider> Future for ConnectionBackground<R>
+where
+    <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
+{
     type Output = Result<(), ProtoError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
@@ -407,13 +450,19 @@ impl Future for ConnectionBackground {
 #[allow(clippy::large_enum_variant)]
 #[allow(clippy::type_complexity)]
 #[must_use = "futures do nothing unless polled"]
-pub(crate) enum ConnectionBackgroundInner {
-    Udp(DnsExchangeBackground<UdpClientStream<TokioUdpSocket>, UdpResponse, TokioTime>),
+pub(crate) enum ConnectionBackgroundInner<R: RuntimeProvider>
+where
+    <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
+{
+    Udp(DnsExchangeBackground<UdpClientStream<R::Udp>, UdpResponse, R::Timer>),
     Tcp(
         DnsExchangeBackground<
-            DnsMultiplexer<TcpClientStream<AsyncIo02As03<TokioTcpStream>>, NoopMessageFinalizer>,
+            DnsMultiplexer<
+                TcpClientStream<<<R as RuntimeProvider>::Tcp as Connect>::Transport>,
+                NoopMessageFinalizer,
+            >,
             DnsMultiplexerSerialResponse,
-            TokioTime,
+            R::Timer,
         >,
     ),
     #[cfg(feature = "dns-over-tls")]
@@ -439,7 +488,10 @@ pub(crate) enum ConnectionBackgroundInner {
     ),
 }
 
-impl Future for ConnectionBackgroundInner {
+impl<R: RuntimeProvider> Future for ConnectionBackgroundInner<R>
+where
+    <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
+{
     type Output = Result<(), ProtoError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
@@ -457,4 +509,30 @@ impl Future for ConnectionBackgroundInner {
             Mdns(ref mut bg) => bg.poll_unpin(cx),
         }
     }
+}
+
+#[cfg(feature = "tokio-runtime")]
+pub mod default_runtime {
+    use super::*;
+    use tokio::net::UdpSocket as TokioUdpSocket;
+
+    impl Spawn for tokio::runtime::Handle {
+        fn spawn_bg(
+            &mut self,
+            future: Pin<Box<dyn Future<Output = Result<(), ProtoError>> + Send + 'static>>,
+        ) {
+            let _join = self.spawn(future);
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct TokioRuntime;
+    impl RuntimeProvider for TokioRuntime {
+        type Handle = tokio::runtime::Handle;
+        type Tcp = AsyncIo02As03<TokioTcpStream>;
+        type Timer = TokioTime;
+        type Udp = TokioUdpSocket;
+    }
+    pub type TokioConnection = GenericConnection;
+    pub type TokioConnectionProvider = GenericConnectionProvider<TokioRuntime>;
 }

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -12,12 +12,14 @@ mod name_server_pool;
 mod name_server_state;
 mod name_server_stats;
 
-pub use self::connection_provider::ConnectionProvider;
-#[cfg(feature = "tokio-runtime")]
-pub use self::connection_provider::{TokioConnection, TokioConnectionProvider};
+pub use self::connection_provider::{ConnectionProvider, RuntimeProvider, Spawn};
+pub use self::connection_provider::{GenericConnection, GenericConnectionProvider};
 #[cfg(feature = "mdns")]
 pub(crate) use self::name_server::mdns_nameserver;
 pub use self::name_server::NameServer;
 pub use self::name_server_pool::NameServerPool;
 use self::name_server_state::NameServerState;
 use self::name_server_stats::NameServerStats;
+
+#[cfg(feature = "tokio-runtime")]
+pub use self::connection_provider::default_runtime::{TokioConnection, TokioConnectionProvider};

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -22,4 +22,4 @@ use self::name_server_state::NameServerState;
 use self::name_server_stats::NameServerStats;
 
 #[cfg(feature = "tokio-runtime")]
-pub use self::connection_provider::default_runtime::{TokioConnection, TokioConnectionProvider};
+pub use self::connection_provider::tokio_runtime::{TokioConnection, TokioConnectionProvider};

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use futures::Future;
+#[cfg(feature = "tokio-runtime")]
 use tokio::runtime::Handle;
 
 use proto::error::{ProtoError, ProtoResult};

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -12,6 +12,7 @@ use std::task::{Context, Poll};
 use futures::{future, Future, TryFutureExt};
 use smallvec::SmallVec;
 #[cfg(test)]
+#[cfg(feature = "tokio-runtime")]
 use tokio::runtime::Handle;
 
 use proto::error::ProtoError;

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -32,14 +32,14 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::AsyncResolver;
+    use crate::TokioAsyncResolver;
 
     fn tls_test(config: ResolverConfig) {
         //env_logger::try_init().ok();
         let mut io_loop = Runtime::new().unwrap();
 
         let resolver =
-            AsyncResolver::new(config, ResolverOpts::default(), io_loop.handle().clone());
+            TokioAsyncResolver::new(config, ResolverOpts::default(), io_loop.handle().clone());
         let resolver = io_loop
             .block_on(resolver)
             .expect("failed to create resolver");

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -19,7 +19,7 @@ use trust_dns_client::rr::{LowerName, Name, Record, RecordType};
 use trust_dns_resolver::config::ResolverConfig;
 use trust_dns_resolver::error::ResolveError;
 use trust_dns_resolver::lookup::Lookup as ResolverLookup;
-use trust_dns_resolver::{AsyncResolver, TokioConnection, TokioConnectionProvider};
+use trust_dns_resolver::TokioAsyncResolver;
 
 use crate::authority::{
     Authority, LookupError, LookupObject, MessageRequest, UpdateResult, ZoneType,
@@ -31,7 +31,7 @@ use crate::store::forwarder::ForwardConfig;
 /// This uses the trust-dns-resolver for resolving requests.
 pub struct ForwardAuthority {
     origin: LowerName,
-    resolver: AsyncResolver<TokioConnection, TokioConnectionProvider>,
+    resolver: TokioAsyncResolver,
 }
 
 impl ForwardAuthority {
@@ -39,7 +39,7 @@ impl ForwardAuthority {
     #[allow(clippy::new_without_default)]
     #[doc(hidden)]
     pub async fn new(runtime: Handle) -> Result<Self, String> {
-        let resolver = AsyncResolver::from_system_conf(runtime)
+        let resolver = TokioAsyncResolver::from_system_conf(runtime)
             .await
             .map_err(|e| format!("error constructing new Resolver: {}", e))?;
 
@@ -62,7 +62,7 @@ impl ForwardAuthority {
         let options = config.options.unwrap_or_default();
         let config = ResolverConfig::from_parts(None, vec![], name_servers);
 
-        let resolver = AsyncResolver::new(config, options, runtime)
+        let resolver = TokioAsyncResolver::new(config, options, runtime)
             .await
             .map_err(|e| format!("error constructing new Resolver: {}", e))?;
 


### PR DESCRIPTION
1. Create a trait RuntimeProvider to abstract the resolver
implementation.
2. Make TokioAsyncResolver as default type.
3. Keep the tls related codes unchanged, which may be abstracted at a
later point.
4. Update the other codes and test cases wherever necessary.