### PR TITLE
Implement ProtoError as a JsValue.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -51,6 +51,8 @@ mdns = ["socket2/reuseport"]
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
 # mtls = ["tls"]
 
+wasm-bindgen-impls = ["wasm-bindgen"]
+
 [lib]
 name = "trust_dns_proto"
 path = "src/lib.rs"
@@ -73,6 +75,7 @@ socket2 = { version = "0.3.10", optional = true }
 thiserror = "1.0.9"
 tokio = { version = "0.2.1", optional = true }
 url = "2.1.0"
+wasm-bindgen = { version = "0.2.58", optional = true }
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -353,6 +353,13 @@ impl From<ProtoError> for String {
     }
 }
 
+#[cfg(feature = "wasm-bindgen-impls")]
+impl From<ProtoError> for wasm_bindgen::JsValue {
+    fn from(e: ProtoError) -> Self {
+        e.to_string().into()
+    }
+}
+
 impl Clone for ProtoErrorKind {
     fn clone(&self) -> Self {
         use self::ProtoErrorKind::*;


### PR DESCRIPTION
This improves error handling within WebAssembly modules.