### PR TITLE
Clippy fixes

### DIFF
--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -133,13 +133,12 @@ fn load_zone(
             warn!(
                 "using deprecated SQLite load configuration, please move to [[zones.stores]] form"
             );
-            let zone_file_path =
-                zone_path.ok_or_else(|| "file is a necessary parameter of zone_config")?;
+            let zone_file_path = zone_path.ok_or("file is a necessary parameter of zone_config")?;
             let journal_file_path = PathBuf::from(zone_file_path.clone())
                 .with_extension("jrnl")
                 .to_str()
                 .map(String::from)
-                .ok_or_else(|| "non-unicode characters in file name")?;
+                .ok_or("non-unicode characters in file name")?;
 
             let config = SqliteConfig {
                 zone_file_path,
@@ -159,8 +158,7 @@ fn load_zone(
         }
         None => {
             let config = FileConfig {
-                zone_file_path: zone_path
-                    .ok_or_else(|| "file is a necessary parameter of zone_config")?,
+                zone_file_path: zone_path.ok_or("file is a necessary parameter of zone_config")?,
             };
             FileAuthority::try_from_config(
                 zone_name,

--- a/crates/client/src/serialize/txt/rdata_parsers/openpgpkey.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/openpgpkey.rs
@@ -23,9 +23,9 @@ use crate::rr::rdata::OPENPGPKEY;
 ///    of [RFC4648].
 /// ```
 pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<OPENPGPKEY> {
-    let encoded_public_key = tokens
-        .next()
-        .ok_or_else(|| ParseErrorKind::Message("OPENPGPKEY public key field is missing"))?;
+    let encoded_public_key = tokens.next().ok_or(ParseErrorKind::Message(
+        "OPENPGPKEY public key field is missing",
+    ))?;
     let public_key = data_encoding::BASE64.decode(encoded_public_key.as_bytes())?;
     Some(OPENPGPKEY::new(public_key))
         .filter(|_| tokens.next().is_none())

--- a/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
@@ -49,12 +49,12 @@ pub fn parse<'i, I: Iterator<Item = &'i str>>(tokens: I) -> ParseResult<TLSA> {
 
     let token = iter
         .next()
-        .ok_or_else(|| ParseErrorKind::Message("TLSA selector field missing"))?;
+        .ok_or(ParseErrorKind::Message("TLSA selector field missing"))?;
     let selector = to_u8(token)?.into();
 
     let token = iter
         .next()
-        .ok_or_else(|| ParseErrorKind::Message("TLSA matching field missing"))?;
+        .ok_or(ParseErrorKind::Message("TLSA matching field missing"))?;
     let matching = to_u8(token)?.into();
 
     // these are all in hex: "a string of hexadecimal characters"

--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -411,7 +411,7 @@ impl Parser {
                 // TODO, should these all be checked operations?
                 '0'..='9' => {
                     collect *= 10;
-                    collect += c.to_digit(10).ok_or_else(|| ParseErrorKind::CharToInt(c))?;
+                    collect += c.to_digit(10).ok_or(ParseErrorKind::CharToInt(c))?;
                 }
                 'S' | 's' => {
                     value += collect;

--- a/crates/client/src/serialize/txt/zone_lex.rs
+++ b/crates/client/src/serialize/txt/zone_lex.rs
@@ -211,7 +211,7 @@ impl<'a> Lexer<'a> {
                                         ))
                                     })
                                     .and_then(|v| {
-                                        let char_data = char_data.take().ok_or_else(|| {
+                                        let char_data = char_data.take().ok_or({
                                             LexerErrorKind::IllegalState("char_data is None")
                                         })?;
 

--- a/crates/https/src/https_server.rs
+++ b/crates/https/src/https_server.rs
@@ -66,7 +66,7 @@ pub(crate) async fn message_from_post<R>(
 where
     R: Stream<Item = Result<Bytes, h2::Error>> + 'static + Send + Debug + Unpin,
 {
-    let mut bytes = BytesMut::with_capacity(length.unwrap_or(0).min(512).max(4096));
+    let mut bytes = BytesMut::with_capacity(length.unwrap_or(0).min(4096).max(512));
 
     loop {
         match request_stream.next().await {

--- a/crates/https/src/request.rs
+++ b/crates/https/src/request.rs
@@ -116,7 +116,7 @@ pub fn verify<T>(name_server: &str, request: &Request<T>) -> HttpsResult<()> {
         return Err("unsupported content type".into());
     }
 
-    let accept = accept.ok_or_else(|| "Accept is unspecified")?;
+    let accept = accept.ok_or("Accept is unspecified")?;
 
     let any_application_and_dns = |q: &QualityItem<Mime>| -> bool {
         q.item.type_() == crate::MIME_APPLICATION && q.item.subtype() == crate::MIME_DNS_BINARY

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -30,10 +30,7 @@ lazy_static! {
     pub static ref ENABLE_BACKTRACE: bool = {
         use std::env;
         let bt = env::var("RUST_BACKTRACE");
-        match bt.as_ref().map(|s| s as &str) {
-            Ok("full") | Ok("1") => true,
-            _ => false,
-        }
+        matches!(bt.as_ref().map(|s| s as &str), Ok("full") | Ok("1"))
     };
 }
 

--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -316,41 +316,41 @@ impl LabelCmp for CaseInsensitive {
 /// Conversion into a Label
 pub trait IntoLabel: Sized {
     /// Convert this into Label
-    fn into_label(self: Self) -> ProtoResult<Label>;
+    fn into_label(self) -> ProtoResult<Label>;
 }
 
 impl<'a> IntoLabel for &'a Label {
-    fn into_label(self: Self) -> ProtoResult<Label> {
+    fn into_label(self) -> ProtoResult<Label> {
         Ok(self.clone())
     }
 }
 
 impl IntoLabel for Label {
-    fn into_label(self: Self) -> ProtoResult<Label> {
+    fn into_label(self) -> ProtoResult<Label> {
         Ok(self)
     }
 }
 
 impl<'a> IntoLabel for &'a str {
-    fn into_label(self: Self) -> ProtoResult<Label> {
+    fn into_label(self) -> ProtoResult<Label> {
         Label::from_utf8(self)
     }
 }
 
 impl IntoLabel for String {
-    fn into_label(self: Self) -> ProtoResult<Label> {
+    fn into_label(self) -> ProtoResult<Label> {
         Label::from_utf8(&self)
     }
 }
 
 impl<'a> IntoLabel for &'a [u8] {
-    fn into_label(self: Self) -> ProtoResult<Label> {
+    fn into_label(self) -> ProtoResult<Label> {
         Label::from_raw_bytes(self)
     }
 }
 
 impl IntoLabel for Vec<u8> {
-    fn into_label(self: Self) -> ProtoResult<Label> {
+    fn into_label(self) -> ProtoResult<Label> {
         Label::from_raw_bytes(&self)
     }
 }

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -252,38 +252,22 @@ impl Property {
 
     /// true if the property is `issue`
     pub fn is_issue(&self) -> bool {
-        if let Property::Issue = *self {
-            true
-        } else {
-            false
-        }
+        matches!(*self, Property::Issue)
     }
 
     /// true if the property is `issueworld`
     pub fn is_issuewild(&self) -> bool {
-        if let Property::IssueWild = *self {
-            true
-        } else {
-            false
-        }
+        matches!(*self, Property::IssueWild)
     }
 
     /// true if the property is `iodef`
     pub fn is_iodef(&self) -> bool {
-        if let Property::Iodef = *self {
-            true
-        } else {
-            false
-        }
+        matches!(*self, Property::Iodef)
     }
 
     /// true if the property is not known to Trust-DNS
     pub fn is_unknown(&self) -> bool {
-        if let Property::Unknown(_) = *self {
-            true
-        } else {
-            false
-        }
+        matches!(*self, Property::Unknown(_))
     }
 }
 
@@ -323,29 +307,17 @@ pub enum Value {
 impl Value {
     /// true if this is an `Issuer`
     pub fn is_issuer(&self) -> bool {
-        if let Value::Issuer(..) = *self {
-            true
-        } else {
-            false
-        }
+        matches!(*self, Value::Issuer(..))
     }
 
     /// true if this is a `Url`
     pub fn is_url(&self) -> bool {
-        if let Value::Url(..) = *self {
-            true
-        } else {
-            false
-        }
+        matches!(*self, Value::Url(..))
     }
 
     /// true if this is an `Unknown`
     pub fn is_unknown(&self) -> bool {
-        if let Value::Unknown(..) = *self {
-            true
-        } else {
-            false
-        }
+        matches!(*self, Value::Unknown(..))
     }
 }
 
@@ -789,10 +761,7 @@ fn read_tag(decoder: &mut BinDecoder, len: Restrict<u8>) -> ProtoResult<String> 
         let ch = decoder
             .pop()?
             .map(char::from)
-            .verify_unwrap(|ch| match ch {
-                'a'..='z' | 'A'..='Z' | '0'..='9' => true,
-                _ => false,
-            })
+            .verify_unwrap(|ch| matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9'))
             .map_err(|_| ProtoError::from("CAA tag character(s) out of bounds"))?;
 
         tag.push(ch);

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -140,10 +140,7 @@ impl RecordType {
     /// Returns true if this is an A or an AAAA record
     #[inline]
     pub fn is_ip_addr(self) -> bool {
-        match self {
-            RecordType::A | RecordType::AAAA => true,
-            _ => false,
-        }
+        matches!(self, RecordType::A | RecordType::AAAA)
     }
 }
 

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -538,10 +538,7 @@ pub enum RrsetRecords<'r> {
 impl<'r> RrsetRecords<'r> {
     /// This is a best effort emptyness check
     pub fn is_empty(&self) -> bool {
-        match *self {
-            RrsetRecords::Empty => true,
-            _ => false,
-        }
+        matches!(*self, RrsetRecords::Empty)
     }
 }
 

--- a/crates/proto/src/serialize/binary/restrict.rs
+++ b/crates/proto/src/serialize/binary/restrict.rs
@@ -124,13 +124,13 @@ impl RestrictedMath for Restrict<usize> {
     type Value = usize;
 
     fn checked_add(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_add(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_add(arg).map(Restrict).ok_or(arg)
     }
     fn checked_sub(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_sub(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_sub(arg).map(Restrict).ok_or(arg)
     }
     fn checked_mul(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_mul(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_mul(arg).map(Restrict).ok_or(arg)
     }
 }
 
@@ -139,13 +139,13 @@ impl RestrictedMath for Restrict<u8> {
     type Value = u8;
 
     fn checked_add(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_add(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_add(arg).map(Restrict).ok_or(arg)
     }
     fn checked_sub(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_sub(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_sub(arg).map(Restrict).ok_or(arg)
     }
     fn checked_mul(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_mul(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_mul(arg).map(Restrict).ok_or(arg)
     }
 }
 
@@ -154,13 +154,13 @@ impl RestrictedMath for Restrict<u16> {
     type Value = u16;
 
     fn checked_add(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_add(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_add(arg).map(Restrict).ok_or(arg)
     }
     fn checked_sub(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_sub(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_sub(arg).map(Restrict).ok_or(arg)
     }
     fn checked_mul(&self, arg: Self::Arg) -> Result<Restrict<Self::Value>, Self::Arg> {
-        self.0.checked_mul(arg).map(Restrict).ok_or_else(|| arg)
+        self.0.checked_mul(arg).map(Restrict).ok_or(arg)
     }
 }
 

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -601,13 +601,13 @@ pub enum NegativeType {
 impl NegativeType {
     /// The response contains an SOA record
     pub fn is_authoritative(&self) -> bool {
-        match self {
+        matches!(
+            self,
             NegativeType::NameErrorType1
-            | NegativeType::NameErrorType2
-            | NegativeType::NoDataType1
-            | NegativeType::NoDataType2 => true,
-            _ => false,
-        }
+                | NegativeType::NameErrorType2
+                | NegativeType::NoDataType1
+                | NegativeType::NoDataType2
+        )
     }
 }
 

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -356,11 +356,7 @@ pub enum Local {
 
 impl Local {
     fn is_local(&self) -> bool {
-        if let Local::ResolveFuture(..) = *self {
-            true
-        } else {
-            false
-        }
+        matches!(*self, Local::ResolveFuture(..))
     }
 
     /// Takes the future

--- a/crates/server/src/authority/error.rs
+++ b/crates/server/src/authority/error.rs
@@ -41,26 +41,17 @@ impl LookupError {
 
     /// True if other records exist at the same name, but not the searched for RecordType
     pub fn is_name_exists(&self) -> bool {
-        match *self {
-            LookupError::NameExists => true,
-            _ => false,
-        }
+        matches!(*self, LookupError::NameExists)
     }
 
     /// This is a non-existent domain name
     pub fn is_nx_domain(&self) -> bool {
-        match *self {
-            LookupError::ResponseCode(ResponseCode::NXDomain) => true,
-            _ => false,
-        }
+        matches!(*self, LookupError::ResponseCode(ResponseCode::NXDomain))
     }
 
     /// This is a non-existent domain name
     pub fn is_refused(&self) -> bool {
-        match *self {
-            LookupError::ResponseCode(ResponseCode::Refused) => true,
-            _ => false,
-        }
+        matches!(*self, LookupError::ResponseCode(ResponseCode::Refused))
     }
 }
 

--- a/crates/server/src/authority/zone_type.rs
+++ b/crates/server/src/authority/zone_type.rs
@@ -31,9 +31,9 @@ pub enum ZoneType {
 impl ZoneType {
     /// Is this an authoritative Authority, i.e. it owns the records of the zone.
     pub fn is_authoritative(self) -> bool {
-        match self {
-            ZoneType::Primary | ZoneType::Secondary | ZoneType::Master | ZoneType::Slave => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            ZoneType::Primary | ZoneType::Secondary | ZoneType::Master | ZoneType::Slave
+        )
     }
 }


### PR DESCRIPTION
This fixes some clippy warnings.
The first commit contains fixes which are machine applicable.
The second commit fixes a buffer sizing where min and max were switched leading to a constant size.
The last commit fixes a problem with the manual implementation of `PartialOrd`.