### PR TITLE
move NX trust bit from ResolverOpts to NameServerConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 
 ### Changed
 
+- (resolver) *BREAKING* Move `ResolverOpts::distrust_nx_responses` to `NameServerConfig::trust_nx_responses` (@djc) #1212
 - (proto) `data-encoding` is now a required dependency #1208
 - (all) minimum rustc version now `1.42`
 - (resolver) For all NxDomain and NoError/NoData responses, `ResolveErrorKind::NoRecordsFound` will be returned #1197
@@ -25,7 +26,7 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 
 ### Fixed
 
-- (resolver) Fix Glue records resolving (@wavenator) #1188 
+- (resolver) Fix Glue records resolving (@wavenator) #1188
 - (resolver) Only fall back on TCP if cons are available (@lukaspustina) #1181
 - (proto) fix empty option at end of edns (@jonasbb) #1143, #744
 - (resolver) Return `REFUSED` instead of `NXDOMAIN` when server is not an authority (@AnIrishDuck) #1137
@@ -343,7 +344,7 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 ### Changed
 
 - Large celanup of signing and verification paths in DNSSec (@briansmith)
-- *breaking* changed `TrustAnchor::insert_trust_anchor` to more safely consume `PublicKey` rather than `Vec<u8>` 
+- *breaking* changed `TrustAnchor::insert_trust_anchor` to more safely consume `PublicKey` rather than `Vec<u8>`
 
 ## 0.11.2 (Client/Server)
 

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -335,9 +335,10 @@ pub struct NameServerConfig {
     pub protocol: Protocol,
     /// SPKI name, only relevant for TLS connections
     pub tls_dns_name: Option<String>,
-    /// Default is to distrust negative responses from upstream nameservers
+    /// Default to not trust negative responses from upstream nameservers
     ///
-    /// Currently only SERVFAIL responses are continued on, this may be expanded to include NXDOMAIN or NoError/Empty responses
+    /// When a SERVFAIL, NXDOMAIN and NoError/Empty response is received, the query will be
+    /// retried against other configured name servers.
     pub trust_nx_responses: bool,
     #[cfg(feature = "dns-over-rustls")]
     #[cfg_attr(feature = "serde-config", serde(skip))]

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -142,7 +142,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> NameSe
                 //   see https://github.com/bluejekyll/trust-dns/issues/606
                 //   TODO: there are probably other return codes from the server we may want to
                 //    retry on. We may also want to evaluate NoError responses that lack records as errors as well
-                let response = if self.options.distrust_nx_responses {
+                let response = if self.config.trust_nx_responses {
                     ResolveError::from_response(response)?
                 } else {
                     response
@@ -238,7 +238,11 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> Eq for
 
 // TODO: once IPv6 is better understood, also make this a binary keep.
 #[cfg(feature = "mdns")]
-pub(crate) fn mdns_nameserver<C, P>(options: ResolverOpts, conn_provider: P) -> NameServer<C, P>
+pub(crate) fn mdns_nameserver<C, P>(
+    options: ResolverOpts,
+    conn_provider: P,
+    trust_nx_responses: bool,
+) -> NameServer<C, P>
 where
     C: DnsHandle<Error = ResolveError>,
     P: ConnectionProvider<Conn = C>,
@@ -247,6 +251,7 @@ where
         socket_addr: *MDNS_IPV4,
         protocol: Protocol::Mdns,
         tls_dns_name: None,
+        trust_nx_responses,
         #[cfg(feature = "dns-over-rustls")]
         tls_config: None,
     };
@@ -279,6 +284,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         };
@@ -312,6 +318,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 252),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         };

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -106,7 +106,7 @@ where
             datagram_conns: Arc::new(datagram_conns),
             stream_conns: Arc::new(stream_conns),
             #[cfg(feature = "mdns")]
-            mdns_conns: name_server::mdns_nameserver(*options, conn_provider.clone()),
+            mdns_conns: name_server::mdns_nameserver(*options, conn_provider.clone(), false),
             options: *options,
             conn_provider,
         }
@@ -428,6 +428,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 253),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         };
@@ -436,6 +437,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         };
@@ -492,6 +494,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         };
@@ -506,7 +509,7 @@ mod tests {
             Arc::new(vec![]),
             Arc::clone(&name_servers),
             #[cfg(feature = "mdns")]
-            name_server::mdns_nameserver(opts, conn_provider.clone()),
+            name_server::mdns_nameserver(opts, conn_provider.clone(), false),
             conn_provider,
         );
 

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -64,6 +64,7 @@ fn into_resolver_config(
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         });
@@ -71,6 +72,7 @@ fn into_resolver_config(
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         });
@@ -119,6 +121,7 @@ mod tests {
                 socket_addr: addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
+                trust_nx_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
             },
@@ -126,6 +129,7 @@ mod tests {
                 socket_addr: addr,
                 protocol: Protocol::Tcp,
                 tls_dns_name: None,
+                trust_nx_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
             },

--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -32,6 +32,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         });
@@ -39,6 +40,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         });

--- a/tests/test-data/named_test_configs/example_forwarder.toml
+++ b/tests/test-data/named_test_configs/example_forwarder.toml
@@ -37,5 +37,5 @@ zone_type = "Forward"
 
 ## remember the port, defaults: 53 for Udp & Tcp, 853 for Tls and 443 for Https.
 ##   Tls and/or Https require features dns-over-tls and/or dns-over-https
-stores = { type = "forward", name_servers = [{ socket_addr = "8.8.8.8:53", protocol = "Udp" },
-                                             { socket_addr = "8.8.8.8:53", protocol = "Tcp" }] }
+stores = { type = "forward", name_servers = [{ socket_addr = "8.8.8.8:53", protocol = "Udp", trust_nx_responses = false },
+                                             { socket_addr = "8.8.8.8:53", protocol = "Tcp", trust_nx_responses = false }] }

--- a/util/src/resolve.rs
+++ b/util/src/resolve.rs
@@ -134,12 +134,14 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            trust_nx_responses: false,
         });
 
         name_servers.push(NameServerConfig {
             socket_addr: *socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            trust_nx_responses: false,
         });
     }
 


### PR DESCRIPTION
As discussed.

As written, I do feel this is more "correct" but maybe also less ergonomic to use, since there's currently no easy way to modify the trust bit on an existing `ResolverConfig`. Maybe we should add a way to do that; some ideas that come to mind are a `name_servers_mut()` method on `ResolverConfig` or maybe even a dedicated `fn trust_nx_responses(mut self)`?

(I'm also fine if you just want to leave this out.)