### PR TITLE
Support for lowercase DNSClass and RecordType fields in zonefiles

### DIFF
--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -207,7 +207,7 @@ impl Parser {
                         // if number, TTL
                         // Token::Number(ref num) => ttl = Some(*num),
                         // One of Class or Type (these cannot be overlapping!)
-                        Token::CharData(data) => {
+                        Token::CharData(mut data) => {
                             // if it's a number it's a ttl
                             let result: ParseResult<u32> = Self::parse_time(&data);
                             if result.is_ok() {
@@ -215,6 +215,7 @@ impl Parser {
                                 State::TtlClassType // hm, should this go to just ClassType?
                             } else {
                                 // if can parse DNSClass, then class
+                                data.make_ascii_uppercase();
                                 let result = DNSClass::from_str(&data);
                                 if result.is_ok() {
                                     class = result.ok();

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -48,7 +48,8 @@ impl FromStr for DNSClass {
     /// assert_eq!(DNSClass::IN, var);
     /// ```
     fn from_str(str: &str) -> ProtoResult<Self> {
-        match str.to_uppercase().as_str() {
+        debug_assert!(str.chars().all(|x| char::is_ascii_uppercase(&x)));
+        match str {
             "IN" => Ok(DNSClass::IN),
             "CH" => Ok(DNSClass::CH),
             "HS" => Ok(DNSClass::HS),

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -48,7 +48,7 @@ impl FromStr for DNSClass {
     /// assert_eq!(DNSClass::IN, var);
     /// ```
     fn from_str(str: &str) -> ProtoResult<Self> {
-        match str {
+        match str.to_uppercase().as_str() {
             "IN" => Ok(DNSClass::IN),
             "CH" => Ok(DNSClass::CH),
             "HS" => Ok(DNSClass::HS),

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -149,7 +149,7 @@ impl FromStr for RecordType {
     /// ```
     fn from_str(str: &str) -> ProtoResult<Self> {
         // TODO missing stuff?
-        match str {
+        match str.to_uppercase().as_str() {
             "A" => Ok(RecordType::A),
             "AAAA" => Ok(RecordType::AAAA),
             "ANAME" => Ok(RecordType::ANAME),

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -149,7 +149,8 @@ impl FromStr for RecordType {
     /// ```
     fn from_str(str: &str) -> ProtoResult<Self> {
         // TODO missing stuff?
-        match str.to_uppercase().as_str() {
+        debug_assert!(str.chars().all(|x| char::is_digit(x, 36)));
+        match str {
             "A" => Ok(RecordType::A),
             "AAAA" => Ok(RecordType::AAAA),
             "ANAME" => Ok(RecordType::ANAME),
@@ -436,7 +437,7 @@ mod tests {
         let mut rtypes = std::collections::HashSet::new();
         for name in record_names.iter().chain(dnssec_record_names) {
             let rtype: RecordType = name.parse().unwrap();
-            assert_eq!(rtype.to_string().as_str(), *name);
+            assert_eq!(rtype.to_string().to_ascii_uppercase().as_str(), *name);
             assert!(rtypes.insert(rtype));
         }
     }

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -59,6 +59,8 @@ certs        CAA 0 issuewild "example.net"
 _443._tcp.www.example.com. IN TLSA (
       0 0 1 d2abde240d7cd3ee6b4b28c54df034b9
             7983a1d16e8a410e4561cb106618e971)
+
+tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.net.      271851  900     1800    6048000 3600
 "###,
     );
 
@@ -96,6 +98,34 @@ _443._tcp.www.example.com. IN TLSA (
         assert_eq!(600, soa.retry());
         assert_eq!(3_600_000, soa.expire());
         assert_eq!(60, soa.minimum());
+    } else {
+        panic!("Not an SOA record!!!") // valid panic, test code
+    }
+
+    let lowercase_record = block_on(authority.lookup(
+        &Name::from_str("tech.").unwrap().into(),
+        RecordType::SOA,
+        false,
+        SupportedAlgorithms::new(),
+    ))
+    .unwrap()
+    .iter()
+    .next()
+    .cloned()
+    .unwrap();
+    assert_eq!(&Name::from_str("tech.").unwrap(), lowercase_record.name());
+    assert_eq!(DNSClass::IN, lowercase_record.dns_class());
+    if let RData::SOA(ref lower_soa) = *lowercase_record.rdata() {
+        assert_eq!(&Name::from_str("ns0.centralnic.net").unwrap(), lower_soa.mname());
+        assert_eq!(
+            &Name::from_str("hostmaster.centralnic.net").unwrap(),
+            lower_soa.rname()
+        );
+        assert_eq!(271851, lower_soa.serial());
+        assert_eq!(900, lower_soa.refresh());
+        assert_eq!(1800, lower_soa.retry());
+        assert_eq!(6_048_000, lower_soa.expire());
+        assert_eq!(3_600, lower_soa.minimum());
     } else {
         panic!("Not an SOA record!!!") // valid panic, test code
     }

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -116,7 +116,10 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     assert_eq!(&Name::from_str("tech.").unwrap(), lowercase_record.name());
     assert_eq!(DNSClass::IN, lowercase_record.dns_class());
     if let RData::SOA(ref lower_soa) = *lowercase_record.rdata() {
-        assert_eq!(&Name::from_str("ns0.centralnic.net").unwrap(), lower_soa.mname());
+        assert_eq!(
+            &Name::from_str("ns0.centralnic.net").unwrap(),
+            lower_soa.mname()
+        );
         assert_eq!(
             &Name::from_str("hostmaster.centralnic.net").unwrap(),
             lower_soa.rname()


### PR DESCRIPTION
Added support for lowercase DNSClass and RecordType fields in zonefile entries, along with tests to validate behavior. Doing this by converting the token to uppercase before matching. Added test to target this case specifically. 

Feature requested to parse TLD zonefiles published by ICANN as a part of their CZDS service. 