### PR TITLE
Support MX record pointing to root label, meaning no service available.

### DIFF
--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -92,6 +92,7 @@ impl FileAuthority {
             origin,
             records.len()
         );
+        debug!("zone: {:#?}", records);
 
         FileAuthority::new(origin, records, zone_type, allow_axfr)
     }

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -227,7 +227,8 @@ impl InMemoryAuthority {
         and_rrsigs: bool,
         supported_algorithms: SupportedAlgorithms,
     ) -> Option<Arc<RecordSet>> {
-        let wildcard = if name.is_wildcard() {
+        // if this is a wildcard or a root, both should break continued lookups
+        let wildcard = if name.is_wildcard() || name.is_root() {
             return None;
         } else {
             name.clone().into_wildcard()

--- a/tests/test-data/named_test_configs/example.com.zone
+++ b/tests/test-data/named_test_configs/example.com.zone
@@ -27,3 +27,5 @@ aname-chain     ANAME   alias
 server          SRV     1 1 443 alias
 
 *.wildcard      CNAME   www
+
+no-service 86400 IN MX 0 .


### PR DESCRIPTION
fixes: #980