### PR TITLE
Expose LabelIter

### DIFF
--- a/crates/proto/src/rr/domain/mod.rs
+++ b/crates/proto/src/rr/domain/mod.rs
@@ -13,5 +13,5 @@ mod try_parse_ip;
 pub mod usage;
 
 pub use self::label::{IntoLabel, Label};
-pub use self::name::{IntoName, Name};
+pub use self::name::{IntoName, LabelIter, Name};
 pub use self::try_parse_ip::TryParseIp;


### PR DESCRIPTION
Bit inconvenient that the type is used in a public interface, but is not exposed.