### PR TITLE
Some more work on reducing dependency load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,12 +209,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -821,12 +815,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,7 +1243,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "log",
  "ring",
  "sct",
@@ -1678,7 +1666,6 @@ dependencies = [
  "tokio-rustls",
  "trust-dns-proto",
  "trust-dns-rustls",
- "typed-headers",
  "webpki",
  "webpki-roots",
 ]
@@ -1853,19 +1840,6 @@ dependencies = [
  "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-resolver",
-]
-
-[[package]]
-name = "typed-headers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3179a61e9eccceead5f1574fd173cf2e162ac42638b9bf214c6ad0baf7efa24a"
-dependencies = [
- "base64 0.11.0",
- "bytes",
- "chrono",
- "http",
- "mime",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,7 @@ dependencies = [
 name = "trust-dns-client"
 version = "0.20.0-alpha.2"
 dependencies = [
- "backtrace",
+ "cfg-if 1.0.0",
  "chrono",
  "data-encoding",
  "futures",
@@ -1651,8 +1651,8 @@ dependencies = [
 name = "trust-dns-https"
 version = "0.20.0-alpha.2"
 dependencies = [
- "backtrace",
  "bytes",
+ "cfg-if 1.0.0",
  "data-encoding",
  "env_logger",
  "futures",
@@ -1724,6 +1724,7 @@ version = "0.20.0-alpha.2"
 dependencies = [
  "async-trait",
  "backtrace",
+ "cfg-if 1.0.0",
  "data-encoding",
  "enum-as-inner",
  "env_logger",
@@ -1752,7 +1753,6 @@ dependencies = [
 name = "trust-dns-resolver"
 version = "0.20.0-alpha.2"
 dependencies = [
- "backtrace",
  "cfg-if 1.0.0",
  "env_logger",
  "futures-executor",
@@ -1798,8 +1798,8 @@ dependencies = [
 name = "trust-dns-server"
 version = "0.20.0-alpha.2"
 dependencies = [
- "backtrace",
  "bytes",
+ "cfg-if 1.0.0",
  "chrono",
  "enum-as-inner",
  "env_logger",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -41,6 +41,7 @@ codecov = { repository = "bluejekyll/trust-dns", branch = "main", service = "git
 maintenance = { status = "actively-developed" }
 
 [features]
+backtrace = ["trust-dns-proto/backtrace"]
 # TODO: the rustls and openssl crates are not deps... should we change that to make them easier to use?
 #  or change this to also be external?
 dns-over-https-openssl = ["dns-over-https", "dns-over-openssl"]
@@ -65,7 +66,7 @@ name = "trust_dns_client"
 path = "src/lib.rs"
 
 [dependencies]
-backtrace = "0.3.50"
+cfg-if = "1"
 chrono = "0.4"
 data-encoding = "2.2.0"
 futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -36,7 +36,7 @@ codecov = { repository = "bluejekyll/trust-dns", branch = "main", service = "git
 maintenance = { status = "actively-developed" }
 
 [features]
-
+backtrace = ["trust-dns-proto/backtrace"]
 dns-over-https-rustls = []
 
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
@@ -47,7 +47,7 @@ name = "trust_dns_https"
 path = "src/lib.rs"
 
 [dependencies]
-backtrace = "0.3.50"
+cfg-if = "1"
 bytes = "0.5"
 data-encoding = "2.2.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -61,7 +61,6 @@ tokio-rustls = "0.14"
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.2", path = "../proto", features = ["tokio-runtime"], default-features = false }
 trust-dns-rustls = { version = "0.20.0-alpha.2", path = "../rustls", default-features = false }
-typed-headers = "0.2"
 webpki-roots = { version = "0.20" }
 webpki = "0.21"
 

--- a/crates/https/src/error.rs
+++ b/crates/https/src/error.rs
@@ -13,6 +13,7 @@ use http::header::ToStrError;
 use thiserror::Error;
 use trust_dns_proto::error::ProtoError;
 
+#[cfg(feature = "backtrace")]
 use crate::proto::{trace, ExtBacktrace};
 
 /// An alias for results returned by functions of this crate
@@ -47,6 +48,7 @@ pub enum ErrorKind {
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
+    #[cfg(feature = "backtrace")]
     backtrack: Option<ExtBacktrace>,
 }
 
@@ -59,11 +61,17 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref backtrace) = self.backtrack {
-            fmt::Display::fmt(&self.kind, f)?;
-            fmt::Debug::fmt(backtrace, f)
-        } else {
-            fmt::Display::fmt(&self.kind, f)
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "backtrace")] {
+                if let Some(ref backtrace) = self.backtrack {
+                    fmt::Display::fmt(&self.kind, f)?;
+                    fmt::Debug::fmt(backtrace, f)
+                } else {
+                    fmt::Display::fmt(&self.kind, f)
+                }
+            } else {
+                fmt::Display::fmt(&self.kind, f)
+            }
         }
     }
 }
@@ -72,6 +80,7 @@ impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
         Error {
             kind,
+            #[cfg(feature = "backtrace")]
             backtrack: trace!(),
         }
     }

--- a/crates/https/src/lib.rs
+++ b/crates/https/src/lib.rs
@@ -14,8 +14,6 @@
 )]
 #![allow(clippy::single_component_path_imports)]
 
-const MIME_APPLICATION: &str = "application";
-const MIME_DNS_BINARY: &str = "dns-message";
 const MIME_APPLICATION_DNS: &str = "application/dns-message";
 const DNS_QUERY_PATH: &str = "/dns-query";
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -59,7 +59,8 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1.36"
-backtrace = "0.3.50"
+backtrace = { version = "0.3.50", optional = true }
+cfg-if = "1"
 data-encoding = "2.2.0"
 enum-as-inner = "0.3"
 futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -15,7 +15,9 @@ use std::{fmt, io, sync};
 use self::not_openssl::SslErrorStack;
 #[cfg(not(feature = "ring"))]
 use self::not_ring::Unspecified;
+#[cfg(feature = "backtrace")]
 pub use backtrace::Backtrace as ExtBacktrace;
+#[cfg(feature = "backtrace")]
 use lazy_static::lazy_static;
 #[cfg(feature = "openssl")]
 use openssl::error::ErrorStack as SslErrorStack;
@@ -25,6 +27,7 @@ use thiserror::Error;
 
 use crate::rr::{Name, RecordType};
 
+#[cfg(feature = "backtrace")]
 lazy_static! {
     /// Boolean for checking if backtrace is enabled at runtime
     pub static ref ENABLE_BACKTRACE: bool = {
@@ -37,6 +40,7 @@ lazy_static! {
 /// Generate a backtrace
 ///
 /// If RUST_BACKTRACE is 1 or full then this will return Some(Backtrace), otherwise, NONE.
+#[cfg(feature = "backtrace")]
 #[macro_export]
 macro_rules! trace {
     () => {{
@@ -222,6 +226,7 @@ pub enum ProtoErrorKind {
 #[derive(Error, Clone, Debug)]
 pub struct ProtoError {
     kind: ProtoErrorKind,
+    #[cfg(feature = "backtrace")]
     backtrack: Option<ExtBacktrace>,
 }
 
@@ -239,11 +244,17 @@ impl ProtoError {
 
 impl fmt::Display for ProtoError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(ref backtrace) = self.backtrack {
-            fmt::Display::fmt(&self.kind, f)?;
-            fmt::Debug::fmt(backtrace, f)
-        } else {
-            fmt::Display::fmt(&self.kind, f)
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "backtrace")] {
+                if let Some(ref backtrace) = self.backtrack {
+                    fmt::Display::fmt(&self.kind, f)?;
+                    fmt::Debug::fmt(backtrace, f)
+                } else {
+                    fmt::Display::fmt(&self.kind, f)
+                }
+            } else {
+                fmt::Display::fmt(&self.kind, f)
+            }
         }
     }
 }
@@ -252,6 +263,7 @@ impl From<ProtoErrorKind> for ProtoError {
     fn from(kind: ProtoErrorKind) -> ProtoError {
         ProtoError {
             kind,
+            #[cfg(feature = "backtrace")]
             backtrack: trace!(),
         }
     }

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -70,6 +70,7 @@ pub use crate::xfer::dnssec_dns_handle::DnssecDnsHandle;
 pub use crate::xfer::retry_dns_handle::RetryDnsHandle;
 #[doc(hidden)]
 pub use crate::xfer::{BufDnsStreamHandle, BufStreamHandle};
+#[cfg(feature = "backtrace")]
 pub use error::ExtBacktrace;
 
 #[cfg(feature = "tokio-runtime")]

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -37,6 +37,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["system-config", "tokio-runtime"]
+backtrace = ["trust-dns-proto/backtrace"]
 dns-over-native-tls = ["dns-over-tls", "tokio-tls", "trust-dns-native-tls"]
 # DNS over TLS with OpenSSL currently needs a good way to set default CAs, use rustls or native-tls
 dns-over-openssl = ["dns-over-tls", "trust-dns-openssl", "tokio-openssl"]
@@ -65,7 +66,6 @@ name = "trust_dns_resolver"
 path = "src/lib.rs"
 
 [dependencies]
-backtrace = "0.3.50"
 cfg-if = "1.0.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 lazy_static = "1.0"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -42,6 +42,7 @@ codecov = { repository = "bluejekyll/trust-dns", branch = "main", service = "git
 maintenance = { status = "actively-developed" }
 
 [features]
+backtrace = ["trust-dns-proto/backtrace"]
 dnssec-openssl = ["dnssec", "openssl", "trust-dns-client/dnssec-openssl", "trust-dns-proto/dnssec-openssl", "trust-dns-resolver/dnssec-openssl"]
 dnssec-ring = ["dnssec", "trust-dns-client/dnssec-ring", "trust-dns-proto/dnssec-ring", "trust-dns-resolver/dnssec-ring"]
 dnssec = []
@@ -70,8 +71,8 @@ name = "trust_dns_server"
 path = "src/lib.rs"
 
 [dependencies]
-backtrace = "0.3.50"
 bytes = "0.5"
+cfg-if = "1"
 chrono = "0.4"
 enum-as-inner = "0.3"
 env_logger = "0.7"

--- a/crates/server/src/error/persistence_error.rs
+++ b/crates/server/src/error/persistence_error.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use crate::proto::error::*;
 use thiserror::Error;
 
+#[cfg(feature = "backtrace")]
 use crate::proto::{trace, ExtBacktrace};
 
 /// An alias for results returned by functions of this crate
@@ -50,6 +51,7 @@ pub enum ErrorKind {
 #[derive(Debug, Error)]
 pub struct Error {
     kind: ErrorKind,
+    #[cfg(feature = "backtrace")]
     backtrack: Option<ExtBacktrace>,
 }
 
@@ -62,11 +64,17 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref backtrace) = self.backtrack {
-            fmt::Display::fmt(&self.kind, f)?;
-            fmt::Debug::fmt(backtrace, f)
-        } else {
-            fmt::Display::fmt(&self.kind, f)
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "with-backtrace")] {
+                if let Some(ref backtrace) = self.backtrack {
+                    fmt::Display::fmt(&self.kind, f)?;
+                    fmt::Debug::fmt(backtrace, f)
+                } else {
+                    fmt::Display::fmt(&self.kind, f)
+                }
+            } else {
+                fmt::Display::fmt(&self.kind, f)
+            }
         }
     }
 }
@@ -75,6 +83,7 @@ impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
         Error {
             kind,
+            #[cfg(feature = "backtrace")]
             backtrack: trace!(),
         }
     }


### PR DESCRIPTION
Together with #1245, this cuts the amount of dependencies in the Cargo.lock for my project (that depends on resolver) by 16 dependencies.