### PR TITLE
[trust-dns-resolver] make some crates optional

### DIFF
--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -36,7 +36,7 @@ codecov = { repository = "bluejekyll/trust-dns", branch = "master", service = "g
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["tokio-runtime"]
+default = ["system-config", "tokio-runtime"]
 dns-over-native-tls = ["dns-over-tls", "tokio-tls", "trust-dns-native-tls"]
 # DNS over TLS with OpenSSL currently needs a good way to set default CAs, use rustls or native-tls
 dns-over-openssl = ["dns-over-tls", "trust-dns-openssl", "tokio-openssl"]
@@ -52,6 +52,7 @@ dnssec-ring = ["dnssec", "trust-dns-proto/dnssec-ring"]
 dnssec = []
 
 serde-config = ["serde", "trust-dns-proto/serde-config"]
+system-config = ["ipconfig", "resolv-conf"]
 
 # enables experimental the mDNS (multicast) feature
 mdns = ["trust-dns-proto/mdns"]
@@ -70,7 +71,7 @@ futures = "0.3.0"
 lazy_static = "1.0"
 log = "0.4"
 lru-cache = "0.1.2"
-resolv-conf = { version = "0.6.0", features = ["system"] }
+resolv-conf = { version = "0.6.0", optional = true, features = ["system"] }
 rustls = {version  = "0.16", optional = true}
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.0"
@@ -87,7 +88,7 @@ trust-dns-rustls = { version = "0.19.0", path = "../rustls", optional = true }
 webpki-roots = { version = "0.18", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-ipconfig = { version = "0.2.0" }
+ipconfig = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -131,6 +131,7 @@ impl TokioAsyncResolver {
     ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
     #[cfg(any(unix, target_os = "windows"))]
+    #[cfg(feature = "system-config")]
     pub async fn tokio_from_system_conf() -> Result<Self, ResolveError> {
         use tokio::runtime::Handle;
         Self::from_system_conf(Handle::current()).await
@@ -168,6 +169,7 @@ impl<R: RuntimeProvider> AsyncResolver<GenericConnection, GenericConnectionProvi
     ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
     #[cfg(any(unix, target_os = "windows"))]
+    #[cfg(feature = "system-config")]
     pub async fn from_system_conf(runtime: R::Handle) -> Result<Self, ResolveError> {
         Self::from_system_conf_with_provider(GenericConnectionProvider::<R>::new(runtime)).await
     }
@@ -256,6 +258,7 @@ impl<C: DnsHandle, P: ConnectionProvider<Conn = C>> AsyncResolver<C, P> {
     ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
     #[cfg(any(unix, target_os = "windows"))]
+    #[cfg(feature = "system-config")]
     pub async fn from_system_conf_with_provider(conn_provider: P) -> Result<Self, ResolveError> {
         let (config, options) = super::system_conf::read_system_conf()?;
         Self::new_with_conn(config, options, conn_provider).await
@@ -649,6 +652,7 @@ pub mod testing {
         }
     }
 
+    #[cfg(feature = "system-config")]
     /// Test AsyncResolver created from system configuration with IP lookup.
     pub fn system_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
@@ -681,6 +685,7 @@ pub mod testing {
         }
     }
 
+    #[cfg(feature = "system-config")]
     /// Test AsyncResolver created from system configuration with host lookups.
     pub fn hosts_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
@@ -1193,6 +1198,7 @@ mod tests {
     #[test]
     #[ignore]
     #[cfg(any(unix, target_os = "windows"))]
+    #[cfg(feature = "system-config")]
     fn test_system_lookup() {
         use super::testing::system_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -202,6 +202,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 extern crate lru_cache;
+#[cfg(feature = "unix-config")]
 extern crate resolv_conf;
 #[cfg(feature = "serde-config")]
 #[macro_use]

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -105,6 +105,7 @@ impl Resolver {
     ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
     #[cfg(any(unix, target_os = "windows"))]
+    #[cfg(feature = "system-config")]
     pub fn from_system_conf() -> io::Result<Self> {
         let (config, options) = super::system_conf::read_system_conf()?;
         Self::new(config, options)

--- a/crates/resolver/src/system_conf/mod.rs
+++ b/crates/resolver/src/system_conf/mod.rs
@@ -13,13 +13,17 @@
 #![allow(missing_docs, unused_extern_crates)]
 
 #[cfg(unix)]
+#[cfg(feature = "system-config")]
 mod unix;
 
 #[cfg(unix)]
+#[cfg(feature = "system-config")]
 pub use self::unix::read_system_conf;
 
 #[cfg(windows)]
+#[cfg(feature = "system-config")]
 mod windows;
 
 #[cfg(target_os = "windows")]
+#[cfg(feature = "system-config")]
 pub use self::windows::read_system_conf;


### PR DESCRIPTION
Make ipconfig and resolv-conf which are related to dns config optional