### PR TITLE
Make EDNS optional for resolvers

### DIFF
--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -89,8 +89,7 @@ pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
             .set_recursion_desired(true);
 
         // Extended dns
-        {
-            // TODO: this should really be configurable...
+        if options.use_edns {
             let edns = message.edns_mut();
             edns.set_max_payload(MAX_PAYLOAD_LEN);
             edns.set_version(0);

--- a/crates/proto/src/xfer/dns_request.rs
+++ b/crates/proto/src/xfer/dns_request.rs
@@ -21,6 +21,8 @@ pub struct DnsRequestOptions {
     // /// If set, then the request will terminate early if all types have been received
     // pub expected_record_types: Option<SmallVec<[RecordType; 2]>>,
     // TODO: add EDNS options here?
+    /// When true, will add EDNS options to the request.
+    pub use_edns: bool,
 }
 
 /// A DNS request object

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -89,8 +89,15 @@ macro_rules! lookup_fn {
                 }
             };
 
-            self.inner_lookup(name, $r, DnsRequestOptions::default())
-                .await
+            self.inner_lookup(
+                name,
+                $r,
+                DnsRequestOptions {
+                    use_edns: self.options.edns0,
+                    ..Default::default()
+                },
+            )
+            .await
         }
     };
     ($p:ident, $l:ty, $r:path, $t:ty) => {

--- a/crates/resolver/src/dns_sd.rs
+++ b/crates/resolver/src/dns_sd.rs
@@ -47,6 +47,9 @@ impl<C: DnsHandle, P: ConnectionProvider<Conn = C>> DnsSdHandle for AsyncResolve
         let ptr_future = async move {
             let options = DnsRequestOptions {
                 expects_multiple_responses: true,
+                // TODO: This should use the AsyncResolver's options.edns0
+                // setting, but options is private.
+                use_edns: false,
             };
 
             this.inner_lookup(name, RecordType::PTR, options).await


### PR DESCRIPTION
Some servers do not support EDNS, and some (such as the ingress-dns
addon to Minikube) return malformed DNS responses when sent EDNS
additional records. Previously, it was not possible to not send the
EDNS records, despite having a ResolverOpts field for it, which was
confusing.

This commit wires the ResolverOpts edns0 option to a new
DnsRequestOptions field and uses that option to control whether or not
additional EDNS records should be used.

Note: this changes the default behavior of the resolver, as the default
value for ResolverOpts::edns0 is false, but previously the additional
EDNS records would be added anyway. It seems this change is inline with
the desired behavior, as the defaults are intended to match the
resolv.conf defaults, which do not use EDNS.

Signed-off-by: Zvi "CtrlZvi" Effron <viz_skywalker+GitHub@outlook.com>