### PR TITLE
Return `REFUSED` instead of `NXDOMAIN` when server is not an authority

### DIFF
--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -361,7 +361,7 @@ impl Catalog {
                 }
             }
         } else {
-            response_header.set_response_code(ResponseCode::NXDomain);
+            response_header.set_response_code(ResponseCode::Refused);
 
             send_response(
                 response_edns,

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -938,7 +938,12 @@ impl Authority for InMemoryAuthority {
                 {
                     return Box::pin(future::err(LookupError::NameExists));
                 } else {
-                    return Box::pin(future::err(LookupError::from(ResponseCode::NXDomain)));
+                    let code = if self.origin().zone_of(name) {
+                        ResponseCode::NXDomain
+                    } else {
+                        ResponseCode::Refused
+                    };
+                    return Box::pin(future::err(LookupError::from(code)));
                 }
             }
             Err(e) => return Box::pin(future::err(e)),

--- a/crates/server/tests/authority_battery/basic.rs
+++ b/crates/server/tests/authority_battery/basic.rs
@@ -584,14 +584,12 @@ pub fn test_srv<A: Authority<Lookup = AuthLookup>>(authority: A) {
 pub fn test_invalid_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let query = Query::query(Name::from_str("www.google.com.").unwrap(), RecordType::A);
 
-    let lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new()));
+    let lookup = block_on(authority.search(&query.into(), false, SupportedAlgorithms::new()));
 
     let err = lookup.expect_err("Lookup for www.google.com succeeded");
     match err {
-        LookupError::ResponseCode(code) =>
-            assert_eq!(code, ResponseCode::Refused),
-        _ => panic!("invalid error enum variant")
+        LookupError::ResponseCode(code) => assert_eq!(code, ResponseCode::Refused),
+        _ => panic!("invalid error enum variant"),
     }
 }
 

--- a/crates/server/tests/authority_battery/basic.rs
+++ b/crates/server/tests/authority_battery/basic.rs
@@ -591,7 +591,7 @@ pub fn test_invalid_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
     match err {
         LookupError::ResponseCode(code) =>
             assert_eq!(code, ResponseCode::Refused),
-        _ => assert!(false, "invalid error enum variant")
+        _ => panic!("invalid error enum variant")
     }
 }
 

--- a/crates/server/tests/authority_battery/basic.rs
+++ b/crates/server/tests/authority_battery/basic.rs
@@ -589,7 +589,7 @@ macro_rules! define_basic_test {
             #[test]
             fn $f () {
                 // Useful for getting debug logs
-                // env_logger::init();
+                // env_logger::try_init().ok();
 
                 let authority = crate::$new("../../tests/test-data/named_test_configs/example.com.zone", module_path!(), stringify!($f));
                 crate::authority_battery::basic::$f(authority);


### PR DESCRIPTION
This is par for the course for most authoritative servers I could find, for example:

```
fmurphy@Franks-MacBook-Pro server % dig @ns1.google.com example.com                  

; <<>> DiG 9.10.6 <<>> @ns1.google.com example.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: REFUSED, id: 10372
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available
```

If you hop into the [RFC](https://tools.ietf.org/html/rfc1035), it seems pretty clear cut:

```
                3               Name Error - Meaningful only for
                                responses from an authoritative name
                                server, this code signifies that the
                                domain name referenced in the query does
                                not exist.

                5               Refused - The name server refuses to
                                perform the specified operation for
                                policy reasons.  For example, a name
                                server may not wish to provide the
                                information to the particular requester,
                                or a name server may not wish to perform
                                a particular operation (e.g., zone

```

I've probably missed some places, and can amend this PR as necessary.