### PR TITLE
Fully support *ring* for all DNSSEC operations.

### DIFF
--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -72,7 +72,7 @@ fn test_ip_lookup_across_threads() {
 }
 
 #[test]
-#[ignore] // these appear to not work on CI
+#[cfg(feature = "dnssec")]
 fn test_sec_lookup() {
     use testing::sec_lookup_test;
     let io_loop = AsyncStdRuntime::new();
@@ -81,7 +81,7 @@ fn test_sec_lookup() {
 }
 
 #[test]
-#[ignore] // these appear to not work on CI
+#[cfg(feature = "dnssec")]
 fn test_sec_lookup_fails() {
     use testing::sec_lookup_fails_test;
     let io_loop = AsyncStdRuntime::new();

--- a/crates/client/src/tcp/tcp_client_connection.rs
+++ b/crates/client/src/tcp/tcp_client_connection.rs
@@ -11,14 +11,14 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::proto::iocompat::AsyncIo02As03;
-use crate::proto::tcp::{TcpClientConnect, TcpClientStream};
-use crate::proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
-use crate::proto::TokioTime;
 use tokio::net::TcpStream;
 
 use crate::client::ClientConnection;
 use crate::error::*;
+use crate::proto::iocompat::AsyncIo02As03;
+use crate::proto::tcp::{TcpClientConnect, TcpClientStream};
+use crate::proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect, DnsRequestSender};
+use crate::proto::TokioTime;
 use crate::rr::dnssec::Signer;
 
 /// Tcp client connection

--- a/crates/proto/src/rr/dnssec/public_key.rs
+++ b/crates/proto/src/rr/dnssec/public_key.rs
@@ -391,9 +391,9 @@ impl<'k> PublicKey for Rsa<'k> {
     #[cfg(feature = "ring")]
     fn verify(&self, algorithm: Algorithm, message: &[u8], signature: &[u8]) -> ProtoResult<()> {
         let alg = match algorithm {
-            Algorithm::RSASHA256 => &signature::RSA_PKCS1_2048_8192_SHA256,
-            Algorithm::RSASHA512 => &signature::RSA_PKCS1_2048_8192_SHA512,
-            Algorithm::RSASHA1 => &signature::RSA_PKCS1_2048_8192_SHA1_FOR_LEGACY_USE_ONLY,
+            Algorithm::RSASHA256 => &signature::RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
+            Algorithm::RSASHA512 => &signature::RSA_PKCS1_1024_8192_SHA512_FOR_LEGACY_USE_ONLY,
+            Algorithm::RSASHA1 => &signature::RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,
             Algorithm::RSASHA1NSEC3SHA1 => {
                 return Err("*ring* doesn't support RSASHA1NSEC3SHA1 yet".into())
             }

--- a/crates/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -16,6 +16,8 @@
 
 //! public key record data for signing zone records
 
+use std::fmt::{self, Display, Formatter};
+
 use crate::error::*;
 use crate::rr::dnssec::{Algorithm, Digest, DigestType};
 use crate::rr::record_data::RData;
@@ -319,6 +321,19 @@ impl DNSKEY {
 impl From<DNSKEY> for RData {
     fn from(key: DNSKEY) -> RData {
         RData::DNSSEC(super::DNSSECRData::DNSKEY(key))
+    }
+}
+
+impl Display for DNSKEY {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        // this should never really fail
+        let tag = self.calculate_key_tag().unwrap_or(0);
+
+        write!(
+            f,
+            "DNSKEY(alg:{} tag:{} zk:{} scp:{})",
+            self.algorithm, tag, self.zone_key, self.secure_entry_point
+        )
     }
 }
 

--- a/crates/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -328,11 +328,12 @@ impl Display for DNSKEY {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         // this should never really fail
         let tag = self.calculate_key_tag().unwrap_or(0);
+        let len: usize = self.public_key.iter().map(|_: &u8| 8).sum();
 
         write!(
             f,
-            "DNSKEY(alg:{} tag:{} zk:{} scp:{})",
-            self.algorithm, tag, self.zone_key, self.secure_entry_point
+            "DNSKEY(alg:{} tag:{} len:{} zk:{} scp:{})",
+            self.algorithm, tag, len, self.zone_key, self.secure_entry_point
         )
     }
 }

--- a/crates/proto/src/rr/dnssec/rdata/ds.rs
+++ b/crates/proto/src/rr/dnssec/rdata/ds.rs
@@ -16,6 +16,8 @@
 
 //! pointer record from parent zone to child zone for dnskey proof
 
+use std::fmt::{self, Display, Formatter};
+
 use crate::error::*;
 use crate::rr::dnssec::{Algorithm, DigestType};
 use crate::serialize::binary::*;
@@ -181,6 +183,12 @@ impl DS {
     #[cfg(not(any(feature = "openssl", feature = "ring")))]
     pub fn covers(&self, _: &Name, _: &DNSKEY) -> ProtoResult<bool> {
         Err("Ring or OpenSSL must be enabled for this feature".into())
+    }
+}
+
+impl Display for DS {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "DS(tag:{} alg:{})", self.key_tag, self.algorithm)
     }
 }
 

--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -30,7 +30,7 @@ pub mod sig;
 use std::str::FromStr;
 
 use enum_as_inner::EnumAsInner;
-use log::debug;
+use log::trace;
 
 use crate::error::*;
 use crate::rr::rdata::null;
@@ -486,39 +486,39 @@ impl DNSSECRData {
     ) -> ProtoResult<Self> {
         match record_type {
             DNSSECRecordType::DNSKEY => {
-                debug!("reading DNSKEY");
+                trace!("reading DNSKEY");
                 dnskey::read(decoder, rdata_length).map(DNSSECRData::DNSKEY)
             }
             DNSSECRecordType::DS => {
-                debug!("reading DS");
+                trace!("reading DS");
                 ds::read(decoder, rdata_length).map(DNSSECRData::DS)
             }
             DNSSECRecordType::KEY => {
-                debug!("reading KEY");
+                trace!("reading KEY");
                 key::read(decoder, rdata_length).map(DNSSECRData::KEY)
             }
             DNSSECRecordType::NSEC => {
-                debug!("reading NSEC");
+                trace!("reading NSEC");
                 nsec::read(decoder, rdata_length).map(DNSSECRData::NSEC)
             }
             DNSSECRecordType::NSEC3 => {
-                debug!("reading NSEC3");
+                trace!("reading NSEC3");
                 nsec3::read(decoder, rdata_length).map(DNSSECRData::NSEC3)
             }
             DNSSECRecordType::NSEC3PARAM => {
-                debug!("reading NSEC3PARAM");
+                trace!("reading NSEC3PARAM");
                 nsec3param::read(decoder).map(DNSSECRData::NSEC3PARAM)
             }
             DNSSECRecordType::RRSIG => {
-                debug!("reading RRSIG");
+                trace!("reading RRSIG");
                 sig::read(decoder, rdata_length).map(DNSSECRData::SIG)
             }
             DNSSECRecordType::SIG => {
-                debug!("reading SIG");
+                trace!("reading SIG");
                 sig::read(decoder, rdata_length).map(DNSSECRData::SIG)
             }
             DNSSECRecordType::Unknown(code) => {
-                debug!("reading unknown dnssec: {}", code);
+                trace!("reading unknown dnssec: {}", code);
                 null::read(decoder, rdata_length).map(|rdata| DNSSECRData::Unknown { code, rdata })
             }
         }

--- a/crates/proto/src/rr/dnssec/trust_anchor.rs
+++ b/crates/proto/src/rr/dnssec/trust_anchor.rs
@@ -69,6 +69,11 @@ impl TrustAnchor {
     pub fn get(&self, idx: usize) -> &[u8] {
         &self.pkeys[idx]
     }
+
+    /// number of keys in trust_anchor
+    pub fn len(&self) -> usize {
+        self.pkeys.len()
+    }
 }
 
 #[test]

--- a/crates/proto/src/rr/dnssec/trust_anchor.rs
+++ b/crates/proto/src/rr/dnssec/trust_anchor.rs
@@ -24,6 +24,7 @@ const ROOT_ANCHOR_ORIG: &[u8] = include_bytes!("roots/19036.rsa");
 const ROOT_ANCHOR_2018: &[u8] = include_bytes!("roots/20326.rsa");
 
 /// The root set of trust anchors for validating DNSSec, anything in this set will be trusted
+#[derive(Clone)]
 pub struct TrustAnchor {
     // TODO: these should also store some information, or more specifically, metadata from the signed
     //  public certificate.

--- a/crates/proto/src/rr/dnssec/trust_anchor.rs
+++ b/crates/proto/src/rr/dnssec/trust_anchor.rs
@@ -74,6 +74,11 @@ impl TrustAnchor {
     pub fn len(&self) -> usize {
         self.pkeys.len()
     }
+
+    /// returns true if there are no keys in the trust_anchor
+    pub fn is_empty(&self) -> bool {
+        self.pkeys.is_empty()
+    }
 }
 
 #[test]

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -22,7 +22,7 @@ use std::convert::From;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use enum_as_inner::EnumAsInner;
-use log::{debug, warn};
+use log::{trace, warn};
 
 use super::domain::Name;
 use super::rdata;
@@ -619,78 +619,78 @@ impl RData {
 
         let result = match record_type {
             RecordType::A => {
-                debug!("reading A");
+                trace!("reading A");
                 rdata::a::read(decoder).map(RData::A)
             }
             RecordType::AAAA => {
-                debug!("reading AAAA");
+                trace!("reading AAAA");
                 rdata::aaaa::read(decoder).map(RData::AAAA)
             }
             RecordType::ANAME => {
-                debug!("reading ANAME");
+                trace!("reading ANAME");
                 rdata::name::read(decoder).map(RData::ANAME)
             }
             rt @ RecordType::ANY | rt @ RecordType::AXFR | rt @ RecordType::IXFR => {
                 return Err(ProtoErrorKind::UnknownRecordTypeValue(rt.into()).into());
             }
             RecordType::CAA => {
-                debug!("reading CAA");
+                trace!("reading CAA");
                 rdata::caa::read(decoder, rdata_length).map(RData::CAA)
             }
             RecordType::CNAME => {
-                debug!("reading CNAME");
+                trace!("reading CNAME");
                 rdata::name::read(decoder).map(RData::CNAME)
             }
             RecordType::ZERO => {
-                debug!("reading EMPTY");
+                trace!("reading EMPTY");
                 return Ok(RData::ZERO);
             }
             RecordType::MX => {
-                debug!("reading MX");
+                trace!("reading MX");
                 rdata::mx::read(decoder).map(RData::MX)
             }
             RecordType::NAPTR => {
-                debug!("reading NAPTR");
+                trace!("reading NAPTR");
                 rdata::naptr::read(decoder).map(RData::NAPTR)
             }
             RecordType::NULL => {
-                debug!("reading NULL");
+                trace!("reading NULL");
                 rdata::null::read(decoder, rdata_length).map(RData::NULL)
             }
             RecordType::NS => {
-                debug!("reading NS");
+                trace!("reading NS");
                 rdata::name::read(decoder).map(RData::NS)
             }
             RecordType::OPENPGPKEY => {
-                debug!("reading OPENPGPKEY");
+                trace!("reading OPENPGPKEY");
                 rdata::openpgpkey::read(decoder, rdata_length).map(RData::OPENPGPKEY)
             }
             RecordType::OPT => {
-                debug!("reading OPT");
+                trace!("reading OPT");
                 rdata::opt::read(decoder, rdata_length).map(RData::OPT)
             }
             RecordType::PTR => {
-                debug!("reading PTR");
+                trace!("reading PTR");
                 rdata::name::read(decoder).map(RData::PTR)
             }
             RecordType::SOA => {
-                debug!("reading SOA");
+                trace!("reading SOA");
                 rdata::soa::read(decoder).map(RData::SOA)
             }
             RecordType::SRV => {
-                debug!("reading SRV");
+                trace!("reading SRV");
                 rdata::srv::read(decoder).map(RData::SRV)
             }
             RecordType::SSHFP => {
-                debug!("reading SSHFP");
+                trace!("reading SSHFP");
                 rdata::sshfp::read(decoder, rdata_length).map(RData::SSHFP)
             }
             RecordType::TLSA => {
-                debug!("reading TLSA");
+                trace!("reading TLSA");
                 rdata::tlsa::read(decoder, rdata_length).map(RData::TLSA)
             }
             RecordType::TXT => {
-                debug!("reading TXT");
+                trace!("reading TXT");
                 rdata::txt::read(decoder, rdata_length).map(RData::TXT)
             }
             #[cfg(feature = "dnssec")]
@@ -698,7 +698,7 @@ impl RData {
                 DNSSECRData::read(decoder, record_type, rdata_length).map(RData::DNSSEC)
             }
             RecordType::Unknown(code) => {
-                debug!("reading Unknown");
+                trace!("reading Unknown");
                 rdata::null::read(decoder, rdata_length).map(|rdata| RData::Unknown { code, rdata })
             }
         };

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -575,6 +575,8 @@ pub mod testing {
     ) where
         <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
     {
+        env_logger::try_init().ok();
+
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
             ResolverConfig::default(),
             ResolverOpts {
@@ -590,7 +592,7 @@ pub mod testing {
             .expect("failed to run lookup");
 
         // TODO: this test is flaky, sometimes 1 is returned, sometimes 2...
-        assert_eq!(response.iter().count(), 1);
+        //assert_eq!(response.iter().count(), 1);
         for address in response.iter() {
             if address.is_ipv4() {
                 assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));
@@ -638,10 +640,10 @@ pub mod testing {
         let error_str = format!("{}", error);
         let expected_str = format!(
             "{}",
-            ProtoError::from(ProtoErrorKind::RrsigsNotPresent {
+            ResolveError::from(ProtoError::from(ProtoErrorKind::RrsigsNotPresent {
                 name,
                 record_type: RecordType::A
-            })
+            }))
         );
         assert_eq!(error_str, expected_str);
         if let ResolveErrorKind::Proto(_) = *error.kind() {

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -569,6 +569,7 @@ pub mod testing {
     }
 
     /// Test IP lookup from URLs with DNSSec validation.
+    #[cfg(feature = "dnssec")]
     pub fn sec_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
@@ -609,6 +610,7 @@ pub mod testing {
 
     /// Test IP lookup from domains that exist but unsigned with DNSSec validation.
     #[allow(deprecated)]
+    #[cfg(feature = "dnssec")]
     pub fn sec_lookup_fails_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
@@ -1178,6 +1180,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "dnssec")]
     fn test_sec_lookup() {
         use super::testing::sec_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
@@ -1186,6 +1189,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "dnssec")]
     fn test_sec_lookup_fails() {
         use super::testing::sec_lookup_fails_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -575,7 +575,7 @@ pub mod testing {
     ) where
         <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
     {
-        env_logger::try_init().ok();
+        //env_logger::try_init().ok();
 
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
             ResolverConfig::default(),
@@ -1178,7 +1178,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // these appear to not work on CI
     fn test_sec_lookup() {
         use super::testing::sec_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
@@ -1187,7 +1186,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // these appear to not work on CI
     fn test_sec_lookup_fails() {
         use super::testing::sec_lookup_fails_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -132,10 +132,11 @@ where
 }
 
 #[test]
-#[ignore]
 #[allow(deprecated)]
 #[cfg(feature = "dnssec")]
 fn test_secure_query_example_udp() {
+    // env_logger::init();
+
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
     let conn = UdpClientConnection::new(addr).unwrap();
     let client = SyncDnssecClient::new(conn).build();
@@ -144,10 +145,11 @@ fn test_secure_query_example_udp() {
 }
 
 #[test]
-#[ignore]
 #[allow(deprecated)]
 #[cfg(feature = "dnssec")]
 fn test_secure_query_example_tcp() {
+    // env_logger::init();
+
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
     let conn = TcpClientConnection::new(addr).unwrap();
     let client = SyncDnssecClient::new(conn).build();


### PR DESCRIPTION
testing with `RUST_LOG=trust_dns_proto::xfer::dnssec_dns_handle=debug cargo test --features="dnssec-ring" -- --show-output --ignored --exact async_resolver::tests::test_sec_lookup`

Currently the feature `dnssec-ring` is not passing, but `dnssec-openssl` does. This is not a "simple" issue of a bad algorithm, as most of the records to validate. It's only the `example.com.` DS record that fails validation:

```
[2020-06-22T00:19:57Z DEBUG trust_dns_proto::xfer::dnssec_dns_handle] failed validation of (example.com., DNSSEC(DS)) with (com., DNSKEY(alg:RSASHA256 tag:39844 zk:true scp:false))
```

Where as `dnssec-openssl` validates properly:

```
[2020-06-22T00:18:48Z DEBUG trust_dns_proto::xfer::dnssec_dns_handle] validated (example.com., DNSSEC(DS)) with (com., DNSKEY(alg:RSASHA256 tag:39844 zk:true scp:false))
```

----
thanks to @Darkspirit you resolved this discrepancy. between openssl and ring.

I had made a bad assumption that sha256 wasn't being used with 1024 bit keys, but it in fact is. This has been corrected.