### PR TITLE
update unreadable comment with proper RFC link and text

### DIFF
--- a/crates/resolver/src/lookup_state.rs
+++ b/crates/resolver/src/lookup_state.rs
@@ -116,14 +116,14 @@ where
         mut client: Self,
         preserved_records: Vec<(Record, u32)>,
     ) -> Result<Lookup, ResolveError> {
-        // see https://tools.ietf.ofc6761
+        // see https://tools.ietf.org/html/rfc6761
         //
         // ```text
-        // Name resolution APIs and librariesognize localhost
-        // names as special analways return the IP loopback address
+        // Name resolution APIs and libraries SHOULD recognize localhost
+        // names as special and SHOULD always return the IP loopback address
         // for address queries and negative responses for all other query
-        // types.  Name resolution APIs SHOULD NOT s for
-        // localhost names to their cocachir(s).
+        // types.  Name resolution APIs SHOULD NOT send queries for
+        // localhost names to their configured caching DNS server(s).
         // ```
         // special use rules only apply to the IN Class
         if query.query_class() == DNSClass::IN {


### PR DESCRIPTION
Not sure what happened with #1033. https://github.com/bluejekyll/trust-dns/commit/e137e72f343960bab9965049bd6c02d05169a603#diff-8c4377672d5e2845202a0e33309051a4R111