### PR TITLE
move to renamed tokio-native-tls crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-openssl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,16 +1599,6 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -1761,7 +1761,7 @@ dependencies = [
  "futures-util",
  "native-tls",
  "tokio",
- "tokio-tls",
+ "tokio-native-tls",
  "trust-dns-proto",
 ]
 
@@ -1827,9 +1827,9 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
+ "tokio-native-tls",
  "tokio-openssl",
  "tokio-rustls",
- "tokio-tls",
  "trust-dns-https",
  "trust-dns-native-tls",
  "trust-dns-openssl",

--- a/crates/native-tls/Cargo.toml
+++ b/crates/native-tls/Cargo.toml
@@ -51,7 +51,7 @@ futures-channel = { version = "0.3.5", default-features = false, features = ["st
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 native-tls = "0.2"
 tokio = "0.2.22"
-tokio-tls = "0.3.1"
+tokio-native-tls = "0.1"
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.2", path = "../proto", features = ["tokio-runtime"], default-features = false }
 

--- a/crates/native-tls/src/tls_client_stream.rs
+++ b/crates/native-tls/src/tls_client_stream.rs
@@ -16,7 +16,7 @@ use native_tls::Certificate;
 #[cfg(feature = "mtls")]
 use native_tls::Pkcs12;
 use tokio::net::TcpStream as TokioTcpStream;
-use tokio_tls::TlsStream as TokioTlsStream;
+use tokio_native_tls::TlsStream as TokioTlsStream;
 
 use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::iocompat::AsyncIo02As03;

--- a/crates/native-tls/src/tls_stream.rs
+++ b/crates/native-tls/src/tls_stream.rs
@@ -16,7 +16,7 @@ use futures_util::TryFutureExt;
 use native_tls::Protocol::Tlsv12;
 use native_tls::{Certificate, Identity, TlsConnector};
 use tokio::net::TcpStream as TokioTcpStream;
-use tokio_tls::{TlsConnector as TokioTlsConnector, TlsStream as TokioTlsStream};
+use tokio_native_tls::{TlsConnector as TokioTlsConnector, TlsStream as TokioTlsStream};
 
 use trust_dns_proto::iocompat::AsyncIo02As03;
 use trust_dns_proto::tcp::{self, TcpStream};

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -38,7 +38,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["system-config", "tokio-runtime"]
 backtrace = ["trust-dns-proto/backtrace"]
-dns-over-native-tls = ["dns-over-tls", "tokio-tls", "trust-dns-native-tls"]
+dns-over-native-tls = ["dns-over-tls", "tokio-native-tls", "trust-dns-native-tls"]
 # DNS over TLS with OpenSSL currently needs a good way to set default CAs, use rustls or native-tls
 dns-over-openssl = ["dns-over-tls", "trust-dns-openssl", "tokio-openssl"]
 dns-over-rustls = ["dns-over-tls", "rustls", "tokio-rustls", "trust-dns-rustls", "webpki-roots"]
@@ -78,7 +78,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.2"
 thiserror = "1.0.20"
 tokio = { version = "0.2.22", optional = true }
-tokio-tls = { version = "0.3.1", optional = true }
+tokio-native-tls = { version = "0.1", optional = true }
 tokio-openssl = { version = "0.4.0", optional = true }
 tokio-rustls = { version = "0.14", optional = true }
 trust-dns-https = { version = "0.20.0-alpha.2", path = "../https", optional = true }

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -13,6 +13,8 @@ use futures_util::future::{Future, FutureExt};
 use futures_util::ready;
 #[cfg(feature = "tokio-runtime")]
 use tokio::net::TcpStream as TokioTcpStream;
+#[cfg(all(feature = "dns-over-native-tls", not(feature = "dns-over-rustls")))]
+use tokio_native_tls::TlsStream as TokioTlsStream;
 #[cfg(all(
     feature = "dns-over-openssl",
     not(feature = "dns-over-rustls"),
@@ -21,8 +23,6 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_openssl::SslStream as TokioTlsStream;
 #[cfg(feature = "dns-over-rustls")]
 use tokio_rustls::client::TlsStream as TokioTlsStream;
-#[cfg(all(feature = "dns-over-native-tls", not(feature = "dns-over-rustls")))]
-use tokio_tls::TlsStream as TokioTlsStream;
 
 use proto;
 use proto::error::ProtoError;


### PR DESCRIPTION
The tokio-tls crate is no longer maintained, I think, and moving to tokio-native-tls is a prerequisite for upgrading to tokio 0.3 (see #1250).