### PR TITLE
#wg-wasm tips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -51,7 +51,7 @@ mdns = ["socket2/reuseport"]
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
 # mtls = ["tls"]
 
-wasm-bindgen-impls = ["wasm-bindgen"]
+wasm-bindgen = ["wasm-bindgen-crate"]
 
 [lib]
 name = "trust_dns_proto"
@@ -75,7 +75,7 @@ socket2 = { version = "0.3.10", optional = true }
 thiserror = "1.0.9"
 tokio = { version = "0.2.1", optional = true }
 url = "2.1.0"
-wasm-bindgen = { version = "0.2.58", optional = true }
+wasm-bindgen-crate = { version = "0.2.58", optional = true, package = "wasm-bindgen" }
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -51,7 +51,7 @@ mdns = ["socket2/reuseport"]
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
 # mtls = ["tls"]
 
-wasm-bindgen = ["wasm-bindgen-crate"]
+wasm-bindgen = ["wasm-bindgen-crate", "js-sys"]
 
 [lib]
 name = "trust_dns_proto"
@@ -64,6 +64,7 @@ data-encoding = { version = "2.1.0", optional = true }
 enum-as-inner = "0.3"
 futures = "0.3.0"
 idna = "0.2.0"
+js-sys = { version = "0.3.35", optional = true }
 lazy_static = "1.0"
 log = "0.4"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -353,8 +353,8 @@ impl From<ProtoError> for String {
     }
 }
 
-#[cfg(feature = "wasm-bindgen-impls")]
-impl From<ProtoError> for wasm_bindgen::JsValue {
+#[cfg(feature = "wasm-bindgen")]
+impl From<ProtoError> for wasm_bindgen_crate::JsValue {
     fn from(e: ProtoError) -> Self {
         e.to_string().into()
     }

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -356,7 +356,7 @@ impl From<ProtoError> for String {
 #[cfg(feature = "wasm-bindgen")]
 impl From<ProtoError> for wasm_bindgen_crate::JsValue {
     fn from(e: ProtoError) -> Self {
-        e.to_string().into()
+        js_sys::Error::new(&e.to_string()).into()
     }
 }
 


### PR DESCRIPTION
As I mentioned on discord, I asked on #wg-wasm about the proper way to do the previous change. I received 2 tips:
 - Using "wasm-bindgen" as the feature name is the most straight-forward for users, but it requires renaming the dependency.
 - Directly returning a JS string as an error result is considered bad practice. js_sys::Error is provided for this purpose, just like one would do it in Javascript.