### PR TITLE
Remove unused `futures` default features

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -73,7 +73,7 @@ path = "src/named.rs"
 [dependencies]
 chrono = "0.4"
 clap = "2.33"
-futures = "0.3.0"
+futures = { version = "0.3.0", default-features = false, features = ["std"] }
 log = "0.4"
 rustls = { version = "0.16", optional = true }
 tokio = { version = "0.2.1", features = ["rt-core", "rt-threaded", "time"] }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)
 description = """
-Trust-DNS is a safe and secure DNS library. This is the Client library with DNSec support. 
+Trust-DNS is a safe and secure DNS library. This is the Client library with DNSec support.
  DNSSec with NSEC validation for negative records, is complete. The client supports
  dynamic DNS with SIG0 authenticated requests, implementing easy to use high level
  funtions. Trust-DNS is based on the Tokio and Futures libraries, which means
@@ -68,7 +68,7 @@ path = "src/lib.rs"
 backtrace = "0.3.40"
 chrono = "0.4"
 data-encoding = "2.1.0"
-futures = "0.3.0"
+futures = { version = "0.3.0", default-features = false, features = ["std"] }
 lazy_static = "1.0"
 log = "0.4"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -84,4 +84,5 @@ trust-dns-proto = { version = "0.19.2", path = "../proto", features = ["dnssec"]
 webpki = { version = "0.21", optional = true }
 
 [dev-dependencies]
+futures = { version = "0.3.0", default-features = false, features = ["std", "executor"] }
 openssl = { version = "0.10", features = ["v102", "v110"], optional = false }

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -67,3 +67,4 @@ webpki = "0.21"
 
 [dev-dependencies]
 env_logger = "0.7"
+futures = { version = "0.3.0", default-features = false, features = ["std", "executor"] }

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -50,7 +50,7 @@ path = "src/lib.rs"
 backtrace = "0.3.40"
 bytes = "0.5"
 data-encoding = "2.1.0"
-futures = "0.3.0"
+futures = { version = "0.3.0", default-features = false, features = ["std"] }
 h2 = { version = "0.2.0", features = ["stream"] }
 http = "0.2"
 log = "0.4"

--- a/crates/native-tls/Cargo.toml
+++ b/crates/native-tls/Cargo.toml
@@ -47,7 +47,7 @@ name = "trust_dns_native_tls"
 path = "src/lib.rs"
 
 [dependencies]
-futures = "0.3.0"
+futures = { version = "0.3.0", default-features = false, features = ["std"] }
 native-tls = "0.2"
 tokio = "0.2.1"
 tokio-tls = "0.3.0"

--- a/crates/openssl/Cargo.toml
+++ b/crates/openssl/Cargo.toml
@@ -47,7 +47,7 @@ name = "trust_dns_openssl"
 path = "src/lib.rs"
 
 [dependencies]
-futures = "0.3.0"
+futures = { version = "0.3.0", default-features = false, features = ["std"] }
 openssl = { version = "0.10", features = ["v102", "v110"] }
 tokio-openssl = "0.4.0"
 tokio = "0.2.1"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -80,4 +80,5 @@ wasm-bindgen-crate = { version = "0.2.58", optional = true, package = "wasm-bind
 
 [dev-dependencies]
 env_logger = "0.7"
+futures = { version = "0.3.0", default-features = false, features = ["std", "executor"] }
 tokio = { version = "0.2.1", features = ["rt-core", "time"] }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -62,7 +62,7 @@ async-trait = "0.1.22"
 backtrace = "0.3.40"
 data-encoding = { version = "2.1.0", optional = true }
 enum-as-inner = "0.3"
-futures = "0.3.0"
+futures = { version = "0.3.0", default-features = false, features = ["std"] }
 idna = "0.2.0"
 js-sys = { version = "0.3.35", optional = true }
 lazy_static = "1.0"

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -67,7 +67,7 @@ path = "src/lib.rs"
 [dependencies]
 backtrace = "0.3.40"
 cfg-if = "0.1.9"
-futures = "0.3.0"
+futures = { version = "0.3.0", default-features = false, features = ["std"] }
 lazy_static = "1.0"
 log = "0.4"
 lru-cache = "0.1.2"

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -83,7 +83,7 @@ tokio-rustls = { version = "0.12.1", optional = true }
 trust-dns-https = { version = "0.19.2", path = "../https", optional = true }
 trust-dns-native-tls = { version = "0.19.2", path = "../native-tls", optional = true }
 trust-dns-openssl = { version = "0.19.2", path = "../openssl", optional = true }
-trust-dns-proto = { version = "0.19.2", path = "../proto" , default-features = false }
+trust-dns-proto = { version = "0.19.2", path = "../proto", default-features = false }
 trust-dns-rustls = { version = "0.19.2", path = "../rustls", optional = true }
 webpki-roots = { version = "0.18", optional = true }
 
@@ -92,3 +92,4 @@ ipconfig = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.7"
+futures = { version = "0.3.0", default-features = false, features = ["std", "executor"] }

--- a/crates/rustls/Cargo.toml
+++ b/crates/rustls/Cargo.toml
@@ -47,7 +47,7 @@ name = "trust_dns_rustls"
 path = "src/lib.rs"
 
 [dependencies]
-futures = "0.3.0"
+futures = { version = "0.3.0", default-features = false, features = ["std"] }
 log = "0.4"
 rustls = "0.16"
 tokio = { version = "0.2.1", features = ["tcp", "io-util"] }


### PR DESCRIPTION
Remove unused dependency over `futures-executor`.

Closes #1002.