### PR TITLE
Fix Glue records resolving

### DIFF
--- a/crates/resolver/src/lookup_state.rs
+++ b/crates/resolver/src/lookup_state.rs
@@ -289,6 +289,10 @@ impl<C: DnsHandle + Send + 'static> CachingClient<C> {
                 .messages_mut()
                 .flat_map(Message::take_additionals)
                 .collect();
+            let name_servers: Vec<Record> = response
+                .messages_mut()
+                .flat_map(Message::take_name_servers)
+                .collect();
 
             // set of names that still require resolution
             // TODO: this needs to be enhanced for SRV
@@ -299,6 +303,7 @@ impl<C: DnsHandle + Send + 'static> CachingClient<C> {
                 .into_iter()
                 // Chained records will generally exist in the additionals section
                 .chain(additionals.into_iter())
+                .chain(name_servers.into_iter())
                 .filter_map(|r| {
                     // because this resolved potentially recursively, we want the min TTL from the chain
                     let ttl = cname_ttl.min(r.ttl());

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -150,7 +150,11 @@ impl<C: DnsHandle, P: ConnectionProvider<Conn = C>> NameServer<C, P> {
                             debug!("{}", note);
                             return Err(ProtoError::from(note));
                         }
-                        ResponseCode::NoError if response.answers().is_empty() => {
+                        ResponseCode::NoError
+                            if response.answers().is_empty()
+                                && response.additionals().is_empty()
+                                && response.name_servers().is_empty() =>
+                        {
                             let note = "Nameserver responded with NoError";
                             debug!("{}", note);
                             return Err(ProtoError::from(note));


### PR DESCRIPTION
NoError error now returns only if answers & additionals & nameservers sections are all empty.
Response records are now chained along with the name_servers section.

fix for #1187