### PR TITLE
Tcp stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 
 ### Changed
 
+- (all) *BREAKING* The `UdpSocket` trait has grown an associated `Time` type.
+- (all) *BREAKING* The `Connect` trait has lost its
+`Transport` associated type, instead relying on the `Self` type.
+- (all) *BREAKING* Introduced a new `DnsTcpStream` trait, which is now a
+bound for implementing the `Connect` trait.
 - (resolver) *BREAKING* Move `CachingClient` from `lookup_state` to `caching_client` module
 - (resolver) *BREAKING* Move `ResolverOpts::distrust_nx_responses` to `NameServerConfig::trust_nx_responses` (@djc) #1212
 - (proto) `data-encoding` is now a required dependency #1208

--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -26,8 +26,8 @@ use trust_dns_client::rr::*;
 use trust_dns_client::tcp::*;
 use trust_dns_client::udp::*;
 use trust_dns_proto::error::*;
+use trust_dns_proto::iocompat::AsyncIo02As03;
 use trust_dns_proto::xfer::*;
-use trust_dns_proto::{iocompat::AsyncIo02As03, TokioTime};
 
 fn find_test_port() -> u16 {
     let server = std::net::UdpSocket::bind(("0.0.0.0", 0)).unwrap();
@@ -183,7 +183,7 @@ fn trust_dns_tcp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TcpStream>>::new::<TokioTime>(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TcpStream>>::new(addr);
     let mp = DnsMultiplexer::new(stream, sender, None::<Arc<Signer>>);
     bench(b, mp);
 
@@ -258,7 +258,7 @@ fn bind_tcp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TcpStream>>::new::<TokioTime>(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TcpStream>>::new(addr);
     let mp = DnsMultiplexer::new(stream, sender, None::<Arc<Signer>>);
     bench(b, mp);
 

--- a/bin/tests/named_test_rsa_dnssec.rs
+++ b/bin/tests/named_test_rsa_dnssec.rs
@@ -70,7 +70,7 @@ async fn standard_tcp_conn(
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
     AsyncClient::new(stream, sender, None)
         .await
         .expect("new AsyncClient failed")

--- a/bin/tests/named_tests.rs
+++ b/bin/tests/named_tests.rs
@@ -23,7 +23,6 @@ use trust_dns_client::op::ResponseCode;
 use trust_dns_client::rr::*;
 use trust_dns_client::tcp::TcpClientStream;
 use trust_dns_client::udp::UdpClientStream;
-use trust_dns_proto::TokioTime;
 
 // TODO: Needed for when TLS tests are added back
 // #[cfg(feature = "dns-over-openssl")]
@@ -40,8 +39,7 @@ fn test_example_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -54,8 +52,7 @@ fn test_example_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -73,8 +70,7 @@ fn test_ipv4_only_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -87,8 +83,7 @@ fn test_ipv4_only_toml_startup() {
             Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         assert!(io_loop.block_on(client).is_err());
@@ -138,8 +133,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -151,8 +145,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
             Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -170,8 +163,7 @@ fn test_nodata_where_name_exists() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -196,8 +188,7 @@ fn test_nxdomain_where_no_name_exists() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -260,8 +251,7 @@ fn test_server_continues_on_bad_data_tcp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -281,8 +271,7 @@ fn test_server_continues_on_bad_data_tcp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -304,8 +293,7 @@ fn test_forward() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -327,8 +315,7 @@ fn test_forward() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) =
-            TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -37,9 +37,7 @@ pub struct AsyncStdTcpStream(async_std::net::TcpStream);
 
 #[async_trait]
 impl Connect for AsyncStdTcpStream {
-    type Transport = AsyncStdTcpStream;
-
-    async fn connect(addr: SocketAddr) -> io::Result<Self::Transport> {
+    async fn connect(addr: SocketAddr) -> io::Result<Self> {
         let stream = async_std::net::TcpStream::connect(addr).await?;
         stream.set_nodelay(true)?;
         Ok(AsyncStdTcpStream(stream))

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -14,6 +14,8 @@ use futures_io::{AsyncRead, AsyncWrite};
 use trust_dns_resolver::proto::tcp::Connect;
 use trust_dns_resolver::proto::udp::UdpSocket;
 
+use crate::time::AsyncStdTime;
+
 pub struct AsyncStdUdpSocket(async_std::net::UdpSocket);
 
 #[async_trait]
@@ -37,6 +39,8 @@ pub struct AsyncStdTcpStream(async_std::net::TcpStream);
 
 #[async_trait]
 impl Connect for AsyncStdTcpStream {
+    type Time = AsyncStdTime;
+
     async fn connect(addr: SocketAddr) -> io::Result<Self> {
         let stream = async_std::net::TcpStream::connect(addr).await?;
         stream.set_nodelay(true)?;

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -20,6 +20,8 @@ pub struct AsyncStdUdpSocket(async_std::net::UdpSocket);
 
 #[async_trait]
 impl UdpSocket for AsyncStdUdpSocket {
+    type Time = AsyncStdTime;
+
     async fn bind(addr: &SocketAddr) -> io::Result<Self> {
         async_std::net::UdpSocket::bind(addr)
             .await

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -11,7 +11,7 @@ use std::pin::Pin;
 
 use async_trait::async_trait;
 use futures_io::{AsyncRead, AsyncWrite};
-use trust_dns_resolver::proto::tcp::Connect;
+use trust_dns_resolver::proto::tcp::{Connect, DnsTcpStream};
 use trust_dns_resolver::proto::udp::UdpSocket;
 
 use crate::time::AsyncStdTime;
@@ -37,10 +37,12 @@ impl UdpSocket for AsyncStdUdpSocket {
 
 pub struct AsyncStdTcpStream(async_std::net::TcpStream);
 
+impl DnsTcpStream for AsyncStdTcpStream {
+    type Time = AsyncStdTime;
+}
+
 #[async_trait]
 impl Connect for AsyncStdTcpStream {
-    type Time = AsyncStdTime;
-
     async fn connect(addr: SocketAddr) -> io::Result<Self> {
         let stream = async_std::net::TcpStream::connect(addr).await?;
         stream.set_nodelay(true)?;

--- a/crates/client/src/https_client_connection.rs
+++ b/crates/client/src/https_client_connection.rs
@@ -46,7 +46,7 @@ impl<T> HttpsClientConnection<T> {
 
 impl<T> ClientConnection for HttpsClientConnection<T>
 where
-    T: Connect + Sync + 'static,
+    T: Connect,
 {
     type Sender = HttpsClientStream;
     type SenderFuture = HttpsClientConnect<T>;

--- a/crates/client/src/https_client_connection.rs
+++ b/crates/client/src/https_client_connection.rs
@@ -46,7 +46,7 @@ impl<T> HttpsClientConnection<T> {
 
 impl<T> ClientConnection for HttpsClientConnection<T>
 where
-    T: Connect + 'static + Unpin + Sync + Send,
+    T: Connect + Sync + 'static,
 {
     type Sender = HttpsClientStream;
     type SenderFuture = HttpsClientConnect<T>;

--- a/crates/client/src/tcp/tcp_client_connection.rs
+++ b/crates/client/src/tcp/tcp_client_connection.rs
@@ -18,7 +18,6 @@ use crate::error::*;
 use crate::proto::iocompat::AsyncIo02As03;
 use crate::proto::tcp::{TcpClientConnect, TcpClientStream};
 use crate::proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect};
-use crate::proto::TokioTime;
 use crate::rr::dnssec::Signer;
 
 /// Tcp client connection
@@ -70,9 +69,10 @@ impl ClientConnection for TcpClientConnection {
     >;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
-        let (tcp_client_stream, handle) = TcpClientStream::<AsyncIo02As03<TcpStream>>::with_timeout::<
-            TokioTime,
-        >(self.name_server, self.timeout);
+        let (tcp_client_stream, handle) = TcpClientStream::<AsyncIo02As03<TcpStream>>::with_timeout(
+            self.name_server,
+            self.timeout,
+        );
         DnsMultiplexer::new(tcp_client_stream, handle, signer)
     }
 }

--- a/crates/https/src/https_client_stream.rs
+++ b/crates/https/src/https_client_stream.rs
@@ -319,7 +319,7 @@ impl HttpsClientStreamBuilder {
     /// * `name_server` - IP and Port for the remote DNS resolver
     /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
     /// * `loop_handle` - The reactor Core handle
-    pub fn build<S: Connect + 'static>(
+    pub fn build<S: Connect>(
         self,
         name_server: SocketAddr,
         dns_name: String,
@@ -351,11 +351,11 @@ impl Default for HttpsClientStreamBuilder {
 /// A future that resolves to an HttpsClientStream
 pub struct HttpsClientConnect<S>(HttpsClientConnectState<S>)
 where
-    S: Connect + 'static;
+    S: Connect;
 
 impl<S> Future for HttpsClientConnect<S>
 where
-    S: Connect + 'static,
+    S: Connect,
 {
     type Output = Result<HttpsClientStream, ProtoError>;
 
@@ -373,7 +373,7 @@ struct TlsConfig {
 #[allow(clippy::type_complexity)]
 enum HttpsClientConnectState<S>
 where
-    S: Connect + 'static,
+    S: Connect,
 {
     ConnectTcp {
         name_server: SocketAddr,
@@ -413,7 +413,7 @@ where
 
 impl<S> Future for HttpsClientConnectState<S>
 where
-    S: Connect + 'static,
+    S: Connect,
 {
     type Output = Result<HttpsClientStream, ProtoError>;
 

--- a/crates/https/src/https_client_stream.rs
+++ b/crates/https/src/https_client_stream.rs
@@ -380,13 +380,13 @@ where
         tls: Option<TlsConfig>,
     },
     TcpConnecting {
-        connect: Pin<Box<dyn Future<Output = io::Result<S::Transport>> + Send>>,
+        connect: Pin<Box<dyn Future<Output = io::Result<S>> + Send>>,
         name_server: SocketAddr,
         tls: Option<TlsConfig>,
     },
     TlsConnecting {
         // FIXME: also abstract away Tokio TLS in RuntimeProvider.
-        tls: TokioTlsConnect<AsyncIo03As02<S::Transport>>,
+        tls: TokioTlsConnect<AsyncIo03As02<S>>,
         name_server_name: Arc<String>,
         name_server: SocketAddr,
     },
@@ -397,10 +397,7 @@ where
                         Output = Result<
                             (
                                 SendRequest<Bytes>,
-                                Connection<
-                                    TokioTlsClientStream<AsyncIo03As02<S::Transport>>,
-                                    Bytes,
-                                >,
+                                Connection<TokioTlsClientStream<AsyncIo03As02<S>>, Bytes>,
                             ),
                             h2::Error,
                         >,

--- a/crates/proto/src/multicast/mdns_client_stream.rs
+++ b/crates/proto/src/multicast/mdns_client_stream.rs
@@ -17,7 +17,7 @@ use crate::error::ProtoError;
 use crate::multicast::mdns_stream::{MDNS_IPV4, MDNS_IPV6};
 use crate::multicast::{MdnsQueryType, MdnsStream};
 use crate::xfer::{DnsClientStream, SerialMessage};
-use crate::{BufDnsStreamHandle, DnsStreamHandle};
+use crate::{BufDnsStreamHandle, DnsStreamHandle, TokioTime};
 
 /// A UDP client stream of DNS binary packets
 #[must_use = "futures do nothing unless polled"]
@@ -83,6 +83,8 @@ impl Display for MdnsClientStream {
 }
 
 impl DnsClientStream for MdnsClientStream {
+    type Time = TokioTime;
+
     fn name_server_addr(&self) -> SocketAddr {
         self.mdns_stream.multicast_addr()
     }

--- a/crates/proto/src/tcp/mod.rs
+++ b/crates/proto/src/tcp/mod.rs
@@ -19,7 +19,7 @@ mod tcp_client_stream;
 mod tcp_stream;
 
 pub use self::tcp_client_stream::{TcpClientConnect, TcpClientStream};
-pub use self::tcp_stream::{Connect, TcpStream};
+pub use self::tcp_stream::{Connect, DnsTcpStream, TcpStream};
 
 #[cfg(feature = "tokio-runtime")]
 #[doc(hidden)]

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -22,7 +22,7 @@ use log::warn;
 use crate::error::ProtoError;
 #[cfg(feature = "tokio-runtime")]
 use crate::iocompat::AsyncIo02As03;
-use crate::tcp::{Connect, TcpStream};
+use crate::tcp::{Connect, DnsTcpStream, TcpStream};
 use crate::xfer::{DnsClientStream, SerialMessage};
 #[cfg(feature = "tokio-runtime")]
 use crate::TokioTime;
@@ -135,10 +135,13 @@ impl<S> Future for TcpClientConnect<S> {
 use tokio::net::TcpStream as TokioTcpStream;
 
 #[cfg(feature = "tokio-runtime")]
+impl DnsTcpStream for AsyncIo02As03<TokioTcpStream> {
+    type Time = TokioTime;
+}
+
+#[cfg(feature = "tokio-runtime")]
 #[async_trait]
 impl Connect for AsyncIo02As03<TokioTcpStream> {
-    type Time = TokioTime;
-
     async fn connect(addr: SocketAddr) -> io::Result<Self> {
         super::tokio::connect(&addr).await.map(AsyncIo02As03)
     }

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -97,6 +97,8 @@ impl<S: DnsTcpStream> Display for TcpClientStream<S> {
 }
 
 impl<S: DnsTcpStream> DnsClientStream for TcpClientStream<S> {
+    type Time = S::Time;
+
     fn name_server_addr(&self) -> SocketAddr {
         self.tcp_stream.peer_addr()
     }

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -35,7 +35,7 @@ pub struct TcpClientStream<S> {
     tcp_stream: TcpStream<S>,
 }
 
-impl<S: Connect + 'static + Send> TcpClientStream<S> {
+impl<S: Connect + 'static> TcpClientStream<S> {
     /// Constructs a new TcpStream for a client to the specified SocketAddr.
     ///
     /// Defaults to a 5 second timeout
@@ -47,7 +47,7 @@ impl<S: Connect + 'static + Send> TcpClientStream<S> {
     pub fn new<TE: 'static + Time>(
         name_server: SocketAddr,
     ) -> (
-        TcpClientConnect<S::Transport>,
+        TcpClientConnect<S>,
         Box<dyn DnsStreamHandle + 'static + Send>,
     ) {
         Self::with_timeout::<TE>(name_server, Duration::from_secs(5))
@@ -63,7 +63,7 @@ impl<S: Connect + 'static + Send> TcpClientStream<S> {
         name_server: SocketAddr,
         timeout: Duration,
     ) -> (
-        TcpClientConnect<S::Transport>,
+        TcpClientConnect<S>,
         Box<dyn DnsStreamHandle + 'static + Send>,
     ) {
         let (stream_future, sender) = TcpStream::<S>::with_timeout::<TE>(name_server, timeout);
@@ -136,9 +136,7 @@ use tokio::net::TcpStream as TokioTcpStream;
 #[cfg(feature = "tokio-runtime")]
 #[async_trait]
 impl Connect for AsyncIo02As03<TokioTcpStream> {
-    type Transport = AsyncIo02As03<TokioTcpStream>;
-
-    async fn connect(addr: SocketAddr) -> io::Result<Self::Transport> {
+    async fn connect(addr: SocketAddr) -> io::Result<Self> {
         super::tokio::connect(&addr).await.map(AsyncIo02As03)
     }
 }

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -35,7 +35,7 @@ pub struct TcpClientStream<S> {
     tcp_stream: TcpStream<S>,
 }
 
-impl<S: Connect + 'static> TcpClientStream<S> {
+impl<S: Connect> TcpClientStream<S> {
     /// Constructs a new TcpStream for a client to the specified SocketAddr.
     ///
     /// Defaults to a 5 second timeout

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -79,7 +79,7 @@ pub enum ReadTcpState {
 
 /// A Stream used for sending data to and from a remote DNS endpoint (client or server).
 #[must_use = "futures do nothing unless polled"]
-pub struct TcpStream<S> {
+pub struct TcpStream<S: DnsTcpStream> {
     socket: S,
     outbound_messages: StreamReceiver,
     send_state: Option<WriteTcpState>,
@@ -87,7 +87,7 @@ pub struct TcpStream<S> {
     peer_addr: SocketAddr,
 }
 
-impl<S> TcpStream<S> {
+impl<S: DnsTcpStream> TcpStream<S> {
     /// Returns the address of the peer connection.
     pub fn peer_addr(&self) -> SocketAddr {
         self.peer_addr
@@ -181,7 +181,7 @@ impl<S: Connect> TcpStream<S> {
     }
 }
 
-impl<S: AsyncRead + AsyncWrite> TcpStream<S> {
+impl<S: DnsTcpStream> TcpStream<S> {
     /// Initializes a TcpStream.
     ///
     /// This is intended for use with a TcpListener and Incoming.
@@ -215,7 +215,7 @@ impl<S: AsyncRead + AsyncWrite> TcpStream<S> {
     }
 }
 
-impl<S: AsyncRead + AsyncWrite + Unpin> Stream for TcpStream<S> {
+impl<S: DnsTcpStream> Stream for TcpStream<S> {
     type Item = io::Result<SerialMessage>;
 
     #[allow(clippy::cognitive_complexity)]

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -87,29 +87,6 @@ pub struct TcpStream<S: DnsTcpStream> {
     peer_addr: SocketAddr,
 }
 
-impl<S: DnsTcpStream> TcpStream<S> {
-    /// Returns the address of the peer connection.
-    pub fn peer_addr(&self) -> SocketAddr {
-        self.peer_addr
-    }
-
-    fn pollable_split(
-        &mut self,
-    ) -> (
-        &mut S,
-        &mut StreamReceiver,
-        &mut Option<WriteTcpState>,
-        &mut ReadTcpState,
-    ) {
-        (
-            &mut self.socket,
-            &mut self.outbound_messages,
-            &mut self.send_state,
-            &mut self.read_state,
-        )
-    }
-}
-
 impl<S: Connect> TcpStream<S> {
     /// Creates a new future of the eventually establish a IO stream connection or fail trying.
     ///
@@ -182,6 +159,27 @@ impl<S: Connect> TcpStream<S> {
 }
 
 impl<S: DnsTcpStream> TcpStream<S> {
+    /// Returns the address of the peer connection.
+    pub fn peer_addr(&self) -> SocketAddr {
+        self.peer_addr
+    }
+
+    fn pollable_split(
+        &mut self,
+    ) -> (
+        &mut S,
+        &mut StreamReceiver,
+        &mut Option<WriteTcpState>,
+        &mut ReadTcpState,
+    ) {
+        (
+            &mut self.socket,
+            &mut self.outbound_messages,
+            &mut self.send_state,
+            &mut self.read_state,
+        )
+    }
+
     /// Initializes a TcpStream.
     ///
     /// This is intended for use with a TcpListener and Incoming.

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -25,14 +25,14 @@ use crate::xfer::{BufStreamHandle, SerialMessage, StreamReceiver};
 use crate::Time;
 
 /// Trait for TCP connection
-#[async_trait]
-pub trait Connect
-where
-    Self: AsyncRead + AsyncWrite + Unpin + Send + Sync + Sized + 'static,
-{
+pub trait DnsTcpStream: AsyncRead + AsyncWrite + Unpin + Send + Sync + Sized + 'static {
     /// Timer type to use with this TCP stream type
     type Time: Time;
+}
 
+/// Trait for TCP connection
+#[async_trait]
+pub trait Connect: DnsTcpStream {
     /// connect to tcp
     async fn connect(addr: SocketAddr) -> io::Result<Self>;
 }

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -28,7 +28,7 @@ use crate::Time;
 #[async_trait]
 pub trait Connect
 where
-    Self: AsyncRead + AsyncWrite + Unpin + Send + Sized,
+    Self: AsyncRead + AsyncWrite + Unpin + Send + Sync + Sized + 'static,
 {
     /// connect to tcp
     async fn connect(addr: SocketAddr) -> io::Result<Self>;
@@ -107,7 +107,7 @@ impl<S> TcpStream<S> {
     }
 }
 
-impl<S: Connect + 'static> TcpStream<S> {
+impl<S: Connect> TcpStream<S> {
     /// Creates a new future of the eventually establish a IO stream connection or fail trying.
     ///
     /// Defaults to a 5 second timeout

--- a/crates/proto/src/tests/tcp.rs
+++ b/crates/proto/src/tests/tcp.rs
@@ -83,10 +83,7 @@ fn tcp_server_setup(
 }
 
 /// Test tcp_stream.
-pub fn tcp_stream_test<S: Connect + 'static, E: Executor, TE: Time>(
-    server_addr: IpAddr,
-    mut exec: E,
-) {
+pub fn tcp_stream_test<S: Connect, E: Executor, TE: Time>(server_addr: IpAddr, mut exec: E) {
     let (succeeded, server_handle, server_addr) =
         tcp_server_setup("test_tcp_stream:server", server_addr);
 
@@ -118,7 +115,7 @@ pub fn tcp_stream_test<S: Connect + 'static, E: Executor, TE: Time>(
 }
 
 /// Test tcp_client_stream.
-pub fn tcp_client_stream_test<S: Connect + 'static, E: Executor, TE: Time + 'static>(
+pub fn tcp_client_stream_test<S: Connect, E: Executor, TE: Time + 'static>(
     server_addr: IpAddr,
     mut exec: E,
 ) {

--- a/crates/proto/src/tests/tcp.rs
+++ b/crates/proto/src/tests/tcp.rs
@@ -2,7 +2,6 @@ use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{atomic::AtomicBool, Arc};
 
-use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::stream::StreamExt;
 
 use crate::error::ProtoError;
@@ -87,9 +86,7 @@ fn tcp_server_setup(
 pub fn tcp_stream_test<S: Connect + 'static, E: Executor, TE: Time>(
     server_addr: IpAddr,
     mut exec: E,
-) where
-    <S as Connect>::Transport: AsyncRead + AsyncWrite + Unpin,
-{
+) {
     let (succeeded, server_handle, server_addr) =
         tcp_server_setup("test_tcp_stream:server", server_addr);
 
@@ -121,12 +118,10 @@ pub fn tcp_stream_test<S: Connect + 'static, E: Executor, TE: Time>(
 }
 
 /// Test tcp_client_stream.
-pub fn tcp_client_stream_test<S: Connect + Send + 'static, E: Executor, TE: Time + 'static>(
+pub fn tcp_client_stream_test<S: Connect + 'static, E: Executor, TE: Time + 'static>(
     server_addr: IpAddr,
     mut exec: E,
-) where
-    <S as Connect>::Transport: AsyncRead + AsyncWrite + Unpin,
-{
+) {
     let (succeeded, server_handle, server_addr) =
         tcp_server_setup("test_tcp_client_stream:server", server_addr);
 

--- a/crates/proto/src/tests/tcp.rs
+++ b/crates/proto/src/tests/tcp.rs
@@ -92,7 +92,7 @@ pub fn tcp_stream_test<S: Connect, E: Executor, TE: Time>(server_addr: IpAddr, m
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5));
-    let (stream, mut sender) = TcpStream::<S>::new::<ProtoError, TE>(server_addr);
+    let (stream, mut sender) = TcpStream::<S>::new::<ProtoError>(server_addr);
 
     let mut stream = exec.block_on(stream).expect("run failed to get stream");
 
@@ -127,7 +127,7 @@ pub fn tcp_client_stream_test<S: Connect, E: Executor, TE: Time + 'static>(
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5));
-    let (stream, mut sender) = TcpClientStream::<S>::new::<TE>(server_addr);
+    let (stream, mut sender) = TcpClientStream::<S>::new(server_addr);
 
     let mut stream = exec.block_on(stream).expect("run failed to get stream");
 

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -117,7 +117,6 @@ pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor, TE: Ti
     use crate::rr::rdata::NULL;
     use crate::rr::{Name, RData, Record, RecordType};
     use crate::xfer::{DnsRequest, DnsRequestSender};
-    use futures_util::future;
     use std::str::FromStr;
     use std::time::Duration;
 
@@ -206,9 +205,8 @@ pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor, TE: Ti
 
     for i in 0..send_recv_times {
         // test once
-        let response_future = exec.block_on(future::lazy(|cx| {
-            stream.send_message(DnsRequest::new(query.clone(), Default::default()), cx)
-        }));
+        let response_future =
+            stream.send_message(DnsRequest::new(query.clone(), Default::default()));
         println!("client sending request {}", i);
         let response = match exec.block_on(response_future) {
             Ok(response) => response,

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -207,7 +207,7 @@ pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor, TE: Ti
     for i in 0..send_recv_times {
         // test once
         let response_future = exec.block_on(future::lazy(|cx| {
-            stream.send_message::<TE>(DnsRequest::new(query.clone(), Default::default()), cx)
+            stream.send_message(DnsRequest::new(query.clone(), Default::default()), cx)
         }));
         println!("client sending request {}", i);
         let response = match exec.block_on(response_future) {

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -107,7 +107,7 @@ fn random_query_id() -> u16 {
 impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> DnsRequestSender
     for UdpClientStream<S, MF>
 {
-    fn send_message<TE: Time>(
+    fn send_message(
         &mut self,
         mut message: DnsRequest,
         _cx: &mut Context<'_>,
@@ -148,7 +148,7 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> DnsRequestSender
         let message_id = message.id();
         let message = SerialMessage::new(bytes, self.name_server);
 
-        TE::timeout::<Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>>(
+        S::Time::timeout::<Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>>(
             self.timeout,
             Box::pin(send_serial_message::<S>(message, message_id)),
         )

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -107,11 +107,7 @@ fn random_query_id() -> u16 {
 impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> DnsRequestSender
     for UdpClientStream<S, MF>
 {
-    fn send_message(
-        &mut self,
-        mut message: DnsRequest,
-        _cx: &mut Context<'_>,
-    ) -> DnsResponseFuture {
+    fn send_message(&mut self, mut message: DnsRequest) -> DnsResponseFuture {
         if self.is_shutdown {
             panic!("can not send messages after stream is shutdown")
         }

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -19,6 +19,7 @@ use rand;
 use rand::distributions::{uniform::Uniform, Distribution};
 
 use crate::xfer::{BufStreamHandle, SerialMessage, StreamReceiver};
+use crate::Time;
 
 /// Trait for UdpSocket
 #[async_trait]
@@ -26,6 +27,9 @@ pub trait UdpSocket
 where
     Self: Sized + Unpin,
 {
+    /// Time implementation used for this type
+    type Time: Time;
+
     /// UdpSocket
     async fn bind(addr: &SocketAddr) -> io::Result<Self>;
     /// Receive data from the socket and returns the number of bytes read and the address from
@@ -222,6 +226,8 @@ impl<S: UdpSocket> Future for NextRandomUdpSocket<S> {
 #[cfg(feature = "tokio-runtime")]
 #[async_trait]
 impl UdpSocket for tokio::net::UdpSocket {
+    type Time = crate::TokioTime;
+
     async fn bind(addr: &SocketAddr) -> io::Result<Self> {
         tokio::net::UdpSocket::bind(addr).await
     }

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -192,7 +192,7 @@ where
                     // if there is no peer, this connection should die...
                     let (dns_request, serial_response): (DnsRequest, _) = dns_request.into_parts();
 
-                    match serial_response.send_response(io_stream.send_message(dns_request, cx)) {
+                    match serial_response.send_response(io_stream.send_message(dns_request)) {
                         Ok(()) => (),
                         Err(_) => {
                             warn!("failed to associate send_message response to the sender");

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -192,9 +192,7 @@ where
                     // if there is no peer, this connection should die...
                     let (dns_request, serial_response): (DnsRequest, _) = dns_request.into_parts();
 
-                    match serial_response
-                        .send_response(io_stream.send_message::<TE>(dns_request, cx))
-                    {
+                    match serial_response.send_response(io_stream.send_message(dns_request, cx)) {
                         Ok(()) => (),
                         Err(_) => {
                             warn!("failed to associate send_message response to the sender");

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -305,7 +305,7 @@ where
     S: DnsClientStream + Unpin + 'static,
     MF: MessageFinalizer + Send + Sync + 'static,
 {
-    fn send_message(&mut self, request: DnsRequest, _: &mut Context<'_>) -> DnsResponseFuture {
+    fn send_message(&mut self, request: DnsRequest) -> DnsResponseFuture {
         if self.is_shutdown {
             panic!("can not send messages after stream is shutdown")
         }

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -305,11 +305,7 @@ where
     S: DnsClientStream + Unpin + 'static,
     MF: MessageFinalizer + Send + Sync + 'static,
 {
-    fn send_message<TE: Time>(
-        &mut self,
-        request: DnsRequest,
-        _: &mut Context<'_>,
-    ) -> DnsResponseFuture {
+    fn send_message(&mut self, request: DnsRequest, _: &mut Context<'_>) -> DnsResponseFuture {
         if self.is_shutdown {
             panic!("can not send messages after stream is shutdown")
         }
@@ -345,7 +341,7 @@ where
         }
 
         // store a Timeout for this message before sending
-        let timeout = TE::delay_for(self.timeout_duration);
+        let timeout = S::Time::delay_for(self.timeout_duration);
 
         let (complete, receiver) = oneshot::channel();
 

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -52,6 +52,9 @@ fn ignore_send<M, E: Debug>(result: Result<M, E>) {
 pub trait DnsClientStream:
     Stream<Item = Result<SerialMessage, ProtoError>> + Display + Send
 {
+    /// Time implementation for this impl
+    type Time: Time;
+
     /// The remote name server address
     fn name_server_addr(&self) -> SocketAddr;
 }

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -126,7 +126,7 @@ pub trait DnsRequestSender: Stream<Item = Result<(), ProtoError>> + Send + Unpin
     /// # Return
     ///
     /// A future which will resolve to a SerialMessage response
-    fn send_message(&mut self, message: DnsRequest, cx: &mut Context<'_>) -> DnsResponseFuture;
+    fn send_message(&mut self, message: DnsRequest) -> DnsResponseFuture;
 
     /// Allows the upstream user to inform the underling stream that it should shutdown.
     ///

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -126,11 +126,7 @@ pub trait DnsRequestSender: Stream<Item = Result<(), ProtoError>> + Send + Unpin
     /// # Return
     ///
     /// A future which will resolve to a SerialMessage response
-    fn send_message<TE: Time>(
-        &mut self,
-        message: DnsRequest,
-        cx: &mut Context<'_>,
-    ) -> DnsResponseFuture;
+    fn send_message(&mut self, message: DnsRequest, cx: &mut Context<'_>) -> DnsResponseFuture;
 
     /// Allows the upstream user to inform the underling stream that it should shutdown.
     ///

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -424,21 +424,19 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> fmt::D
 #[cfg(any(test, feature = "testing"))]
 #[allow(dead_code)]
 pub mod testing {
-    use std::{marker::Unpin, net::*, str::FromStr};
+    use std::{net::*, str::FromStr};
 
     use crate::config::{LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts};
     use crate::name_server::{GenericConnection, GenericConnectionProvider, RuntimeProvider};
     use crate::AsyncResolver;
-    use proto::{rr::Name, tcp::Connect, Executor};
+    use proto::{rr::Name, Executor};
 
     /// Test IP lookup from URLs.
     pub fn lookup_test<E: Executor, R: RuntimeProvider>(
         config: ResolverConfig,
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
             config,
             ResolverOpts::default(),
@@ -466,10 +464,7 @@ pub mod testing {
     }
 
     /// Test IP lookup from IP literals.
-    pub fn ip_lookup_test<E: Executor, R: RuntimeProvider>(mut exec: E, handle: R::Handle)
-    where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    pub fn ip_lookup_test<E: Executor, R: RuntimeProvider>(mut exec: E, handle: R::Handle) {
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
             ResolverConfig::default(),
             ResolverOpts::default(),
@@ -501,9 +496,7 @@ pub mod testing {
     /// Test IP lookup from IP literals across threads.
     pub fn ip_lookup_across_threads_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         // Test ensuring that running the background task on a separate
         // executor in a separate thread from the futures returned by the
         // AsyncResolver works correctly.
@@ -559,9 +552,7 @@ pub mod testing {
     pub fn sec_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         //env_logger::try_init().ok();
 
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
@@ -600,9 +591,7 @@ pub mod testing {
     pub fn sec_lookup_fails_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         use crate::error::*;
         use proto::rr::RecordType;
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
@@ -645,9 +634,7 @@ pub mod testing {
     pub fn system_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let resolver =
             AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::from_system_conf(
                 handle,
@@ -678,9 +665,7 @@ pub mod testing {
     pub fn hosts_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let resolver =
             AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::from_system_conf(
                 handle,
@@ -705,9 +690,7 @@ pub mod testing {
     pub fn fqdn_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let domain = Name::from_str("incorrect.example.com.").unwrap();
         let search = vec![
             Name::from_str("bad.example.com.").unwrap(),
@@ -744,9 +727,7 @@ pub mod testing {
     pub fn ndots_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let domain = Name::from_str("incorrect.example.com.").unwrap();
         let search = vec![
             Name::from_str("bad.example.com.").unwrap(),
@@ -786,9 +767,7 @@ pub mod testing {
     pub fn large_ndots_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let domain = Name::from_str("incorrect.example.com.").unwrap();
         let search = vec![
             Name::from_str("bad.example.com.").unwrap(),
@@ -828,9 +807,7 @@ pub mod testing {
     pub fn domain_search_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         //env_logger::try_init().ok();
 
         // domain is good now, should be combined with the name to form www.example.com
@@ -871,9 +848,7 @@ pub mod testing {
     pub fn search_list_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let domain = Name::from_str("incorrect.example.com.").unwrap();
         let search = vec![
             // let's skip one search domain to test the loop...
@@ -913,9 +888,7 @@ pub mod testing {
     pub fn idna_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
             ResolverConfig::default(),
             ResolverOpts::default(),
@@ -936,9 +909,7 @@ pub mod testing {
     pub fn localhost_ipv4_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
             ResolverConfig::default(),
             ResolverOpts {
@@ -964,9 +935,7 @@ pub mod testing {
     pub fn localhost_ipv6_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
             ResolverConfig::default(),
             ResolverOpts {
@@ -992,9 +961,7 @@ pub mod testing {
     pub fn search_ipv4_large_ndots_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let mut config = ResolverConfig::default();
         config.add_search(Name::from_str("example.com").unwrap());
 
@@ -1024,9 +991,7 @@ pub mod testing {
     pub fn search_ipv6_large_ndots_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let mut config = ResolverConfig::default();
         config.add_search(Name::from_str("example.com").unwrap());
 
@@ -1056,9 +1021,7 @@ pub mod testing {
     pub fn search_ipv6_name_parse_fails_test<E: Executor + Send + 'static, R: RuntimeProvider>(
         mut exec: E,
         handle: R::Handle,
-    ) where
-        <<R as RuntimeProvider>::Tcp as Connect>::Transport: Unpin,
-    {
+    ) {
         let mut config = ResolverConfig::default();
         config.add_search(Name::from_str("example.com").unwrap());
 

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -131,7 +131,7 @@ where
                 let timeout = options.timeout;
 
                 let (stream, handle) =
-                    TcpClientStream::<R::Tcp>::with_timeout::<R::Timer>(socket_addr, timeout);
+                    TcpClientStream::<R::Tcp>::with_timeout(socket_addr, timeout);
                 // TODO: need config for Signer...
                 let dns_conn = DnsMultiplexer::with_timeout(
                     stream,

--- a/crates/rustls/src/tls_stream.rs
+++ b/crates/rustls/src/tls_stream.rs
@@ -21,7 +21,7 @@ use tokio_rustls::TlsConnector;
 use webpki::{DNSName, DNSNameRef};
 
 use trust_dns_proto::iocompat::AsyncIo02As03;
-use trust_dns_proto::tcp::{self, TcpStream};
+use trust_dns_proto::tcp::{self, DnsTcpStream, TcpStream};
 use trust_dns_proto::xfer::{BufStreamHandle, StreamReceiver};
 
 /// Predefined type for abstracting the TlsClientStream with TokioTls
@@ -36,7 +36,7 @@ pub type TlsStream<S> = TcpStream<S>;
 /// Initializes a TlsStream with an existing tokio_tls::TlsStream.
 ///
 /// This is intended for use with a TlsListener and Incoming connections
-pub fn tls_from_stream<S: futures_io::AsyncRead + futures_io::AsyncWrite>(
+pub fn tls_from_stream<S: DnsTcpStream>(
     stream: S,
     peer_addr: SocketAddr,
 ) -> (TlsStream<S>, BufStreamHandle) {

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -24,7 +24,7 @@ use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::{
     DnsClientStream, DnsMultiplexer, DnsMultiplexerConnect, SerialMessage,
 };
-use trust_dns_proto::StreamHandle;
+use trust_dns_proto::{StreamHandle, TokioTime};
 
 use trust_dns_server::authority::{Catalog, MessageRequest, MessageResponse};
 use trust_dns_server::server::{Request, RequestHandler, ResponseHandler};
@@ -117,6 +117,8 @@ impl fmt::Display for TestClientStream {
 }
 
 impl DnsClientStream for TestClientStream {
+    type Time = TokioTime;
+
     fn name_server_addr(&self) -> SocketAddr {
         SocketAddr::from(([127, 0, 0, 1], 1234))
     }
@@ -205,6 +207,8 @@ impl fmt::Display for NeverReturnsClientStream {
 }
 
 impl DnsClientStream for NeverReturnsClientStream {
+    type Time = TokioTime;
+
     fn name_server_addr(&self) -> SocketAddr {
         SocketAddr::from(([0, 0, 0, 0], 53))
     }

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -82,7 +82,7 @@ fn test_query_udp_ipv6() {
 fn test_query_tcp_ipv4() {
     let mut io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
     let client = AsyncClient::new(stream, sender, None);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -101,7 +101,7 @@ fn test_query_tcp_ipv6() {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
     let client = AsyncClient::new(stream, sender, None);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -928,9 +928,10 @@ fn test_timeout_query_tcp() {
         .next()
         .unwrap();
 
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::with_timeout::<
-        TokioTime,
-    >(addr, std::time::Duration::from_millis(1));
+    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::with_timeout(
+        addr,
+        std::time::Duration::from_millis(1),
+    );
     let client = AsyncClient::with_timeout(
         Box::new(stream),
         sender,

--- a/tests/integration-tests/tests/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/dnssec_client_handle_tests.rs
@@ -15,9 +15,9 @@ use trust_dns_client::rr::Name;
 use trust_dns_client::rr::{DNSClass, RData, RecordType};
 use trust_dns_client::tcp::TcpClientStream;
 
+use trust_dns_proto::iocompat::AsyncIo02As03;
 use trust_dns_proto::udp::{UdpClientConnect, UdpClientStream};
 use trust_dns_proto::DnssecDnsHandle;
-use trust_dns_proto::{iocompat::AsyncIo02As03, TokioTime};
 use trust_dns_server::authority::{Authority, Catalog};
 
 use trust_dns_integration::authority::create_secure_example;
@@ -303,7 +303,7 @@ where
 
     let mut io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new::<TokioTime>(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
     let client = AsyncClient::new(Box::new(stream), sender, None);
     let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);


### PR DESCRIPTION
The `DnsTcpStream` name isn't great, but I wasn't sure what else could be used... Maybe flip the naming for `DnsTcpStream` and `TcpStream`? Any other suggestions?

An further direction might be to move the `RuntimeProvider` trait from resolver into proto and use it to govern all this stuff directly.