### PR TITLE
Set TCP_NODELAY when building a TCP connection

### DIFF
--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -40,9 +40,9 @@ impl Connect for AsyncStdTcpStream {
     type Transport = AsyncStdTcpStream;
 
     async fn connect(addr: SocketAddr) -> io::Result<Self::Transport> {
-        async_std::net::TcpStream::connect(addr)
-            .await
-            .map(AsyncStdTcpStream)
+        let stream = async_std::net::TcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        Ok(AsyncStdTcpStream(stream))
     }
 }
 

--- a/crates/native-tls/src/tls_stream.rs
+++ b/crates/native-tls/src/tls_stream.rs
@@ -19,7 +19,7 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_tls::{TlsConnector as TokioTlsConnector, TlsStream as TokioTlsStream};
 
 use trust_dns_proto::iocompat::AsyncIo02As03;
-use trust_dns_proto::tcp::TcpStream;
+use trust_dns_proto::tcp::{self, TcpStream};
 use trust_dns_proto::xfer::{BufStreamHandle, StreamReceiver};
 
 /// A TlsStream counterpart to the TcpStream which embeds a secure TlsStream
@@ -140,7 +140,7 @@ impl TlsStreamBuilder {
         let ca_chain = self.ca_chain.clone();
         let identity = self.identity;
 
-        let tcp_stream: Result<TokioTcpStream, _> = TokioTcpStream::connect(&name_server).await;
+        let tcp_stream = tcp::tokio::connect(&name_server).await;
 
         // TODO: for some reason the above wouldn't accept a ?
         let tcp_stream = match tcp_stream {

--- a/crates/openssl/src/tls_stream.rs
+++ b/crates/openssl/src/tls_stream.rs
@@ -21,7 +21,7 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_openssl::{self, SslStream as TokioTlsStream};
 
 use trust_dns_proto::iocompat::AsyncIo02As03;
-use trust_dns_proto::tcp::TcpStream;
+use trust_dns_proto::tcp::{self, TcpStream};
 use trust_dns_proto::xfer::BufStreamHandle;
 
 pub trait TlsIdentityExt {
@@ -129,7 +129,7 @@ async fn connect_tls(
     dns_name: String,
     name_server: SocketAddr,
 ) -> Result<TokioTlsStream<TokioTcpStream>, io::Error> {
-    let tcp = TokioTcpStream::connect(&name_server).await.map_err(|e| {
+    let tcp = tcp::tokio::connect(&name_server).await.map_err(|e| {
         io::Error::new(
             io::ErrorKind::ConnectionRefused,
             format!("tls error: {}", e),

--- a/crates/proto/src/tcp/mod.rs
+++ b/crates/proto/src/tcp/mod.rs
@@ -20,3 +20,15 @@ mod tcp_stream;
 
 pub use self::tcp_client_stream::{TcpClientConnect, TcpClientStream};
 pub use self::tcp_stream::{Connect, TcpStream};
+
+#[cfg(feature = "tokio-runtime")]
+#[doc(hidden)]
+pub mod tokio {
+    use std::io;
+    use std::net::SocketAddr;
+    use tokio::net::TcpStream as TokioTcpStream;
+
+    pub async fn connect(addr: &SocketAddr) -> Result<TokioTcpStream, io::Error> {
+        TokioTcpStream::connect(addr).await
+    }
+}

--- a/crates/proto/src/tcp/mod.rs
+++ b/crates/proto/src/tcp/mod.rs
@@ -29,6 +29,8 @@ pub mod tokio {
     use tokio::net::TcpStream as TokioTcpStream;
 
     pub async fn connect(addr: &SocketAddr) -> Result<TokioTcpStream, io::Error> {
-        TokioTcpStream::connect(addr).await
+        let stream = TokioTcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        Ok(stream)
     }
 }

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -139,7 +139,7 @@ impl Connect for AsyncIo02As03<TokioTcpStream> {
     type Transport = AsyncIo02As03<TokioTcpStream>;
 
     async fn connect(addr: SocketAddr) -> io::Result<Self::Transport> {
-        TokioTcpStream::connect(&addr).await.map(AsyncIo02As03)
+        super::tokio::connect(&addr).await.map(AsyncIo02As03)
     }
 }
 

--- a/crates/rustls/src/tls_stream.rs
+++ b/crates/rustls/src/tls_stream.rs
@@ -21,7 +21,7 @@ use tokio_rustls::TlsConnector;
 use webpki::{DNSName, DNSNameRef};
 
 use trust_dns_proto::iocompat::AsyncIo02As03;
-use trust_dns_proto::tcp::TcpStream;
+use trust_dns_proto::tcp::{self, TcpStream};
 use trust_dns_proto::xfer::{BufStreamHandle, StreamReceiver};
 
 /// Predefined type for abstracting the TlsClientStream with TokioTls
@@ -106,7 +106,7 @@ async fn connect_tls(
     dns_name: String,
     outbound_messages: StreamReceiver,
 ) -> io::Result<TcpStream<AsyncIo02As03<TokioTlsClientStream>>> {
-    let tcp = TokioTcpStream::connect(&name_server).await?;
+    let tcp = tcp::tokio::connect(&name_server).await?;
 
     let dns_name = DNSNameRef::try_from_ascii_str(&dns_name)
         .map(DNSName::from)


### PR DESCRIPTION
I happened to be reading [this article](https://rachelbythebay.com/w/2020/10/14/lag/) about unexpected minimum latencies and it referenced [Nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm). Since DNS queries are sensitive to latency and DNS messages are usually smaller than the Maximum Segment Size, this seems sensible.