### PR TITLE
Increased the UDP buffer size to 4096 as recommended by RFC6891 when …

### DIFF
--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -158,7 +158,7 @@ impl<S: UdpSocket + Send + 'static> Stream for UdpStream<S> {
         // receive all inbound messages
 
         // TODO: this should match edns settings
-        let mut buf = [0u8; 2048];
+        let mut buf = [0u8; 4096];
         let (len, src) = ready!(socket.recv_from(&mut buf).poll_unpin(cx))?;
 
         Poll::Ready(Some(Ok(SerialMessage::new(


### PR DESCRIPTION
# Description

As discussed in issue #1078 this PR increases the UDP buffer size from 2048 to 4096 to allow larger payloads.