### PR TITLE
force dns-over-rustls for tools crate

### DIFF
--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -13,7 +13,9 @@ mod dns_over_rustls;
 
 cfg_if! {
     if #[cfg(feature = "dns-over-rustls")] {
-        pub(crate) use self::dns_over_rustls::{new_tls_stream, CLIENT_CONFIG};
+        pub(crate) use self::dns_over_rustls::new_tls_stream;
+        #[cfg(feature = "dns-over-https-rustls")]
+        pub(crate) use self::dns_over_rustls::CLIENT_CONFIG;
     } else if #[cfg(feature = "dns-over-native-tls")] {
         pub(crate) use self::dns_over_native_tls::new_tls_stream;
     } else if #[cfg(feature = "dns-over-openssl")] {

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -35,6 +35,9 @@ license = "MIT/Apache-2.0"
 codecov = { repository = "bluejekyll/trust-dns", branch = "main", service = "github" }
 maintenance = { status = "actively-developed" }
 
+[features]
+dns-over-rustls = ["trust-dns-resolver/dns-over-rustls"]
+
 [[bin]]
 name = "dnskey-to-pem"
 path = "src/bind_dnskey_to_pem.rs"

--- a/util/src/resolve.rs
+++ b/util/src/resolve.rs
@@ -135,6 +135,8 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             protocol: Protocol::Tcp,
             tls_dns_name: None,
             trust_nx_responses: false,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         });
 
         name_servers.push(NameServerConfig {
@@ -142,6 +144,8 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             protocol: Protocol::Udp,
             tls_dns_name: None,
             trust_nx_responses: false,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
         });
     }
 


### PR DESCRIPTION
This is so we get a consistent requirement for the availability of the
`tls_config` field in the `NameServerConfig` struct; whether this is
required otherwise depends on whether that feature is enabled for the
resolver crate dependency.