### PR TITLE
Mark socket2 as optional, it does not work on the wasm32-unknown-unknown platform.

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -69,7 +69,7 @@ rand = "0.7"
 ring = { version = "0.16", optional = true, features = ["std"] }
 serde = { version = "1.0", optional = true }
 smallvec = "1.0"
-socket2 = { version = "0.3.10" }
+socket2 = { version = "0.3.10", optional = true }
 tokio = { version = "0.2.1", optional = true }
 url = "2.1.0"
 


### PR DESCRIPTION
I want to use trust-dns as an in-browser DNS client (using a dns-over-https resolver).
This will eventually require trust-dns to export some kind of API that is not considered unstable, but by marking socket2 as optional, it is possible to experiment with this (I have a working proof of concept).

I have not noticed any problem with this change for running the tests, but did not look into it beyond that. Are there any problems that could be expected from this change?

I might also open an issue to discuss the way towards the in-browser client. Either by exposing a stable crate that such a client can depend on, or for implementing such a client as a part this project.