### PR TITLE
updated `LookupIpStrategy` documentation

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -617,7 +617,7 @@ pub enum LookupIpStrategy {
 }
 
 impl Default for LookupIpStrategy {
-    /// Returns [`LookupIpStrategy::Ipv4AndIpv6`] as the default.
+    /// Returns [`LookupIpStrategy::Ipv4thenIpv6`] as the default.
     fn default() -> Self {
         LookupIpStrategy::Ipv4thenIpv6
     }


### PR DESCRIPTION
It's also possible that the actual code is what's outdated, but another piece of documentation above seems to agree with the code, so I figured it was just this documentation that hadn't been updated yet.