### PR TITLE
Change the return value for ResponseCode::high from u16 to u8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 - (resolver) use IntoName trait on synchronous resolver interface (@krisztian-kovacs) #1095
 - (resolver) *BREAKING* removed async for `AsyncResolver::new` (@balboah) #1077 #1056
 - (server) *BREAKING* removed `Runtime` from `ServerFuture::register_socket` (@LucioFranco) #1088 #1087
+- (proto) *Breaking* Adjust the return value from `ResponseCode::high` from u16 to u8 #1202
 
 ### Fixed
 

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -136,9 +136,9 @@ impl ResponseCode {
         (u16::from(self) & 0x000F) as u8
     }
 
-    /// returns the high 12 bits for the edns portion of the response code
-    pub fn high(self) -> u16 {
-        (u16::from(self) & 0x0FF0) >> 4
+    /// returns the high 8 bits for the EDNS portion of the response code
+    pub fn high(self) -> u8 {
+        ((u16::from(self) & 0x0FF0) >> 4) as u8
     }
 
     /// Combines the EDNS high and low from the Header to produce the Extended ResponseCode


### PR DESCRIPTION
The EDNS response code part only contains 8 bit so the return type fits its
need better. This aligns the type with `ResponseCode::from` and
`Edns::set_rcode_high`.

Closes #1202