### PR TITLE
SUGGESTION: Allow CNAME records on A/AAAA lookups

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2018"
 # use_try_shorthand = true
 # error_on_line_overflow = false
 # error_on_line_overflow_comments = false

--- a/crates/resolver/src/lookup_state.rs
+++ b/crates/resolver/src/lookup_state.rs
@@ -726,7 +726,12 @@ mod tests {
 
         if let Ok(records) = records {
             if let Records::Exists(records) = records {
-                assert!(records.iter().all(|&(_, ttl)| ttl == 1));
+                for (record, ttl) in records.iter() {
+                    if record.record_type() == RecordType::CNAME {
+                        continue;
+                    }
+                    assert_eq!(ttl, &1);
+                }
             } else {
                 panic!("records don't exist");
             }

--- a/crates/resolver/src/lookup_state.rs
+++ b/crates/resolver/src/lookup_state.rs
@@ -295,13 +295,16 @@ impl<C: DnsHandle + Send + 'static> CachingClient<C> {
                     if query.query_class() == r.dns_class() {
                         // standard evaluation, it's an any type or it's the requested type and the search_name matches
                         if (query.query_type().is_any() || query.query_type() == r.rr_type())
-                            && (search_name.as_ref() == r.name() || query.name() == r.name()) {
-                            return Some((r, ttl))
+                            && (search_name.as_ref() == r.name() || query.name() == r.name())
+                        {
+                            return Some((r, ttl));
                         }
                         // CNAME evaluation, it's an A/AAAA lookup and the record is from the CNAME lookup chain.
-                        if (query.query_type() == RecordType::A || query.query_type() == RecordType::AAAA)
-                            && r.rr_type() == RecordType::CNAME {
-                            return Some((r, ttl))
+                        if (query.query_type() == RecordType::A
+                            || query.query_type() == RecordType::AAAA)
+                            && r.rr_type() == RecordType::CNAME
+                        {
+                            return Some((r, ttl));
                         }
                         // srv evaluation, it's an srv lookup and the srv_search_name/target matches this name
                         //    and it's an IP


### PR DESCRIPTION
This resolves my specific issue mentioned in #184. But I haven't considered what other records that should allow CNAME records and the risk involved with returning too many records or breaking other parts of trust-dns.

@bluejekyll 