### PR TITLE
Export CAA Property::as_str

### DIFF
--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -239,7 +239,8 @@ pub enum Property {
 }
 
 impl Property {
-    fn as_str(&self) -> &str {
+    /// Convert to string form
+    pub fn as_str(&self) -> &str {
         match *self {
             Property::Issue => "issue",
             Property::IssueWild => "issuewild",


### PR DESCRIPTION
I use this as a part of an IRC bot (to provide a !dig command) and without as_str, formatting this is much harder as I'd need to handle all the enum variants myself. This exports as_str from the CAA Property similarly to the DNSSEC Algorithm.

Additionally, I've started looking at implementing Display for some of the record types, but I'm not sure how useful that would be (that isn't included in this PR).