### PR TITLE
avoid unwrap() for functions that don't error

### DIFF
--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -526,7 +526,7 @@ pub mod tests {
                             let (buffer, addr) = buffer_and_addr
                                 .expect("no msg received")
                                 .expect("error receiving msg")
-                                .unwrap();
+                                .into_parts();
 
                             assert_eq!(&buffer, test_bytes);
                             //println!("server got data! {}", addr);
@@ -582,7 +582,7 @@ pub mod tests {
                     let (buffer, _addr) = buffer_and_addr
                         .expect("no msg received")
                         .expect("error receiving msg")
-                        .unwrap();
+                        .into_parts();
                     println!("client got data!");
 
                     assert_eq!(&buffer, test_bytes);

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -261,7 +261,7 @@ impl Record {
     }
 
     /// Returns the RData consuming the Record
-    pub fn unwrap_rdata(self) -> RData {
+    pub fn into_data(self) -> RData {
         self.rdata
     }
 }

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -297,7 +297,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> Stream for TcpStream<S> {
                     // already handled above, here to make sure the poll() pops the next message
                     Poll::Ready(Some(message)) => {
                         // if there is no peer, this connection should die...
-                        let (buffer, dst) = message.unwrap();
+                        let (buffer, dst) = message.into_parts();
 
                         // This is an error if the destination is not our peer (this is TCP after all)
                         //  This will kill the connection...

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -192,7 +192,7 @@ where
                 // already handled above, here to make sure the poll() pops the next message
                 Poll::Ready(Some(dns_request)) => {
                     // if there is no peer, this connection should die...
-                    let (dns_request, serial_response): (DnsRequest, _) = dns_request.unwrap();
+                    let (dns_request, serial_response): (DnsRequest, _) = dns_request.into_parts();
 
                     match serial_response
                         .send_response(io_stream.send_message::<TE>(dns_request, cx))
@@ -357,7 +357,7 @@ where
                     } {
                         // ignoring errors... best effort send...
                         outbound_message
-                            .unwrap()
+                            .into_parts()
                             .1
                             .send_response(error.clone().into())
                             .ok();

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -40,7 +40,7 @@ pub trait DnsStreamHandle: 'static + Send {
 
 impl DnsStreamHandle for StreamHandle {
     fn send(&mut self, buffer: SerialMessage) -> Result<(), ProtoError> {
-        UnboundedSender::unbounded_send(&self.sender, buffer.unwrap().0)
+        UnboundedSender::unbounded_send(&self.sender, buffer.into_parts().0)
             .map_err(|e| ProtoError::from(format!("mpsc::SendError {}", e)))
     }
 }

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -325,7 +325,7 @@ where
             }
         };
 
-        let (mut request, request_options) = request.unwrap();
+        let (mut request, request_options) = request.into_parts();
         request.set_id(query_id);
 
         let now = match SystemTime::now().duration_since(UNIX_EPOCH) {

--- a/crates/proto/src/xfer/dns_request.rs
+++ b/crates/proto/src/xfer/dns_request.rs
@@ -46,7 +46,7 @@ impl DnsRequest {
     }
 
     /// Unwraps the raw message
-    pub fn unwrap(self) -> (Message, DnsRequestOptions) {
+    pub fn into_parts(self) -> (Message, DnsRequestOptions) {
         (self.message, self.options)
     }
 }

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -676,7 +676,7 @@ where
                 // this filter is technically unnecessary, can probably remove it...
                 .filter(|rrsig| is_dnssec(rrsig, DNSSECRecordType::RRSIG))
                 .map(|rrsig| {
-                    if let RData::DNSSEC(DNSSECRData::SIG(sig)) = rrsig.unwrap_rdata() {
+                    if let RData::DNSSEC(DNSSECRData::SIG(sig)) = rrsig.into_data() {
                         // setting up the context explicitly.
                         sig
                     } else {
@@ -723,7 +723,7 @@ where
         // this filter is technically unnecessary, can probably remove it...
         .filter(|rrsig| is_dnssec(rrsig, DNSSECRecordType::RRSIG))
         .map(|rrsig|
-            if let RData::DNSSEC(DNSSECRData::SIG(sig)) = rrsig.unwrap_rdata() {
+            if let RData::DNSSEC(DNSSECRData::SIG(sig)) = rrsig.into_data() {
                 // setting up the context explicitly.
                 sig
             } else {

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -102,7 +102,7 @@ impl DnsStreamHandle for BufDnsStreamHandle {
         let sender: &mut _ = &mut self.sender;
         sender
             .sender
-            .unbounded_send(SerialMessage::new(buffer.unwrap().0, name_server))
+            .unbounded_send(SerialMessage::new(buffer.into_parts().0, name_server))
             .map_err(|e| ProtoError::from(format!("mpsc::SendError {}", e)))
     }
 }
@@ -224,7 +224,7 @@ impl OneshotDnsRequest {
         )
     }
 
-    fn unwrap(self) -> (DnsRequest, OneshotDnsResponse) {
+    fn into_parts(self) -> (DnsRequest, OneshotDnsResponse) {
         (
             self.dns_request,
             OneshotDnsResponse(self.sender_for_response),

--- a/crates/proto/src/xfer/serial_message.rs
+++ b/crates/proto/src/xfer/serial_message.rs
@@ -34,7 +34,7 @@ impl SerialMessage {
     }
 
     /// Unwrap the Bytes and address
-    pub fn unwrap(self) -> (Vec<u8>, SocketAddr) {
+    pub fn into_parts(self) -> (Vec<u8>, SocketAddr) {
         (self.message, self.addr)
     }
 

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -413,7 +413,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
             self.client_cache.clone(),
             DnsRequestOptions::default(),
             hosts,
-            finally_ip_addr.map(Record::unwrap_rdata),
+            finally_ip_addr.map(Record::into_data),
         )
         .await
     }

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -171,7 +171,7 @@ impl Iterator for LookupIntoIter {
     fn next(&mut self) -> Option<Self::Item> {
         match self.records {
             // a zero overhead unwrap
-            Ok(ref mut iter) => iter.next().map(Record::unwrap_rdata),
+            Ok(ref mut iter) => iter.next().map(Record::into_data),
             Err(ref records) => {
                 let rdata = records.get(self.index).map(Record::rdata);
                 self.index += 1;

--- a/tests/integration-tests/tests/mdns_tests.rs
+++ b/tests/integration-tests/tests/mdns_tests.rs
@@ -78,7 +78,7 @@ fn mdns_responsder(
                         let (data, src) = data_src
                             .expect("no buffer received")
                             .expect("error receiving buffer")
-                            .unwrap();
+                            .into_parts();
 
                         stream = stream_tmp.into_future();
                         timeout = timeout_tmp;


### PR DESCRIPTION
`into_*()` and `into_parts()` specifically seem more idiomatic for these functions.