### PR TITLE
Support $INCLUDE for master files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,6 @@ jobs:
         version: ${{ env.CARGO_MAKE_VERSION }}
     
     - name: cargo make publish
+      env:
+        CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
       run: cargo make publish

--- a/crates/client/src/serialize/txt/master.rs
+++ b/crates/client/src/serialize/txt/master.rs
@@ -158,7 +158,9 @@ impl Parser {
 
                     match t {
                         // if Dollar, then $INCLUDE or $ORIGIN
-                        Token::Include => State::Include,
+                        Token::Include => {
+                            return Err(ParseError::from(ParseErrorKind::Message("The parser does not support $INCLUDE. Consider inlining file before parsing")))
+                        },
                         Token::Origin => State::Origin,
                         Token::Ttl => State::Ttl,
 
@@ -197,14 +199,9 @@ impl Parser {
                         _ => return Err(ParseErrorKind::UnexpectedToken(t).into()),
                     }
                 }
-                State::Include => {
-                    match t {
-                        Token::CharData(filepath) => {
-                            State::StartLine // TODO: next token should be EOL
-                        }
-                        _ => return Err(ParseErrorKind::UnexpectedToken(t).into()),
-                    }
-                }
+                State::Include => return Err(ParseError::from(ParseErrorKind::Message(
+                    "The parser does not support $INCLUDE. Consider inlining file before parsing",
+                ))),
                 State::TtlClassType => {
                     match t {
                         // if number, TTL

--- a/crates/client/src/serialize/txt/master.rs
+++ b/crates/client/src/serialize/txt/master.rs
@@ -158,11 +158,7 @@ impl Parser {
 
                     match t {
                         // if Dollar, then $INCLUDE or $ORIGIN
-                        Token::Include => {
-                            return Err(ParseError::from(ParseErrorKind::Message(
-                                "$INCLUDE is not yet implemented",
-                            )))
-                        }
+                        Token::Include => State::Include,
                         Token::Origin => State::Origin,
                         Token::Ttl => State::Ttl,
 
@@ -202,9 +198,12 @@ impl Parser {
                     }
                 }
                 State::Include => {
-                    return Err(ParseError::from(ParseErrorKind::Message(
-                        "$INCLUDE is not yet implemented",
-                    )))
+                    match t {
+                        Token::CharData(filepath) => {
+                            State::StartLine // TODO: next token should be EOL
+                        }
+                        _ => return Err(ParseErrorKind::UnexpectedToken(t).into()),
+                    }
                 }
                 State::TtlClassType => {
                     match t {

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -288,5 +288,24 @@ mod tests {
             RData::A(ip) => assert_eq!(Ipv4Addr::new(127, 0, 0, 1), *ip),
             _ => panic!("wrong rdata type returned"),
         }
+
+        let include_lookup = block_on(Authority::lookup(
+            &authority,
+            &LowerName::from_str("include.alias.example.com.").unwrap(),
+            RecordType::A,
+            false,
+            SupportedAlgorithms::new(),
+        ))
+        .expect("INCLUDE lookup failed");
+
+        match include_lookup
+            .into_iter()
+            .next()
+            .expect("A record not found in authity")
+            .rdata()
+        {
+            RData::A(ip) => assert_eq!(Ipv4Addr::new(127, 0, 0, 5), *ip),
+            _ => panic!("wrong rdata type returned"),
+        }
     }
 }

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -103,7 +103,11 @@ impl FileAuthority {
 
                     let mut include_buf = String::new();
 
-                    debug!("loading included zone file: {:?}", include_zone_path);
+                    info!(
+                        "including file {} into {}",
+                        include_zone_path.display(),
+                        zone_path.display()
+                    );
 
                     FileAuthority::read_file(include_zone_path, &mut include_buf)?;
                     buf.push_str(&include_buf);

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -111,8 +111,19 @@ impl FileAuthority {
             let content = line.unwrap();
             let mut lexer = Lexer::new(&content);
 
-            match (lexer.next_token(), lexer.next_token()) {
-                (Ok(Some(Token::Include)), Ok(Some(Token::CharData(include_path)))) => {
+            match (lexer.next_token(), lexer.next_token(), lexer.next_token()) {
+                (
+                    Ok(Some(Token::Include)),
+                    Ok(Some(Token::CharData(include_path))),
+                    Ok(Some(Token::CharData(_domain))),
+                ) => {
+                    return Err(format!(
+                        "Domain name for $INCLUDE is not supported at {}, trying to include {}",
+                        zone_path.display(),
+                        include_path
+                    ));
+                }
+                (Ok(Some(Token::Include)), Ok(Some(Token::CharData(include_path))), _) => {
                     // RFC1035 (section 5) does not specify how filename for $INCLUDE
                     // should be resolved into file path. The underlying code implements the
                     // following:

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -387,14 +387,6 @@ mod tests {
             _ => panic!("wrong rdata type returned"),
         }
 
-        /// some options how to make it happen:
-        /// 1. parser:parse_file that builds lexer's as it needs
-        ///    (mut lexer should be replaced with current_lexer and
-        ///    stack of "previous" lexer's, swap when we finished with
-        ///    the lexer)
-        /// 2. pub function to "prepare" file before building lexer,
-        ///    going line by line and simply injecting content of a different
-        ///    file before even creating lexer
         let include_lookup = block_on(Authority::lookup(
             &authority,
             &LowerName::from_str("include.alias.example.com.").unwrap(),

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -71,7 +71,8 @@ impl FileAuthority {
     /// even make it configurable, in practice it's hard to expect INCLUDES deeper than
     /// 3-4 levels anyways).
     ///
-    /// TODO: $INCLUDE could specify domain name
+    /// TODO: $INCLUDE could specify domain name -- to support on-flight swap for Origin
+    /// value we definitely need to rethink and rework loader/parser/lexer
     fn read_file(zone_path: PathBuf, buf: &mut String) -> Result<(), String> {
         let file = File::open(&zone_path)
             .map_err(|e| format!("failed to read {}: {:?}", zone_path.display(), e))?;

--- a/tests/test-data/named_test_configs/example.com.zone
+++ b/tests/test-data/named_test_configs/example.com.zone
@@ -29,3 +29,5 @@ server          SRV     1 1 443 alias
 *.wildcard      CNAME   www
 
 no-service 86400 IN MX 0 .
+
+$INCLUDE include.example.com.zone

--- a/tests/test-data/named_test_configs/include.example.com.zone
+++ b/tests/test-data/named_test_configs/include.example.com.zone
@@ -1,0 +1,1 @@
+include.this.has.dots   A       127.0.0.5

--- a/tests/test-data/named_test_configs/include.example.com.zone
+++ b/tests/test-data/named_test_configs/include.example.com.zone
@@ -1,1 +1,1 @@
-include.this.has.dots   A       127.0.0.5
+include.alias	A	127.0.0.5


### PR DESCRIPTION
Note: this is WIP. Sharing earlier to discuss some architectural challenges to get full support for `$INCLUDE`.

Because of how `Parser`/`Lexer` are implemented right now, the approach that I took is to update `FileAuthority` loader to read file line-by-line, run each line through Lexer to detect INCLUDEs, recursively process included file and inline the result. I extended the test file with a single `$INCLUDE` directive to make sure that the approach works in general. It exposes a few interesting problems tho'...

1. `Lexer` is executed twice for the file
2. `Parser` logic is not very intuitive now as it requires file to be pre-processed before parsing. Error message that explains this makes it a little bit better, but overall still feels bad.
3. (this one is the most significant) Regarding the RFC1035 `$INCLUDE` might specify a different origin domain. Meaning that inclining content of the file is not enough, we should actually parse it with respect to origin.

I'm not sure what's the best way forward from here because all of these couples logic of file loader/parser/lexer pretty heavily. Somewhat simple solution would be to define file loaders as a `Lexer` that internally maintains stack of nested lexers flattening stream of tokens. Problem #3 remains unsolved in this case, as far as we need to propagate not only the token, but current origin as well.

@bluejekyll What do you think?