### PR TITLE
Only fall back on TCP if cons are available

### DIFF
--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -246,12 +246,13 @@ where
                     }
                 })
                 // if UDP fails, try TCP but only if it has connections available
-                .or_else(move |e|
-                    if stream_conns2.is_empty() { 
-                        future::Either::Left(future::err(e)) 
+                .or_else(move |e| {
+                    if stream_conns2.is_empty() {
+                        future::Either::Left(future::err(e))
                     } else {
                         future::Either::Right(Self::try_send(opts, stream_conns2, tcp_message2))
-                    })
+                    }
+                }),
         )
     }
 }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -245,8 +245,13 @@ where
                         future::Either::Right(future::ok(response))
                     }
                 })
-                // if UDP fails, try TCP
-                .or_else(move |_| Self::try_send(opts, stream_conns2, tcp_message2)),
+                // if UDP fails, try TCP but only if it has connections available
+                .or_else(move |e|
+                    if stream_conns2.is_empty() { 
+                        future::Either::Left(future::err(e)) 
+                    } else {
+                        future::Either::Right(Self::try_send(opts, stream_conns2, tcp_message2))
+                    })
         )
     }
 }


### PR DESCRIPTION
`NameServerPool` falls back on TCP if UDP fails, e.g., due to a timeout. It does
this even when no TCP connections are available. This obscures the underlying UDP
error by `ProtoError::from("No connections available")`.

This commit changes this behavior by checking if TCP connections are available
first and if not, passing the original UDP error along.