### PR TITLE
Cleanup unimplemented for RData parser

### DIFF
--- a/crates/client/src/serialize/txt/rdata_parsers/null.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/null.rs
@@ -21,7 +21,6 @@ use crate::rr::rdata::NULL;
 
 /// Parse the RData from a set of Tokens
 #[allow(unused)]
-#[allow(clippy::unimplemented)] // TODO: remove and change to an error
 pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<NULL> {
-    unimplemented!()
+    Err(ParseError::from(ParseErrorKind::Msg("NULL record type is not parsable".to_string())))
 }

--- a/crates/client/src/serialize/txt/rdata_parsers/null.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/null.rs
@@ -22,5 +22,7 @@ use crate::rr::rdata::NULL;
 /// Parse the RData from a set of Tokens
 #[allow(unused)]
 pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<NULL> {
-    Err(ParseError::from(ParseErrorKind::Msg("Parse is not implemented for NULL record".to_string())))
+    Err(ParseError::from(ParseErrorKind::Msg(
+        "Parse is not implemented for NULL record".to_string(),
+    )))
 }

--- a/crates/client/src/serialize/txt/rdata_parsers/null.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/null.rs
@@ -22,5 +22,5 @@ use crate::rr::rdata::NULL;
 /// Parse the RData from a set of Tokens
 #[allow(unused)]
 pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<NULL> {
-    Err(ParseError::from(ParseErrorKind::Msg("NULL record type is not parsable".to_string())))
+    Err(ParseError::from(ParseErrorKind::Msg("Parse is not implemented for NULL record".to_string())))
 }

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -137,7 +137,6 @@ impl Authority for ForwardAuthority {
         ))
     }
 
-    #[allow(clippy::unimplemented)]
     fn get_nsec_records(
         &self,
         _name: &LowerName,


### PR DESCRIPTION
This PR partially covers #917 except unimplemented `$INCLUDE` from master files. Seems like  it would be valueable to have $INCLUDE implemented not just wrapped into Error, right?