### PR TITLE
[trust-dns-resolver] refactor unit tests

### DIFF
--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -115,14 +115,20 @@ pub mod iocompat {
 // This trait is created to facilitate running the tests defined in the tests mod using different types of
 // executors. It's used in Fuchsia OS, please be mindful when update it.
 pub trait Executor {
+    /// Create the implementor itself.
+    fn new() -> Self;
+
     /// Spawns a future object to run synchronously or asynchronously depending on the specific
     /// executor.
     fn block_on<F: Future>(&mut self, future: F) -> F::Output;
 }
 
-//#[cfg(any(test, feature = "testing"))]
 #[cfg(feature = "tokio-runtime")]
 impl Executor for Runtime {
+    fn new() -> Self {
+        Runtime::new().expect("failed to create tokio runtime")
+    }
+
     fn block_on<F: Future>(&mut self, future: F) -> F::Output {
         self.block_on(future)
     }

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -120,7 +120,7 @@ pub trait Executor {
     fn block_on<F: Future>(&mut self, future: F) -> F::Output;
 }
 
-#[cfg(any(test, feature = "testing"))]
+//#[cfg(any(test, feature = "testing"))]
 #[cfg(feature = "tokio-runtime")]
 impl Executor for Runtime {
     fn block_on<F: Future>(&mut self, future: F) -> F::Output {

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -56,6 +56,7 @@ serde-config = ["serde", "trust-dns-proto/serde-config"]
 # enables experimental the mDNS (multicast) feature
 mdns = ["trust-dns-proto/mdns"]
 
+testing = []
 tokio-runtime = ["tokio/rt-core", "trust-dns-proto/tokio-runtime"]
 
 [lib]

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -243,6 +243,8 @@ mod tls;
 // reexports from proto
 pub use self::proto::rr::{IntoName, Name, TryParseIp};
 
+#[cfg(feature = "testing")]
+pub use async_resolver::testing;
 pub use async_resolver::AsyncResolver;
 #[cfg(feature = "tokio-runtime")]
 pub use async_resolver::TokioAsyncResolver;

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -22,4 +22,6 @@ use self::name_server_state::NameServerState;
 use self::name_server_stats::NameServerStats;
 
 #[cfg(feature = "tokio-runtime")]
-pub use self::connection_provider::tokio_runtime::{TokioConnection, TokioConnectionProvider};
+pub use self::connection_provider::tokio_runtime::{
+    TokioConnection, TokioConnectionProvider, TokioRuntime,
+};


### PR DESCRIPTION
This allows the unit tests defined in the async_resolver mod to run with different runtime. In my use case, Fuchsia does not need to reinvent the wheel or duplicate the test cases defined in trust-dns-resolver. 