### PR TITLE
Support reading the root hints file

### DIFF
--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -139,15 +139,16 @@ impl Parser {
         &mut self,
         lexer: Lexer,
         origin: Option<Name>,
+        class: Option<DNSClass>,
     ) -> ParseResult<(Name, BTreeMap<RrKey, RecordSet>)> {
         let mut lexer = lexer;
         let mut records: BTreeMap<RrKey, RecordSet> = BTreeMap::new();
 
         let mut origin: Option<Name> = origin;
+        let mut class: Option<DNSClass> = class;
         let mut current_name: Option<Name> = None;
         let mut rtype: Option<RecordType> = None;
         let mut ttl: Option<u32> = None;
-        let mut class: Option<DNSClass> = None;
         let mut state = State::StartLine;
 
         while let Some(t) = lexer.next_token()? {

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -192,7 +192,7 @@ impl FileAuthority {
 
         let lexer = Lexer::new(&buf);
         let (origin, records) = Parser::new()
-            .parse(lexer, Some(origin))
+            .parse(lexer, Some(origin), None)
             .map_err(|e| format!("failed to parse {}: {:?}", config.zone_file_path, e))?;
 
         info!(

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -59,7 +59,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()));
+    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()), None);
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
     }
@@ -437,7 +437,7 @@ a       A       127.0.0.1
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()));
+    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()), None);
 
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
@@ -465,7 +465,7 @@ b       A       127.0.0.2
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()));
+    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()), None);
 
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
@@ -492,7 +492,7 @@ a       A       127.0.0.1
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()));
+    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()), None);
 
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
@@ -501,4 +501,25 @@ a       A       127.0.0.1
     let (origin, records) = records.unwrap();
 
     assert!(InMemoryAuthority::new(origin, records, ZoneType::Primary, false).is_ok());
+}
+
+#[test]
+fn test_named_root() {
+    let lexer = Lexer::new(
+        r###"
+.                        3600000      NS    A.ROOT-SERVERS.NET.
+"###,
+    );
+
+    let records = Parser::new().parse(lexer, Some(Name::root()), Some(DNSClass::IN));
+
+    if records.is_err() {
+        panic!("failed to parse: {:?}", records.err())
+    }
+
+    let (_, records) = records.unwrap();
+    let key = RrKey::new(LowerName::from(Name::root()), RecordType::NS);
+
+    assert!(records.contains_key(&key));
+    assert_eq!(records[&key].dns_class(), DNSClass::IN)
 }


### PR DESCRIPTION
I want to parse the [named.root](https://www.internic.net/domain/named.root) file with trust_dns, but it's currently impossible because it contains no class fields. This PR adds the support I need as well as a unit test to keep it working.
The change is not API compatible. If you wish I'll make it compatible so long as you give me some direction how.