### PR TITLE
Upgrade to Tokio 0.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['1.42.0', beta, nightly]
+        version: ['1.45.0', beta, nightly]
     steps:
     - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 
 ### Changed
 
+- (all) upgraded to Tokio 0.3
 - (https) dns_hostname args all are `Arc<str>` rather than `Arc<String>`, use `Arc::from`
 - (proto) Set TCP_NODELAY when building a TCP connection (@djc) #1249
 - (all) *BREAKING* The `UdpSocket` trait has grown an associated `Time` type.
@@ -19,7 +20,7 @@ bound for implementing the `Connect` trait.
 - (resolver) *BREAKING* Move `CachingClient` from `lookup_state` to `caching_client` module
 - (resolver) *BREAKING* Move `ResolverOpts::distrust_nx_responses` to `NameServerConfig::trust_nx_responses` (@djc) #1212
 - (proto) `data-encoding` is now a required dependency #1208
-- (all) minimum rustc version now `1.42`
+- (all) minimum rustc version now `1.45`
 - (resolver) For all NxDomain and NoError/NoData responses, `ResolveErrorKind::NoRecordsFound` will be returned #1197
 - (server) Support for lowercase DNSClass and RecordType fields in zonefiles (@zhanif3) #1186
 - (resolver) Make EDNS optional for resolvers (@CtrlZvi) #1173

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501c8252b73bd01379aaae1521523c2629ff1bc6ea46c29e0baff515cee60f1b"
+dependencies = [
+ "native-tls",
+ "tokio 0.3.3",
+]
+
+[[package]]
 name = "tokio-openssl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,7 +1854,7 @@ dependencies = [
  "futures-util",
  "native-tls",
  "tokio 0.3.3",
- "tokio-native-tls",
+ "tokio-native-tls 0.2.0",
  "trust-dns-proto",
 ]
 
@@ -1910,7 +1920,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio 0.3.3",
- "tokio-native-tls",
+ "tokio-native-tls 0.1.0",
  "tokio-openssl 0.4.0",
  "tokio-rustls 0.14.1",
  "trust-dns-https",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "futures-io",
+ "futures-util",
  "trust-dns-resolver",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-openssl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01e5cc2d3a154fa310982d0affaec8140d6476805422265b2f648eb813f937f"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "tokio 0.3.3",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,7 +1856,7 @@ dependencies = [
  "futures-util",
  "openssl",
  "tokio 0.3.3",
- "tokio-openssl",
+ "tokio-openssl 0.5.0",
  "trust-dns-proto",
 ]
 
@@ -1900,7 +1911,7 @@ dependencies = [
  "thiserror",
  "tokio 0.3.3",
  "tokio-native-tls",
- "tokio-openssl",
+ "tokio-openssl 0.4.0",
  "tokio-rustls 0.14.1",
  "trust-dns-https",
  "trust-dns-native-tls",
@@ -1946,7 +1957,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio 0.3.3",
- "tokio-openssl",
+ "tokio-openssl 0.4.0",
  "tokio-rustls 0.14.1",
  "toml",
  "trust-dns-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
  "gimli",
 ]
@@ -36,7 +36,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124ac8c265e407641c3362b8f4d39cdb4e243885b71eef087be27199790f5a3a"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
 dependencies = [
  "async-executor",
  "async-io",
@@ -104,7 +104,7 @@ dependencies = [
  "polling",
  "vec-arena",
  "waker-fn",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -196,9 +196,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -247,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
 name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,7 +286,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -328,7 +334,7 @@ dependencies = [
  "regex",
  "terminal_size",
  "unicode-width",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -361,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "encode_unicode"
@@ -449,22 +455,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -590,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "gloo-timers"
@@ -613,7 +603,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -621,7 +611,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -671,7 +661,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -680,7 +670,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -722,15 +712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,7 +719,7 @@ checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
  "socket2",
  "widestring",
- "winapi 0.3.9",
+ "winapi",
  "winreg",
 ]
 
@@ -764,16 +745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,9 +761,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -852,9 +823,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "miniz_oxide"
@@ -868,33 +839,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
  "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "socket2",
+ "winapi",
 ]
 
 [[package]]
@@ -922,18 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
  "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -946,10 +898,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.43"
+name = "ntapi"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -957,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -976,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
@@ -1048,7 +1009,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1125,7 +1086,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1160,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -1253,9 +1214,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1265,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -1275,7 +1236,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1300,7 +1261,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1345,7 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1428,7 +1389,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1469,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.46"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad5de3220ea04da322618ded2c42233d02baca219d6f160a3e9c87cda16c942"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1489,7 +1450,7 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1508,7 +1469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1557,7 +1518,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1572,10 +1533,23 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
- "iovec",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
+dependencies = [
+ "autocfg",
+ "bytes 0.6.0",
+ "futures-core",
  "lazy_static",
+ "libc",
  "memchr",
  "mio",
  "num_cpus",
@@ -1586,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1602,7 +1576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1612,7 +1586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
 dependencies = [
  "openssl",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1623,7 +1597,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio",
+ "tokio 0.2.22",
  "webpki",
 ]
 
@@ -1633,12 +1607,12 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1693,7 +1667,7 @@ dependencies = [
  "native-tls",
  "regex",
  "rustls",
- "tokio",
+ "tokio 0.3.3",
  "trust-dns-client",
  "trust-dns-https",
  "trust-dns-native-tls",
@@ -1724,7 +1698,7 @@ dependencies = [
  "rustls",
  "serde",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "trust-dns-https",
  "trust-dns-proto",
  "webpki",
@@ -1747,7 +1721,7 @@ dependencies = [
 name = "trust-dns-https"
 version = "0.20.0-alpha.3"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "cfg-if 1.0.0",
  "data-encoding",
  "env_logger",
@@ -1758,7 +1732,7 @@ dependencies = [
  "log",
  "rustls",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "tokio-rustls",
  "trust-dns-proto",
  "trust-dns-rustls",
@@ -1779,7 +1753,7 @@ dependencies = [
  "rand",
  "rusqlite",
  "rustls",
- "tokio",
+ "tokio 0.3.3",
  "trust-dns-client",
  "trust-dns-https",
  "trust-dns-openssl",
@@ -1797,7 +1771,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "native-tls",
- "tokio",
+ "tokio 0.3.3",
  "tokio-native-tls",
  "trust-dns-proto",
 ]
@@ -1809,7 +1783,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "openssl",
- "tokio",
+ "tokio 0.3.3",
  "tokio-openssl",
  "trust-dns-proto",
 ]
@@ -1840,7 +1814,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "url",
  "wasm-bindgen",
 ]
@@ -1863,7 +1837,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "tokio-native-tls",
  "tokio-openssl",
  "tokio-rustls",
@@ -1885,7 +1859,7 @@ dependencies = [
  "log",
  "openssl",
  "rustls",
- "tokio",
+ "tokio 0.3.3",
  "tokio-rustls",
  "trust-dns-proto",
  "webpki",
@@ -1895,7 +1869,7 @@ dependencies = [
 name = "trust-dns-server"
 version = "0.20.0-alpha.3"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "cfg-if 1.0.0",
  "chrono",
  "enum-as-inner",
@@ -1910,7 +1884,7 @@ dependencies = [
  "rustls",
  "serde",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "tokio-openssl",
  "tokio-rustls",
  "toml",
@@ -1933,7 +1907,7 @@ dependencies = [
  "log",
  "openssl",
  "structopt",
- "tokio",
+ "tokio 0.3.3",
  "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-resolver",
@@ -2146,12 +2120,6 @@ checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2159,12 +2127,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2178,7 +2140,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2193,15 +2155,5 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "async-trait",
  "futures-io",
  "futures-util",
+ "pin-utils",
  "trust-dns-resolver",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,16 +1607,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
-dependencies = [
- "native-tls",
- "tokio 0.2.22",
-]
-
-[[package]]
-name = "tokio-native-tls"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501c8252b73bd01379aaae1521523c2629ff1bc6ea46c29e0baff515cee60f1b"
@@ -1854,7 +1844,7 @@ dependencies = [
  "futures-util",
  "native-tls",
  "tokio 0.3.3",
- "tokio-native-tls 0.2.0",
+ "tokio-native-tls",
  "trust-dns-proto",
 ]
 
@@ -1920,9 +1910,9 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio 0.3.3",
- "tokio-native-tls 0.1.0",
- "tokio-openssl 0.4.0",
- "tokio-rustls 0.14.1",
+ "tokio-native-tls",
+ "tokio-openssl 0.5.0",
+ "tokio-rustls 0.20.0",
  "trust-dns-https",
  "trust-dns-native-tls",
  "trust-dns-openssl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -535,7 +535,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "waker-fn",
 ]
 
@@ -619,9 +619,9 @@ dependencies = [
 [[package]]
 name = "h2"
 version = "0.3.0"
-source = "git+https://github.com/hyperium/h2.git#cbbdd305b1afc1eaf19f2e3b26f9419048041e7d"
+source = "git+https://github.com/hyperium/h2.git#dc3079ab89ca9fa7b79e014f5b2a835f30f4916b"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.6.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 dependencies = [
  "libc",
  "log",
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi",
@@ -1081,6 +1081,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -1306,9 +1312,9 @@ checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
  "base64",
  "log",
@@ -1400,11 +1406,11 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi",
@@ -1547,9 +1553,9 @@ checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
+checksum = "9dfe2523e6fa84ddf5e688151d4e5fddc51678de9752c6512a24714c23818d61"
 dependencies = [
  "autocfg",
  "bytes 0.6.0",
@@ -1559,7 +1565,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "slab",
  "tokio-macros",
 ]
@@ -1598,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3f045b4a15afc543ffe6e02bae7ecf372e89a0f9f8c4b15b13f0ceed4f105"
+checksum = "28c0f299ee89149992d30f2783e966bc6fc497f5a02fc470f8b0182851c04632"
 dependencies = [
  "rustls",
  "tokio",
@@ -1609,15 +1615,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24793699f4665ba0416ed287dc794fe6b11a4aa5e4e95b58624f45f6c46b97d4"
+checksum = "73af76301319bcacf00d26d3c75534ef248dcad7ceaf36d93ec902453c3b1706"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.6.0",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -1637,8 +1643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
- "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tracing-core",
 ]
 
@@ -1727,7 +1732,7 @@ dependencies = [
 name = "trust-dns-https"
 version = "0.20.0-alpha.3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.6.0",
  "cfg-if 1.0.0",
  "data-encoding",
  "env_logger",
@@ -1875,7 +1880,7 @@ dependencies = [
 name = "trust-dns-server"
 version = "0.20.0-alpha.3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 0.6.0",
  "cfg-if 1.0.0",
  "chrono",
  "enum-as-inner",
@@ -2103,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -629,7 +629,26 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 0.2.22",
- "tokio-util",
+ "tokio-util 0.3.1",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.0"
+source = "git+https://github.com/hyperium/h2.git#cbbdd305b1afc1eaf19f2e3b26f9419048041e7d"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 0.3.3",
+ "tokio-util 0.4.0",
  "tracing",
  "tracing-futures",
 ]
@@ -879,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
+checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1644,6 +1663,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24793699f4665ba0416ed287dc794fe6b11a4aa5e4e95b58624f45f6c46b97d4"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio 0.3.3",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,13 +1788,13 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-util",
- "h2",
+ "h2 0.3.0",
  "http",
  "log",
  "rustls",
  "thiserror",
  "tokio 0.3.3",
- "tokio-rustls 0.14.1",
+ "tokio-rustls 0.20.0",
  "trust-dns-proto",
  "trust-dns-rustls",
  "webpki",
@@ -1904,7 +1937,7 @@ dependencies = [
  "env_logger",
  "futures-executor",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
  "log",
  "openssl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,26 +616,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 0.2.22",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
 version = "0.3.0"
 source = "git+https://github.com/hyperium/h2.git#cbbdd305b1afc1eaf19f2e3b26f9419048041e7d"
 dependencies = [
@@ -647,8 +627,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.3.3",
- "tokio-util 0.4.0",
+ "tokio",
+ "tokio-util",
  "tracing",
  "tracing-futures",
 ]
@@ -1565,18 +1545,6 @@ checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "memchr",
- "pin-project-lite",
-]
-
-[[package]]
-name = "tokio"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
@@ -1612,17 +1580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501c8252b73bd01379aaae1521523c2629ff1bc6ea46c29e0baff515cee60f1b"
 dependencies = [
  "native-tls",
- "tokio 0.3.3",
-]
-
-[[package]]
-name = "tokio-openssl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
-dependencies = [
- "openssl",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -1633,19 +1591,7 @@ checksum = "d01e5cc2d3a154fa310982d0affaec8140d6476805422265b2f648eb813f937f"
 dependencies = [
  "openssl",
  "openssl-sys",
- "tokio 0.3.3",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
-dependencies = [
- "futures-core",
- "rustls",
- "tokio 0.2.22",
- "webpki",
+ "tokio",
 ]
 
 [[package]]
@@ -1655,22 +1601,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba3f045b4a15afc543ffe6e02bae7ecf372e89a0f9f8c4b15b13f0ceed4f105"
 dependencies = [
  "rustls",
- "tokio 0.3.3",
+ "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1684,7 +1616,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.3.3",
+ "tokio",
 ]
 
 [[package]]
@@ -1739,7 +1671,7 @@ dependencies = [
  "native-tls",
  "regex",
  "rustls",
- "tokio 0.3.3",
+ "tokio",
  "trust-dns-client",
  "trust-dns-https",
  "trust-dns-native-tls",
@@ -1770,7 +1702,7 @@ dependencies = [
  "rustls",
  "serde",
  "thiserror",
- "tokio 0.3.3",
+ "tokio",
  "trust-dns-https",
  "trust-dns-proto",
  "webpki",
@@ -1799,13 +1731,13 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-util",
- "h2 0.3.0",
+ "h2",
  "http",
  "log",
  "rustls",
  "thiserror",
- "tokio 0.3.3",
- "tokio-rustls 0.20.0",
+ "tokio",
+ "tokio-rustls",
  "trust-dns-proto",
  "trust-dns-rustls",
  "webpki",
@@ -1825,7 +1757,7 @@ dependencies = [
  "rand",
  "rusqlite",
  "rustls",
- "tokio 0.3.3",
+ "tokio",
  "trust-dns-client",
  "trust-dns-https",
  "trust-dns-openssl",
@@ -1843,7 +1775,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "native-tls",
- "tokio 0.3.3",
+ "tokio",
  "tokio-native-tls",
  "trust-dns-proto",
 ]
@@ -1855,8 +1787,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "openssl",
- "tokio 0.3.3",
- "tokio-openssl 0.5.0",
+ "tokio",
+ "tokio-openssl",
  "trust-dns-proto",
 ]
 
@@ -1886,7 +1818,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "thiserror",
- "tokio 0.3.3",
+ "tokio",
  "url",
  "wasm-bindgen",
 ]
@@ -1909,10 +1841,10 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "tokio 0.3.3",
+ "tokio",
  "tokio-native-tls",
- "tokio-openssl 0.5.0",
- "tokio-rustls 0.20.0",
+ "tokio-openssl",
+ "tokio-rustls",
  "trust-dns-https",
  "trust-dns-native-tls",
  "trust-dns-openssl",
@@ -1931,8 +1863,8 @@ dependencies = [
  "log",
  "openssl",
  "rustls",
- "tokio 0.3.3",
- "tokio-rustls 0.20.0",
+ "tokio",
+ "tokio-rustls",
  "trust-dns-proto",
  "webpki",
 ]
@@ -1948,7 +1880,7 @@ dependencies = [
  "env_logger",
  "futures-executor",
  "futures-util",
- "h2 0.2.7",
+ "h2",
  "http",
  "log",
  "openssl",
@@ -1956,9 +1888,9 @@ dependencies = [
  "rustls",
  "serde",
  "thiserror",
- "tokio 0.3.3",
- "tokio-openssl 0.4.0",
- "tokio-rustls 0.14.1",
+ "tokio",
+ "tokio-openssl",
+ "tokio-rustls",
  "toml",
  "trust-dns-client",
  "trust-dns-https",
@@ -1979,7 +1911,7 @@ dependencies = [
  "log",
  "openssl",
  "structopt",
- "tokio 0.3.3",
+ "tokio",
  "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-resolver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.10"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
+checksum = "40a0b2bb8ae20fede194e779150fe283f65a4a08461b496de546ec366b174ad9"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
 dependencies = [
  "async-attributes",
  "async-global-executor",
@@ -260,9 +260,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
 
 [[package]]
 name = "cfg-if"
@@ -339,10 +339,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.7.0"
+name = "const_fn"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -350,18 +356,19 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
+ "const_fn",
  "lazy_static",
 ]
 
@@ -457,10 +464,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "futures"
-version = "0.3.7"
+name = "form_urlencoded"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -473,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -483,15 +500,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -501,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-lite"
@@ -522,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -534,24 +551,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -862,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1091,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-error"
@@ -1327,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.4.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1340,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1483,18 +1500,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1598,6 +1615,17 @@ dependencies = [
  "futures-core",
  "rustls",
  "tokio 0.2.22",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3f045b4a15afc543ffe6e02bae7ecf372e89a0f9f8c4b15b13f0ceed4f105"
+dependencies = [
+ "rustls",
+ "tokio 0.3.3",
  "webpki",
 ]
 
@@ -1733,7 +1761,7 @@ dependencies = [
  "rustls",
  "thiserror",
  "tokio 0.3.3",
- "tokio-rustls",
+ "tokio-rustls 0.14.1",
  "trust-dns-proto",
  "trust-dns-rustls",
  "webpki",
@@ -1840,7 +1868,7 @@ dependencies = [
  "tokio 0.3.3",
  "tokio-native-tls",
  "tokio-openssl",
- "tokio-rustls",
+ "tokio-rustls 0.14.1",
  "trust-dns-https",
  "trust-dns-native-tls",
  "trust-dns-openssl",
@@ -1860,7 +1888,7 @@ dependencies = [
  "openssl",
  "rustls",
  "tokio 0.3.3",
- "tokio-rustls",
+ "tokio-rustls 0.20.0",
  "trust-dns-proto",
  "webpki",
 ]
@@ -1886,7 +1914,7 @@ dependencies = [
  "thiserror",
  "tokio 0.3.3",
  "tokio-openssl",
- "tokio-rustls",
+ "tokio-rustls 0.14.1",
  "toml",
  "trust-dns-client",
  "trust-dns-https",
@@ -1957,10 +1985,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ members = ["crates/proto",
            "util",
            "tests/compatibility-tests",
            "tests/integration-tests"]
+
+# [patch.crates-io]
+# tokio = { path = "../tokio/tokio" }
+# mio = { git = "https://github.com/tokio-rs/mio.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = ["crates/proto",
            "tests/compatibility-tests",
            "tests/integration-tests"]
 
-# [patch.crates-io]
+[patch.crates-io]
 # tokio = { path = "../tokio/tokio" }
 # mio = { git = "https://github.com/tokio-rs/mio.git" }
+h2 = { git = "https://github.com/hyperium/h2.git" }

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ presume that the trust-dns repos have already been synced to the local system:
 
 ### Minimum Rust Version
 
-- The current minimum rustc version for this project is `1.42`
+- The current minimum rustc version for this project is `1.45`
 - OpenSSL development libraries (optional in client and resolver, min version 1.0.2)
 
 ### Mac OS X: using homebrew

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -76,7 +76,7 @@ clap = "2.33"
 futures = { version = "0.3.5", default-features = false, features = ["std"] }
 log = "0.4"
 rustls = { version = "0.18", optional = true }
-tokio = { version = "0.2.22", features = ["rt-core", "rt-threaded", "time"] }
+tokio = { version = "0.3.0", features = ["time"] }
 trust-dns-client = { version = "0.20.0-alpha.3", path = "../crates/client" }
 trust-dns-openssl = { version = "0.20.0-alpha.3", path = "../crates/openssl", optional = true }
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../crates/proto" }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -75,7 +75,7 @@ chrono = "0.4"
 clap = "2.33"
 futures = { version = "0.3.5", default-features = false, features = ["std"] }
 log = "0.4"
-rustls = { version = "0.18", optional = true }
+rustls = { version = "0.19", optional = true }
 tokio = { version = "0.3.0", features = ["time"] }
 trust-dns-client = { version = "0.20.0-alpha.3", path = "../crates/client" }
 trust-dns-openssl = { version = "0.20.0-alpha.3", path = "../crates/openssl", optional = true }
@@ -91,4 +91,4 @@ trust-dns-proto = { version = "0.20.0-alpha.3", path = "../crates/proto", featur
 trust-dns-native-tls = { version = "0.20.0-alpha.3", path = "../crates/native-tls" }
 trust-dns-https = { version = "0.20.0-alpha.3", path = "../crates/https" }
 trust-dns-resolver = { version = "0.20.0-alpha.3", path = "../crates/resolver" }
-webpki-roots = { version = "0.20" }
+webpki-roots = "0.21"

--- a/bin/README.md
+++ b/bin/README.md
@@ -44,7 +44,7 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -26,7 +26,7 @@ use trust_dns_client::rr::*;
 use trust_dns_client::tcp::*;
 use trust_dns_client::udp::*;
 use trust_dns_proto::error::*;
-use trust_dns_proto::iocompat::AsyncIo02As03;
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 use trust_dns_proto::xfer::*;
 
 fn find_test_port() -> u16 {
@@ -50,7 +50,7 @@ fn wrap_process(named: Child, server_port: u16) -> NamedProcess {
     let mut started = false;
 
     for _ in 0..20 {
-        let mut io_loop = Runtime::new().unwrap();
+        let io_loop = Runtime::new().unwrap();
         let addr: SocketAddr = ("127.0.0.1", server_port)
             .to_socket_addrs()
             .unwrap()
@@ -118,7 +118,7 @@ where
     F: Future<Output = Result<S, ProtoError>> + 'static + Send + Unpin,
     S: DnsRequestSender,
 {
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let client = AsyncClient::connect(stream);
     let (mut client, bg) = io_loop.block_on(client).expect("failed to create client");
     io_loop.spawn(bg);
@@ -183,7 +183,7 @@ fn trust_dns_tcp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TcpStream>>::new(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TcpStream>>::new(addr);
     let mp = DnsMultiplexer::new(stream, sender, None::<Arc<Signer>>);
     bench(b, mp);
 
@@ -258,7 +258,7 @@ fn bind_tcp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TcpStream>>::new(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TcpStream>>::new(addr);
     let mp = DnsMultiplexer::new(stream, sender, None::<Arc<Signer>>);
     bench(b, mp);
 

--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -107,10 +107,7 @@ fn load_zone(
         }
         #[cfg(feature = "resolver")]
         Some(StoreConfig::Forward(ref config)) => {
-            use trust_dns_server::resolver::TokioHandle;
-
-            let forwarder =
-                ForwardAuthority::try_from_config(zone_name, zone_type, config, TokioHandle);
+            let forwarder = ForwardAuthority::try_from_config(zone_name, zone_type, config);
             let forwarder = runtime.block_on(forwarder)?;
 
             Box::new(forwarder)

--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -46,7 +46,6 @@ use trust_dns_server::authority::{AuthorityObject, Catalog, ZoneType};
 use trust_dns_server::config::dnssec::{self, TlsCertConfig};
 use trust_dns_server::config::{Config, ZoneConfig};
 use trust_dns_server::logger;
-use trust_dns_server::resolver::TokioHandle;
 use trust_dns_server::server::ServerFuture;
 use trust_dns_server::store::file::{FileAuthority, FileConfig};
 #[cfg(feature = "resolver")]
@@ -108,6 +107,8 @@ fn load_zone(
         }
         #[cfg(feature = "resolver")]
         Some(StoreConfig::Forward(ref config)) => {
+            use trust_dns_server::resolver::TokioHandle;
+
             let forwarder =
                 ForwardAuthority::try_from_config(zone_name, zone_type, config, TokioHandle);
             let forwarder = runtime.block_on(forwarder)?;

--- a/bin/tests/named_https_tests.rs
+++ b/bin/tests/named_https_tests.rs
@@ -24,7 +24,7 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 use trust_dns_client::client::*;
 use trust_dns_https::HttpsClientStreamBuilder;
-use trust_dns_proto::iocompat::AsyncIo02As03;
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 
 use server_harness::{named_test_harness, query_a};
 
@@ -73,7 +73,7 @@ fn test_example_https_toml_startup() {
         let https_builder = HttpsClientStreamBuilder::with_client_config(client_config);
 
         let mp = https_builder
-            .build::<AsyncIo02As03<TokioTcpStream>>(addr, "ns.example.com".to_string());
+            .build::<AsyncIoTokioAsStd<TokioTcpStream>>(addr, "ns.example.com".to_string());
         let client = AsyncClient::connect(mp);
 
         // ipv4 should succeed

--- a/bin/tests/named_test_rsa_dnssec.rs
+++ b/bin/tests/named_test_rsa_dnssec.rs
@@ -20,7 +20,7 @@ use trust_dns_client::proto::tcp::TcpClientStream;
 use trust_dns_client::proto::xfer::{DnsExchangeBackground, DnsMultiplexer};
 use trust_dns_client::proto::DnssecDnsHandle;
 use trust_dns_client::rr::dnssec::*;
-use trust_dns_proto::{iocompat::AsyncIo02As03, TokioTime};
+use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, TokioTime};
 
 use server_harness::*;
 
@@ -61,7 +61,7 @@ async fn standard_tcp_conn(
 ) -> (
     AsyncClient,
     DnsExchangeBackground<
-        DnsMultiplexer<TcpClientStream<AsyncIo02As03<TokioTcpStream>>, Signer>,
+        DnsMultiplexer<TcpClientStream<AsyncIoTokioAsStd<TokioTcpStream>>, Signer>,
         TokioTime,
     >,
 ) {
@@ -70,7 +70,7 @@ async fn standard_tcp_conn(
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+    let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
     AsyncClient::new(stream, sender, None)
         .await
         .expect("new AsyncClient failed")

--- a/bin/tests/named_tests.rs
+++ b/bin/tests/named_tests.rs
@@ -29,7 +29,7 @@ use trust_dns_client::udp::UdpClientStream;
 // use trust_dns_openssl::TlsClientStreamBuilder;
 
 use server_harness::{named_test_harness, query_a};
-use trust_dns_proto::iocompat::AsyncIo02As03;
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 
 #[test]
 fn test_example_toml_startup() {
@@ -39,7 +39,7 @@ fn test_example_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -52,7 +52,7 @@ fn test_example_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -70,7 +70,7 @@ fn test_ipv4_only_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -83,7 +83,7 @@ fn test_ipv4_only_toml_startup() {
             Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         assert!(io_loop.block_on(client).is_err());
@@ -133,7 +133,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -145,7 +145,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
             Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -158,12 +158,12 @@ fn test_ipv4_and_ipv6_toml_startup() {
 #[test]
 fn test_nodata_where_name_exists() {
     named_test_harness("example.toml", |_, tcp_port, _, _| {
-        let mut io_loop = Runtime::new().unwrap();
+        let io_loop = Runtime::new().unwrap();
         let addr: SocketAddr = SocketAddr::new(
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -183,12 +183,12 @@ fn test_nodata_where_name_exists() {
 #[test]
 fn test_nxdomain_where_no_name_exists() {
     named_test_harness("example.toml", |_, tcp_port, _, _| {
-        let mut io_loop = Runtime::new().unwrap();
+        let io_loop = Runtime::new().unwrap();
         let addr: SocketAddr = SocketAddr::new(
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -251,7 +251,7 @@ fn test_server_continues_on_bad_data_tcp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -271,7 +271,7 @@ fn test_server_continues_on_bad_data_tcp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -293,7 +293,7 @@ fn test_forward() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -315,7 +315,7 @@ fn test_forward() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::<AsyncIo02As03<TokioTcpStream>>::new(addr);
+        let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");

--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -91,7 +91,9 @@ where
             }
 
             kill_named();
-            panic!("timeout");
+
+            println!("Thread Killer has been awoken, killing process");
+            std::process::exit(-1);
         })
         .expect("could not start thread killer");
 

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -67,6 +67,7 @@ path = "src/lib.rs"
 async-std = "1.6"
 async-trait = "0.1.36"
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 trust-dns-resolver = { version = "0.20.0-alpha.3", path = "../resolver", default-features = false }
 
 [dev-dependencies]

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -68,6 +68,7 @@ async-std = "1.6"
 async-trait = "0.1.36"
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
+pin-utils = "0.1.0"
 trust-dns-resolver = { version = "0.20.0-alpha.3", path = "../resolver", default-features = false }
 
 [dev-dependencies]

--- a/crates/async-std-resolver/README.md
+++ b/crates/async-std-resolver/README.md
@@ -51,7 +51,7 @@ async fn main() {
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -25,7 +25,7 @@ pub struct AsyncStdUdpSocket(async_std::net::UdpSocket);
 impl UdpSocket for AsyncStdUdpSocket {
     type Time = AsyncStdTime;
 
-    async fn bind(addr: &SocketAddr) -> io::Result<Self> {
+    async fn bind(addr: SocketAddr) -> io::Result<Self> {
         async_std::net::UdpSocket::bind(addr)
             .await
             .map(AsyncStdUdpSocket)
@@ -50,7 +50,7 @@ impl UdpSocket for AsyncStdUdpSocket {
         &self,
         cx: &mut Context,
         buf: &[u8],
-        target: &SocketAddr,
+        target: SocketAddr,
     ) -> Poll<io::Result<usize>> {
         let fut = self.0.send_to(buf, target);
         pin_mut!(fut);
@@ -58,7 +58,7 @@ impl UdpSocket for AsyncStdUdpSocket {
         fut.poll_unpin(cx)
     }
 
-    async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+    async fn send_to(&self, buf: &[u8], target: SocketAddr) -> io::Result<usize> {
         self.0.send_to(buf, target).await
     }
 }

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -28,11 +28,11 @@ impl UdpSocket for AsyncStdUdpSocket {
             .map(AsyncStdUdpSocket)
     }
 
-    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.0.recv_from(buf).await
     }
 
-    async fn send_to(&mut self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+    async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
         self.0.send_to(buf, target).await
     }
 }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -80,7 +80,7 @@ ring = { version = "0.16", optional = true, features = ["std"]}
 rustls = { version = "0.18", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0.20"
-tokio = { version = "0.2.22", features = ["rt-core"] }
+tokio = { version = "0.3.0", features = ["rt"] }
 trust-dns-https = { version = "0.20.0-alpha.3", path = "../https", optional = true }
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["dnssec"]}
 webpki = { version = "0.21", optional = true }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -77,7 +77,7 @@ openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 radix_trie = "0.2.0"
 rand = "0.7"
 ring = { version = "0.16", optional = true, features = ["std"]}
-rustls = { version = "0.18", optional = true }
+rustls = { version = "0.19", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0.20"
 tokio = { version = "0.3.0", features = ["rt"] }

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -74,7 +74,7 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -74,11 +74,10 @@ pub trait Client {
 
     /// This will create a new AsyncClient and spawn it into a new Runtime
     fn spawn_client(&self) -> ClientResult<(Self::Handle, Runtime)> {
-        let mut builder = runtime::Builder::new();
-        builder.basic_scheduler();
+        let mut builder = runtime::Builder::new_current_thread();
         builder.enable_all();
 
-        let mut reactor = builder.build()?;
+        let reactor = builder.build()?;
         let client = self.new_future();
 
         let (client, bg) = reactor.block_on(client)?;
@@ -105,7 +104,7 @@ pub trait Client {
         query_class: DNSClass,
         query_type: RecordType,
     ) -> ClientResult<DnsResponse> {
-        let (mut client, mut runtime) = self.spawn_client()?;
+        let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.query(name.clone(), query_class, query_type))
     }
@@ -128,7 +127,7 @@ pub trait Client {
     where
         R: Into<RecordSet>,
     {
-        let (mut client, mut runtime) = self.spawn_client()?;
+        let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.notify(name, query_class, query_type, rrset))
     }
@@ -170,7 +169,7 @@ pub trait Client {
     where
         R: Into<RecordSet>,
     {
-        let (mut client, mut runtime) = self.spawn_client()?;
+        let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.create(rrset, zone_origin))
     }
@@ -213,7 +212,7 @@ pub trait Client {
     where
         R: Into<RecordSet>,
     {
-        let (mut client, mut runtime) = self.spawn_client()?;
+        let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.append(rrset, zone_origin, must_exist))
     }
@@ -269,7 +268,7 @@ pub trait Client {
         CR: Into<RecordSet>,
         NR: Into<RecordSet>,
     {
-        let (mut client, mut runtime) = self.spawn_client()?;
+        let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.compare_and_swap(current, new, zone_origin))
     }
@@ -313,7 +312,7 @@ pub trait Client {
     where
         R: Into<RecordSet>,
     {
-        let (mut client, mut runtime) = self.spawn_client()?;
+        let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.delete_by_rdata(record, zone_origin))
     }
@@ -354,7 +353,7 @@ pub trait Client {
     /// The update must go to a zone authority (i.e. the server used in the ClientConnection). If
     /// the rrset does not exist and must_exist is false, then the RRSet will be deleted.
     fn delete_rrset(&self, record: Record, zone_origin: Name) -> ClientResult<DnsResponse> {
-        let (mut client, mut runtime) = self.spawn_client()?;
+        let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.delete_rrset(record, zone_origin))
     }
@@ -389,7 +388,7 @@ pub trait Client {
         zone_origin: Name,
         dns_class: DNSClass,
     ) -> ClientResult<DnsResponse> {
-        let (mut client, mut runtime) = self.spawn_client()?;
+        let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.delete_all(name_of_records, zone_origin, dns_class))
     }

--- a/crates/client/src/tcp/tcp_client_connection.rs
+++ b/crates/client/src/tcp/tcp_client_connection.rs
@@ -15,7 +15,7 @@ use tokio::net::TcpStream;
 
 use crate::client::ClientConnection;
 use crate::error::*;
-use crate::proto::iocompat::AsyncIo02As03;
+use crate::proto::iocompat::AsyncIoTokioAsStd;
 use crate::proto::tcp::{TcpClientConnect, TcpClientStream};
 use crate::proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect};
 use crate::rr::dnssec::Signer;
@@ -61,18 +61,19 @@ impl TcpClientConnection {
 }
 
 impl ClientConnection for TcpClientConnection {
-    type Sender = DnsMultiplexer<TcpClientStream<AsyncIo02As03<TcpStream>>, Signer>;
+    type Sender = DnsMultiplexer<TcpClientStream<AsyncIoTokioAsStd<TcpStream>>, Signer>;
     type SenderFuture = DnsMultiplexerConnect<
-        TcpClientConnect<AsyncIo02As03<TcpStream>>,
-        TcpClientStream<AsyncIo02As03<TcpStream>>,
+        TcpClientConnect<AsyncIoTokioAsStd<TcpStream>>,
+        TcpClientStream<AsyncIoTokioAsStd<TcpStream>>,
         Signer,
     >;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
-        let (tcp_client_stream, handle) = TcpClientStream::<AsyncIo02As03<TcpStream>>::with_timeout(
-            self.name_server,
-            self.timeout,
-        );
+        let (tcp_client_stream, handle) =
+            TcpClientStream::<AsyncIoTokioAsStd<TcpStream>>::with_timeout(
+                self.name_server,
+                self.timeout,
+            );
         DnsMultiplexer::new(tcp_client_stream, handle, signer)
     }
 }

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -48,20 +48,20 @@ path = "src/lib.rs"
 
 [dependencies]
 cfg-if = "1"
-bytes = "0.5"
+bytes = "0.6"
 data-encoding = "2.2.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 h2 = { version = "0.3.0", features = ["stream"] }
 http = "0.2"
 log = "0.4"
-rustls = "0.18"
+rustls = "0.19"
 thiserror = "1.0.20"
 tokio = { version = "0.3", features = ["io-util", "net", "rt"] }
-tokio-rustls = "0.20.0"
+tokio-rustls = "0.21.0"
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["tokio-runtime"], default-features = false }
 trust-dns-rustls = { version = "0.20.0-alpha.3", path = "../rustls", default-features = false }
-webpki-roots = { version = "0.20" }
+webpki-roots = "0.21"
 webpki = "0.21"
 
 [dev-dependencies]

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -56,7 +56,7 @@ http = "0.2"
 log = "0.4"
 rustls = "0.18"
 thiserror = "1.0.20"
-tokio = { version = "0.2.22", features = ["tcp", "io-util", "rt-core"] }
+tokio = { version = "0.3.0", features = ["io-util", "net", "rt"] }
 tokio-rustls = "0.14"
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["tokio-runtime"], default-features = false }

--- a/crates/https/Cargo.toml
+++ b/crates/https/Cargo.toml
@@ -51,13 +51,13 @@ cfg-if = "1"
 bytes = "0.5"
 data-encoding = "2.2.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
-h2 = { version = "0.2.6", features = ["stream"] }
+h2 = { version = "0.3.0", features = ["stream"] }
 http = "0.2"
 log = "0.4"
 rustls = "0.18"
 thiserror = "1.0.20"
-tokio = { version = "0.3.0", features = ["io-util", "net", "rt"] }
-tokio-rustls = "0.14"
+tokio = { version = "0.3", features = ["io-util", "net", "rt"] }
+tokio-rustls = "0.20.0"
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["tokio-runtime"], default-features = false }
 trust-dns-rustls = { version = "0.20.0-alpha.3", path = "../rustls", default-features = false }

--- a/crates/https/README.md
+++ b/crates/https/README.md
@@ -6,7 +6,7 @@ This library allows for HTTPS connections to be established to remote DNS server
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/https/src/https_client_stream.rs
+++ b/crates/https/src/https_client_stream.rs
@@ -541,7 +541,7 @@ mod tests {
 
     #[test]
     fn test_https_google() {
-        // self::env_logger::try_init().ok();
+        //env_logger::try_init().ok();
 
         let google = SocketAddr::from(([8, 8, 8, 8], 443));
         let mut request = Message::new();

--- a/crates/native-tls/Cargo.toml
+++ b/crates/native-tls/Cargo.toml
@@ -50,7 +50,7 @@ path = "src/lib.rs"
 futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 native-tls = "0.2"
-tokio = "0.2.22"
+tokio = "0.3.0"
 tokio-native-tls = "0.1"
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["tokio-runtime"], default-features = false }

--- a/crates/native-tls/Cargo.toml
+++ b/crates/native-tls/Cargo.toml
@@ -51,7 +51,7 @@ futures-channel = { version = "0.3.5", default-features = false, features = ["st
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 native-tls = "0.2"
 tokio = "0.3.0"
-tokio-native-tls = "0.1"
+tokio-native-tls = "0.2.0"
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["tokio-runtime"], default-features = false }
 

--- a/crates/native-tls/README.md
+++ b/crates/native-tls/README.md
@@ -6,7 +6,7 @@ This library allows for TLS connections to be established to remote DNS servers.
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/native-tls/src/tests.rs
+++ b/crates/native-tls/src/tests.rs
@@ -87,7 +87,8 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
                 }
             }
 
-            panic!("timeout");
+            println!("Thread Killer has been awoken, killing process");
+            std::process::exit(-1);
         })
         .unwrap();
 

--- a/crates/native-tls/src/tls_client_stream.rs
+++ b/crates/native-tls/src/tls_client_stream.rs
@@ -19,7 +19,7 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_native_tls::TlsStream as TokioTlsStream;
 
 use trust_dns_proto::error::ProtoError;
-use trust_dns_proto::iocompat::AsyncIo02As03;
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 use trust_dns_proto::tcp::TcpClientStream;
 use trust_dns_proto::xfer::BufDnsStreamHandle;
 
@@ -28,7 +28,7 @@ use crate::TlsStreamBuilder;
 /// TlsClientStream secure DNS over TCP stream
 ///
 /// See TlsClientStreamBuilder::new()
-pub type TlsClientStream = TcpClientStream<AsyncIo02As03<TokioTlsStream<TokioTcpStream>>>;
+pub type TlsClientStream = TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<TokioTcpStream>>>;
 
 /// Builder for TlsClientStream
 pub struct TlsClientStreamBuilder(TlsStreamBuilder);

--- a/crates/openssl/Cargo.toml
+++ b/crates/openssl/Cargo.toml
@@ -51,9 +51,9 @@ futures-channel = { version = "0.3.5", default-features = false, features = ["st
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 openssl = { version = "0.10", features = ["v102", "v110"] }
 tokio-openssl = "0.4.0"
-tokio = "0.2.22"
+tokio = "0.3.0"
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["openssl"] }
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["v102", "v110"] }
-tokio = "0.2.22"
+tokio = "0.3.0"

--- a/crates/openssl/Cargo.toml
+++ b/crates/openssl/Cargo.toml
@@ -50,7 +50,7 @@ path = "src/lib.rs"
 futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 openssl = { version = "0.10", features = ["v102", "v110"] }
-tokio-openssl = "0.4.0"
+tokio-openssl = "0.5.0"
 tokio = "0.3.0"
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["openssl"] }
 

--- a/crates/openssl/README.md
+++ b/crates/openssl/README.md
@@ -6,7 +6,7 @@ This library allows for TLS connections to be established to remote DNS servers.
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/openssl/src/tls_client_stream.rs
+++ b/crates/openssl/src/tls_client_stream.rs
@@ -18,14 +18,14 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_openssl::SslStream as TokioTlsStream;
 
 use trust_dns_proto::error::ProtoError;
-use trust_dns_proto::iocompat::AsyncIo02As03;
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 use trust_dns_proto::tcp::TcpClientStream;
 use trust_dns_proto::xfer::BufDnsStreamHandle;
 
 use super::TlsStreamBuilder;
 
 /// A Type definition for the TLS stream
-pub type TlsClientStream = TcpClientStream<AsyncIo02As03<TokioTlsStream<TokioTcpStream>>>;
+pub type TlsClientStream = TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<TokioTcpStream>>>;
 
 /// A Builder for the TlsClientStream
 pub struct TlsClientStreamBuilder(TlsStreamBuilder);

--- a/crates/openssl/tests/openssl_tests.rs
+++ b/crates/openssl/tests/openssl_tests.rs
@@ -74,7 +74,8 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
                 }
             }
 
-            panic!("timeout");
+            println!("Thread Killer has been awoken, killing process");
+            std::process::exit(-1);
         })
         .unwrap();
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -40,7 +40,7 @@ dnssec-openssl = ["dnssec", "openssl"]
 dnssec-ring = ["dnssec", "ring"]
 dnssec = []
 testing = []
-tokio-runtime = ["tokio/rt-core", "tokio/udp", "tokio/tcp", "tokio/time"]
+tokio-runtime = ["tokio/net", "tokio/rt", "tokio/time", "tokio/rt-multi-thread"]
 default = ["tokio-runtime"]
 
 serde-config = ["serde"]
@@ -78,11 +78,11 @@ serde = { version = "1.0", optional = true }
 smallvec = "1.2"
 socket2 = { version = "0.3.12", optional = true }
 thiserror = "1.0.20"
-tokio = { version = "0.2.22", optional = true }
+tokio = { version = "0.3.0", optional = true }
 url = "2.1.0"
 wasm-bindgen-crate = { version = "0.2.58", optional = true, package = "wasm-bindgen" }
 
 [dev-dependencies]
 env_logger = "0.8"
 futures-executor = { version = "0.3.5", default-features = false, features = ["std"] }
-tokio = { version = "0.2.22", features = ["rt-core", "time"] }
+tokio = { version = "0.3.0", features = ["rt", "time"] }

--- a/crates/proto/README.md
+++ b/crates/proto/README.md
@@ -6,7 +6,7 @@ Trust-DNS Proto is the foundational DNS protocol library and implementation for 
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -86,7 +86,7 @@ pub mod iocompat {
     /// Conversion from `tokio::io::{AsyncRead, AsyncWrite}` to `std::io::{AsyncRead, AsyncWrite}`
     pub struct AsyncIoTokioAsStd<T: TokioAsyncRead + TokioAsyncWrite>(pub T);
 
-    impl<T: TokioAsyncRead + TokioAsyncWrite> Unpin for AsyncIoTokioAsStd<T> {}
+    impl<T: TokioAsyncRead + TokioAsyncWrite + Unpin> Unpin for AsyncIoTokioAsStd<T> {}
     impl<R: TokioAsyncRead + TokioAsyncWrite + Unpin> AsyncRead for AsyncIoTokioAsStd<R> {
         fn poll_read(
             mut self: Pin<&mut Self>,
@@ -119,6 +119,7 @@ pub mod iocompat {
     /// Conversion from `std::io::{AsyncRead, AsyncWrite}` to `tokio::io::{AsyncRead, AsyncWrite}`
     pub struct AsyncIoStdAsTokio<T: AsyncRead + AsyncWrite>(pub T);
 
+    impl<T: AsyncRead + AsyncWrite + Unpin> Unpin for AsyncIoStdAsTokio<T> {}
     impl<R: AsyncRead + AsyncWrite + Unpin> TokioAsyncRead for AsyncIoStdAsTokio<R> {
         fn poll_read(
             self: Pin<&mut Self>,

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -125,10 +125,9 @@ pub mod iocompat {
             cx: &mut Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<io::Result<()>> {
-            let buf = buf.initialized_mut();
             Pin::new(&mut self.get_mut().0)
-                .poll_read(cx, buf)
-                .map_ok(|_| ())
+                .poll_read(cx, buf.initialized_mut())
+                .map_ok(|len| buf.advance(len))
         }
     }
 

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -12,7 +12,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures_util::lock::Mutex;
 use futures_util::stream::{Stream, StreamExt};
 use futures_util::{future, future::Future, ready, FutureExt, TryFutureExt};
 use lazy_static::lazy_static;
@@ -44,7 +43,7 @@ pub struct MdnsStream {
     datagram: Option<UdpStream<UdpSocket>>,
     // FIXME: like UdpStream, this Arc is unnecessary, only needed for temp async/await capture below
     /// In one-shot multicast, this will not join the multicast group
-    multicast: Option<Arc<Mutex<UdpSocket>>>,
+    multicast: Option<Arc<UdpSocket>>,
     /// Receiving portion of the MdnsStream
     rcving_mcast: Option<Pin<Box<dyn Future<Output = io::Result<SerialMessage>> + Send>>>,
 }
@@ -146,9 +145,7 @@ impl MdnsStream {
                         let datagram: Option<_> =
                             socket.map(|socket| UdpStream::from_parts(socket, outbound_messages));
                         let multicast: Option<_> = multicast_socket.map(|multicast_socket| {
-                            Arc::new(Mutex::new(
-                                UdpSocket::from_std(multicast_socket).expect("bad handle?"),
-                            ))
+                            Arc::new(UdpSocket::from_std(multicast_socket).expect("bad handle?"))
                         });
 
                         MdnsStream {
@@ -297,7 +294,6 @@ impl Stream for MdnsStream {
                 let receive_future = async {
                     let socket = socket;
                     let mut buf = [0u8; 2048];
-                    let mut socket = socket.lock().await;
                     let (len, src) = socket.recv_from(&mut buf).await?;
 
                     Ok(SerialMessage::new(
@@ -439,7 +435,7 @@ pub mod tests {
         // use env_logger;
         // env_logger::init();
 
-        let mut io_loop = runtime::Runtime::new().unwrap();
+        let io_loop = runtime::Runtime::new().unwrap();
         let (stream, _) = MdnsStream::new(
             SocketAddr::new(*TEST_MDNS_IPV4, BASE_TEST_PORT),
             MdnsQueryType::OneShot,
@@ -482,11 +478,10 @@ pub mod tests {
         let server_handle = std::thread::Builder::new()
             .name("test_one_shot_mdns:server".to_string())
             .spawn(move || {
-                let mut server_loop = runtime::Runtime::new().unwrap();
-                let mut timeout =
-                    future::lazy(|_| tokio::time::delay_for(Duration::from_millis(100)))
-                        .flatten()
-                        .boxed();
+                let server_loop = runtime::Runtime::new().unwrap();
+                let mut timeout = future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
+                    .flatten()
+                    .boxed();
 
                 // TTLs are 0 so that multicast test packets never leave the test host...
                 // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
@@ -535,28 +530,27 @@ pub mod tests {
                         }
                         Either::Right(((), buffer_and_addr_stream_tmp)) => {
                             server_stream = buffer_and_addr_stream_tmp;
-                            timeout = future::lazy(|_| {
-                                tokio::time::delay_for(Duration::from_millis(100))
-                            })
-                            .flatten()
-                            .boxed();
+                            timeout =
+                                future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
+                                    .flatten()
+                                    .boxed();
                         }
                     }
 
                     // let the server turn for a bit... send the message
-                    server_loop.block_on(tokio::time::delay_for(Duration::from_millis(100)));
+                    server_loop.block_on(tokio::time::sleep(Duration::from_millis(100)));
                 }
             })
             .unwrap();
 
         // setup the client, which is going to run on the testing thread...
-        let mut io_loop = runtime::Runtime::new().unwrap();
+        let io_loop = runtime::Runtime::new().unwrap();
 
         // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
         let (stream, mut sender) =
             MdnsStream::new(mdns_addr, MdnsQueryType::OneShot, Some(1), None, Some(5));
         let mut stream = io_loop.block_on(stream).ok().unwrap().into_future();
-        let mut timeout = future::lazy(|_| tokio::time::delay_for(Duration::from_millis(100)))
+        let mut timeout = future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
             .flatten()
             .boxed();
         let mut successes = 0;
@@ -587,7 +581,7 @@ pub mod tests {
                 }
                 Either::Right(((), buffer_and_addr_stream_tmp)) => {
                     stream = buffer_and_addr_stream_tmp;
-                    timeout = future::lazy(|_| tokio::time::delay_for(Duration::from_millis(100)))
+                    timeout = future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
                         .flatten()
                         .boxed();
                 }
@@ -634,11 +628,10 @@ pub mod tests {
         let _server_handle = std::thread::Builder::new()
             .name("test_one_shot_mdns:server".to_string())
             .spawn(move || {
-                let mut io_loop = runtime::Runtime::new().unwrap();
-                let mut timeout =
-                    future::lazy(|_| tokio::time::delay_for(Duration::from_millis(100)))
-                        .flatten()
-                        .boxed();
+                let io_loop = runtime::Runtime::new().unwrap();
+                let mut timeout = future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
+                    .flatten()
+                    .boxed();
 
                 // TTLs are 0 so that multicast test packets never leave the test host...
                 // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
@@ -672,27 +665,26 @@ pub mod tests {
                         }
                         Either::Right(((), buffer_and_addr_stream_tmp)) => {
                             server_stream = buffer_and_addr_stream_tmp;
-                            timeout = future::lazy(|_| {
-                                tokio::time::delay_for(Duration::from_millis(100))
-                            })
-                            .flatten()
-                            .boxed();
+                            timeout =
+                                future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
+                                    .flatten()
+                                    .boxed();
                         }
                     }
 
                     // let the server turn for a bit... send the message
-                    io_loop.block_on(tokio::time::delay_for(Duration::from_millis(100)));
+                    io_loop.block_on(tokio::time::sleep(Duration::from_millis(100)));
                 }
             })
             .unwrap();
 
         // setup the client, which is going to run on the testing thread...
-        let mut io_loop = runtime::Runtime::new().unwrap();
+        let io_loop = runtime::Runtime::new().unwrap();
         // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
         let (stream, mut sender) =
             MdnsStream::new(mdns_addr, MdnsQueryType::OneShot, Some(1), None, Some(5));
         let mut stream = io_loop.block_on(stream).ok().unwrap().into_future();
-        let mut timeout = future::lazy(|_| tokio::time::delay_for(Duration::from_millis(100)))
+        let mut timeout = future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
             .flatten()
             .boxed();
 
@@ -720,7 +712,7 @@ pub mod tests {
                 }
                 Either::Right(((), buffer_and_addr_stream_tmp)) => {
                     stream = buffer_and_addr_stream_tmp;
-                    timeout = future::lazy(|_| tokio::time::delay_for(Duration::from_millis(100)))
+                    timeout = future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
                         .flatten()
                         .boxed();
                 }

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -20,7 +20,7 @@ use log::warn;
 
 use crate::error::ProtoError;
 #[cfg(feature = "tokio-runtime")]
-use crate::iocompat::AsyncIo02As03;
+use crate::iocompat::AsyncIoTokioAsStd;
 use crate::tcp::{Connect, DnsTcpStream, TcpStream};
 use crate::xfer::{DnsClientStream, SerialMessage};
 #[cfg(feature = "tokio-runtime")]
@@ -139,7 +139,7 @@ impl<S: DnsTcpStream> Future for TcpClientConnect<S> {
 use tokio::net::TcpStream as TokioTcpStream;
 
 #[cfg(feature = "tokio-runtime")]
-impl<T> DnsTcpStream for AsyncIo02As03<T>
+impl<T> DnsTcpStream for AsyncIoTokioAsStd<T>
 where
     T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync + Sized + 'static,
 {
@@ -148,16 +148,16 @@ where
 
 #[cfg(feature = "tokio-runtime")]
 #[async_trait]
-impl Connect for AsyncIo02As03<TokioTcpStream> {
+impl Connect for AsyncIoTokioAsStd<TokioTcpStream> {
     async fn connect(addr: SocketAddr) -> io::Result<Self> {
-        super::tokio::connect(&addr).await.map(AsyncIo02As03)
+        super::tokio::connect(&addr).await.map(AsyncIoTokioAsStd)
     }
 }
 
 #[cfg(test)]
 #[cfg(feature = "tokio-runtime")]
 mod tests {
-    use super::AsyncIo02As03;
+    use super::AsyncIoTokioAsStd;
     #[cfg(not(target_os = "linux"))]
     use std::net::Ipv6Addr;
     use std::net::{IpAddr, Ipv4Addr};
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn test_tcp_stream_ipv4() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_client_stream_test::<AsyncIo02As03<TokioTcpStream>, Runtime, TokioTime>(
+        tcp_client_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime, TokioTime>(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             io_loop,
         )
@@ -179,7 +179,7 @@ mod tests {
     #[cfg(not(target_os = "linux"))] // ignored until Travis-CI fixes IPv6
     fn test_tcp_stream_ipv6() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_client_stream_test::<AsyncIo02As03<TokioTcpStream>, Runtime, TokioTime>(
+        tcp_client_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime, TokioTime>(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
             io_loop,
         )

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -436,14 +436,14 @@ mod tests {
     use tokio::net::TcpStream as TokioTcpStream;
     use tokio::runtime::Runtime;
 
-    use crate::iocompat::AsyncIo02As03;
+    use crate::iocompat::AsyncIoTokioAsStd;
     use crate::TokioTime;
 
     use crate::tests::tcp_stream_test;
     #[test]
     fn test_tcp_stream_ipv4() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_stream_test::<AsyncIo02As03<TokioTcpStream>, Runtime, TokioTime>(
+        tcp_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime, TokioTime>(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             io_loop,
         )
@@ -453,7 +453,7 @@ mod tests {
     #[cfg(not(target_os = "linux"))] // ignored until Travis-CI fixes IPv6
     fn test_tcp_stream_ipv6() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_stream_test::<AsyncIo02As03<TokioTcpStream>, Runtime, TokioTime>(
+        tcp_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime, TokioTime>(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
             io_loop,
         )

--- a/crates/proto/src/tests/tcp.rs
+++ b/crates/proto/src/tests/tcp.rs
@@ -30,7 +30,8 @@ fn tcp_server_setup(
                 }
             }
 
-            panic!("timeout");
+            println!("Thread Killer has been awoken, killing process");
+            std::process::exit(-1);
         })
         .unwrap();
 

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -84,7 +84,7 @@ pub async fn udp_stream_test<S: UdpSocket + Send + 'static>(server_addr: IpAddr)
     };
 
     println!("binding client socket");
-    let socket = S::bind(&client_addr.to_socket_addrs().unwrap().next().unwrap())
+    let socket = S::bind(client_addr.to_socket_addrs().unwrap().next().unwrap())
         .await
         .expect("could not create socket"); // some random address...
     println!("bound client socket");

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -58,7 +58,7 @@ pub async fn udp_stream_test<S: UdpSocket + Send + 'static>(server_addr: IpAddr)
         .spawn(move || {
             let mut buffer = [0_u8; 512];
 
-            for _i in 0..send_recv_times {
+            for _ in 0..send_recv_times {
                 // wait for some bytes...
                 //println!("receiving message: {}", _i);
                 let (len, addr) = server.recv_from(&mut buffer).expect("receive failed");

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -211,7 +211,7 @@ async fn send_serial_message<S: UdpSocket + Send>(
     let name_server = msg.addr();
     let socket: S = NextRandomUdpSocket::new(&name_server).await?;
     let bytes = msg.bytes();
-    let addr = &msg.addr();
+    let addr = msg.addr();
     let len_sent: usize = socket.send_to(bytes, addr).await?;
 
     if bytes.len() != len_sent {

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -209,7 +209,7 @@ async fn send_serial_message<S: UdpSocket + Send>(
     msg_id: u16,
 ) -> Result<DnsResponse, ProtoError> {
     let name_server = msg.addr();
-    let mut socket: S = NextRandomUdpSocket::new(&name_server).await?;
+    let socket: S = NextRandomUdpSocket::new(&name_server).await?;
     let bytes = msg.bytes();
     let addr = &msg.addr();
     let len_sent: usize = socket.send_to(bytes, addr).await?;

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -78,9 +78,9 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.2"
 thiserror = "1.0.20"
 tokio = { version = "0.3.0", optional = true }
-tokio-native-tls = { version = "0.1", optional = true }
-tokio-openssl = { version = "0.4.0", optional = true }
-tokio-rustls = { version = "0.14", optional = true }
+tokio-native-tls = { version = "0.2", optional = true }
+tokio-openssl = { version = "0.5.0", optional = true }
+tokio-rustls = { version = "0.20", optional = true }
 trust-dns-https = { version = "0.20.0-alpha.3", path = "../https", optional = true }
 trust-dns-native-tls = { version = "0.20.0-alpha.3", path = "../native-tls", optional = true }
 trust-dns-openssl = { version = "0.20.0-alpha.3", path = "../openssl", optional = true }

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -73,20 +73,20 @@ log = "0.4"
 lru-cache = "0.1.2"
 parking_lot = "0.11"
 resolv-conf = { version = "0.7.0", optional = true, features = ["system"] }
-rustls = {version  = "0.18", optional = true}
+rustls = {version  = "0.19", optional = true}
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.2"
 thiserror = "1.0.20"
 tokio = { version = "0.3.0", optional = true }
 tokio-native-tls = { version = "0.2", optional = true }
 tokio-openssl = { version = "0.5.0", optional = true }
-tokio-rustls = { version = "0.20", optional = true }
+tokio-rustls = { version = "0.21", optional = true }
 trust-dns-https = { version = "0.20.0-alpha.3", path = "../https", optional = true }
 trust-dns-native-tls = { version = "0.20.0-alpha.3", path = "../native-tls", optional = true }
 trust-dns-openssl = { version = "0.20.0-alpha.3", path = "../openssl", optional = true }
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", default-features = false }
 trust-dns-rustls = { version = "0.20.0-alpha.3", path = "../rustls", optional = true }
-webpki-roots = { version = "0.20", optional = true }
+webpki-roots = { version = "0.21", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ipconfig = { version = "0.2.2", optional = true }

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -59,7 +59,7 @@ system-config = ["ipconfig", "resolv-conf"]
 mdns = ["trust-dns-proto/mdns"]
 
 testing = []
-tokio-runtime = ["tokio/rt-core", "trust-dns-proto/tokio-runtime"]
+tokio-runtime = ["tokio/rt", "trust-dns-proto/tokio-runtime"]
 
 [lib]
 name = "trust_dns_resolver"
@@ -77,7 +77,7 @@ rustls = {version  = "0.18", optional = true}
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.2"
 thiserror = "1.0.20"
-tokio = { version = "0.2.22", optional = true }
+tokio = { version = "0.3.0", optional = true }
 tokio-native-tls = { version = "0.1", optional = true }
 tokio-openssl = { version = "0.4.0", optional = true }
 tokio-rustls = { version = "0.14", optional = true }

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -98,7 +98,7 @@ Success for query name: www.example.com. type: A class: IN
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -13,9 +13,9 @@ use std::task::Poll;
 use futures_util::future;
 
 #[cfg(feature = "tokio-runtime")]
-use trust_dns_resolver::TokioAsyncResolver;
-#[cfg(feature = "tokio-runtime")]
 use trust_dns_resolver::{IntoName, TryParseIp};
+#[cfg(feature = "tokio-runtime")]
+use trust_dns_resolver::{TokioAsyncResolver, TokioHandle};
 
 // This is an example of registering a static global resolver into any system.
 //
@@ -42,7 +42,7 @@ lazy_static! {
         // This thread will manage the actual resolution runtime
         thread::spawn(move || {
             // A runtime for this new thread
-            let mut runtime = tokio::runtime::Runtime::new().expect("failed to launch Runtime");
+            let runtime = tokio::runtime::Runtime::new().expect("failed to launch Runtime");
 
             // our platform independent future, result, see next blocks
             let resolver = {
@@ -51,7 +51,7 @@ lazy_static! {
                 #[cfg(any(unix, windows))]
                 {
                     // use the system resolver configuration
-                    TokioAsyncResolver::from_system_conf(runtime.handle().clone())
+                    TokioAsyncResolver::from_system_conf(TokioHandle)
                 }
 
                 // For other operating systems, we can use one of the preconfigured definitions
@@ -134,7 +134,7 @@ fn main() {
         .iter()
         .map(|name| {
             let join = thread::spawn(move || {
-                let mut runtime = tokio::runtime::Runtime::new().expect("failed to launch Runtime");
+                let runtime = tokio::runtime::Runtime::new().expect("failed to launch Runtime");
                 runtime.block_on(resolve(*name, 443))
             });
 

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -6,19 +6,19 @@
 #[cfg(feature = "tokio-runtime")]
 fn main() {
     use tokio::runtime::Runtime;
-    use trust_dns_resolver::TokioAsyncResolver;
+    use trust_dns_resolver::{TokioAsyncResolver, TokioHandle};
 
     env_logger::init();
 
     // Set up the standard tokio runtime (multithreaded by default).
-    let mut runtime = Runtime::new().expect("Failed to create runtime");
+    let runtime = Runtime::new().expect("Failed to create runtime");
 
     let resolver = {
         // To make this independent, if targeting macOS, BSD, Linux, or Windows, we can use the system's configuration:
         #[cfg(any(unix, windows))]
         {
             // use the system resolver configuration
-            TokioAsyncResolver::from_system_conf(runtime.handle().clone())
+            TokioAsyncResolver::from_system_conf(TokioHandle)
         }
 
         // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -144,7 +144,9 @@ impl TokioAsyncResolver {
 }
 
 impl<R: RuntimeProvider> AsyncResolver<GenericConnection, GenericConnectionProvider<R>> {
-    /// Construct a new `AsyncResolver` with the provided configuration.
+    /// Construct a new generic `AsyncResolver` with the provided configuration.
+    ///
+    /// see [crate::trust_dns_resolver::TokioAsyncResolver::tokio] instead.
     ///
     /// # Arguments
     ///
@@ -171,6 +173,8 @@ impl<R: RuntimeProvider> AsyncResolver<GenericConnection, GenericConnectionProvi
 
     /// Constructs a new Resolver with the system configuration.
     ///
+    /// see [crate::trust_dns_resolver::TokioAsyncResolver::tokio_from_system_conf] instead.
+    ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
     #[cfg(any(unix, target_os = "windows"))]
     #[cfg(feature = "system-config")]
@@ -193,7 +197,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
     /// background task that runs resolutions for the `AsyncResolver`. See the
     /// documentation for `AsyncResolver` for more information on how to use
     /// the background future.
-    pub fn new_with_conn(
+    pub(crate) fn new_with_conn(
         config: ResolverConfig,
         options: ResolverOpts,
         conn_provider: P,
@@ -239,7 +243,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.
     #[cfg(any(unix, target_os = "windows"))]
     #[cfg(feature = "system-config")]
-    pub fn from_system_conf_with_provider(conn_provider: P) -> Result<Self, ResolveError> {
+    pub(crate) fn from_system_conf_with_provider(conn_provider: P) -> Result<Self, ResolveError> {
         let (config, options) = super::system_conf::read_system_conf()?;
         Self::new_with_conn(config, options, conn_provider)
     }

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -30,7 +30,7 @@ use crate::name_server::{
     RuntimeProvider,
 };
 #[cfg(feature = "tokio-runtime")]
-use crate::name_server::{TokioConnection, TokioConnectionProvider};
+use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
 
 use crate::Hosts;
 
@@ -130,8 +130,7 @@ impl TokioAsyncResolver {
     /// documentation for `AsyncResolver` for more information on how to use
     /// the background future.
     pub fn tokio(config: ResolverConfig, options: ResolverOpts) -> Result<Self, ResolveError> {
-        use tokio::runtime::Handle;
-        Self::new(config, options, Handle::current())
+        Self::new(config, options, TokioHandle)
     }
 
     /// Constructs a new Tokio based Resolver with the system configuration.
@@ -140,8 +139,7 @@ impl TokioAsyncResolver {
     #[cfg(any(unix, target_os = "windows"))]
     #[cfg(feature = "system-config")]
     pub fn tokio_from_system_conf() -> Result<Self, ResolveError> {
-        use tokio::runtime::Handle;
-        Self::from_system_conf(Handle::current())
+        Self::from_system_conf(TokioHandle)
     }
 }
 
@@ -1089,7 +1087,7 @@ mod tests {
     fn test_lookup_google() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         lookup_test::<Runtime, TokioRuntime>(ResolverConfig::google(), io_loop, handle)
     }
 
@@ -1097,7 +1095,7 @@ mod tests {
     fn test_lookup_cloudflare() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         lookup_test::<Runtime, TokioRuntime>(ResolverConfig::cloudflare(), io_loop, handle)
     }
 
@@ -1105,7 +1103,7 @@ mod tests {
     fn test_lookup_quad9() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         lookup_test::<Runtime, TokioRuntime>(ResolverConfig::quad9(), io_loop, handle)
     }
 
@@ -1113,15 +1111,15 @@ mod tests {
     fn test_ip_lookup() {
         use super::testing::ip_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         ip_lookup_test::<Runtime, TokioRuntime>(io_loop, handle)
     }
 
     #[test]
     fn test_ip_lookup_across_threads() {
         use super::testing::ip_lookup_across_threads_test;
-        let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let _io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
+        let handle = TokioHandle;
         ip_lookup_across_threads_test::<Runtime, TokioRuntime>(handle)
     }
 
@@ -1130,7 +1128,7 @@ mod tests {
     fn test_sec_lookup() {
         use super::testing::sec_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         sec_lookup_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1139,7 +1137,7 @@ mod tests {
     fn test_sec_lookup_fails() {
         use super::testing::sec_lookup_fails_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         sec_lookup_fails_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1150,7 +1148,7 @@ mod tests {
     fn test_system_lookup() {
         use super::testing::system_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         system_lookup_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1161,7 +1159,7 @@ mod tests {
     fn test_hosts_lookup() {
         use super::testing::hosts_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         hosts_lookup_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1169,7 +1167,7 @@ mod tests {
     fn test_fqdn() {
         use super::testing::fqdn_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         fqdn_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1177,7 +1175,7 @@ mod tests {
     fn test_ndots() {
         use super::testing::ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         ndots_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1185,7 +1183,7 @@ mod tests {
     fn test_large_ndots() {
         use super::testing::large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         large_ndots_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1193,7 +1191,7 @@ mod tests {
     fn test_domain_search() {
         use super::testing::domain_search_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         domain_search_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1201,7 +1199,7 @@ mod tests {
     fn test_search_list() {
         use super::testing::search_list_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         search_list_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1209,7 +1207,7 @@ mod tests {
     fn test_idna() {
         use super::testing::idna_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         idna_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1217,7 +1215,7 @@ mod tests {
     fn test_localhost_ipv4() {
         use super::testing::localhost_ipv4_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         localhost_ipv4_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1225,7 +1223,7 @@ mod tests {
     fn test_localhost_ipv6() {
         use super::testing::localhost_ipv6_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         localhost_ipv6_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1233,7 +1231,7 @@ mod tests {
     fn test_search_ipv4_large_ndots() {
         use super::testing::search_ipv4_large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         search_ipv4_large_ndots_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1241,7 +1239,7 @@ mod tests {
     fn test_search_ipv6_large_ndots() {
         use super::testing::search_ipv6_large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         search_ipv6_large_ndots_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 
@@ -1249,7 +1247,7 @@ mod tests {
     fn test_search_ipv6_name_parse_fails() {
         use super::testing::search_ipv6_name_parse_fails_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = io_loop.handle().clone();
+        let handle = TokioHandle;
         search_ipv6_name_parse_fails_test::<Runtime, TokioRuntime>(io_loop, handle);
     }
 }

--- a/crates/resolver/src/dns_sd.rs
+++ b/crates/resolver/src/dns_sd.rs
@@ -161,21 +161,21 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::*;
-    use crate::TokioAsyncResolver;
+    use crate::{TokioAsyncResolver, TokioHandle};
 
     use super::*;
 
     #[test]
     #[ignore]
     fn test_list_services() {
-        let mut io_loop = Runtime::new().unwrap();
+        let io_loop = Runtime::new().unwrap();
         let resolver = TokioAsyncResolver::new(
             ResolverConfig::default(),
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv6thenIpv4,
                 ..ResolverOpts::default()
             },
-            io_loop.handle().clone(),
+            TokioHandle,
         )
         .expect("failed to create resolver");
 

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -34,15 +34,14 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::TokioAsyncResolver;
+    use crate::{TokioAsyncResolver, TokioHandle};
 
     fn https_test(config: ResolverConfig) {
         //env_logger::try_init().ok();
-        let mut io_loop = Runtime::new().unwrap();
+        let io_loop = Runtime::new().unwrap();
 
-        let resolver =
-            TokioAsyncResolver::new(config, ResolverOpts::default(), io_loop.handle().clone())
-                .expect("failed to create resolver");
+        let resolver = TokioAsyncResolver::new(config, ResolverOpts::default(), TokioHandle)
+            .expect("failed to create resolver");
 
         let response = io_loop
             .block_on(resolver.lookup_ip("www.example.com."))

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -222,7 +222,7 @@ pub use async_resolver::TokioAsyncResolver;
 pub use hosts::Hosts;
 pub use name_server::ConnectionProvider;
 #[cfg(feature = "tokio-runtime")]
-pub use name_server::{TokioConnection, TokioConnectionProvider};
+pub use name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
 #[cfg(feature = "tokio-runtime")]
 pub use resolver::Resolver;
 

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -23,5 +23,5 @@ use self::name_server_stats::NameServerStats;
 
 #[cfg(feature = "tokio-runtime")]
 pub use self::connection_provider::tokio_runtime::{
-    TokioConnection, TokioConnectionProvider, TokioRuntime,
+    TokioConnection, TokioConnectionProvider, TokioHandle, TokioRuntime,
 };

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -12,8 +12,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use futures_util::{future::Future, lock::Mutex};
-#[cfg(feature = "tokio-runtime")]
-use tokio::runtime::Handle;
 
 #[cfg(feature = "mdns")]
 use proto::multicast::MDNS_IPV4;
@@ -25,7 +23,7 @@ use crate::config::{NameServerConfig, ResolverOpts};
 use crate::error::ResolveError;
 use crate::name_server::{ConnectionProvider, NameServerState, NameServerStats};
 #[cfg(feature = "tokio-runtime")]
-use crate::name_server::{TokioConnection, TokioConnectionProvider};
+use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
 
 /// Specifies the details of a remote NameServer used for lookups
 #[derive(Clone)]
@@ -51,7 +49,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> Debug
 
 #[cfg(feature = "tokio-runtime")]
 impl NameServer<TokioConnection, TokioConnectionProvider> {
-    pub fn new(config: NameServerConfig, options: ResolverOpts, runtime: Handle) -> Self {
+    pub fn new(config: NameServerConfig, options: ResolverOpts, runtime: TokioHandle) -> Self {
         Self::new_with_provider(config, options, TokioConnectionProvider::new(runtime))
     }
 }
@@ -290,8 +288,8 @@ mod tests {
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         };
-        let mut io_loop = Runtime::new().unwrap();
-        let runtime_handle = io_loop.handle().clone();
+        let io_loop = Runtime::new().unwrap();
+        let runtime_handle = TokioHandle;
         let name_server = future::lazy(|_| {
             NameServer::<_, TokioConnectionProvider>::new(
                 config,
@@ -324,8 +322,8 @@ mod tests {
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
         };
-        let mut io_loop = Runtime::new().unwrap();
-        let runtime_handle = io_loop.handle().clone();
+        let io_loop = Runtime::new().unwrap();
+        let runtime_handle = TokioHandle;
         let name_server = future::lazy(|_| {
             NameServer::<_, TokioConnectionProvider>::new(config, options, runtime_handle)
         });

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -20,7 +20,7 @@ use crate::error::*;
 use crate::lookup;
 use crate::lookup::Lookup;
 use crate::lookup_ip::LookupIp;
-use crate::name_server::{TokioConnection, TokioConnectionProvider};
+use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
 use crate::AsyncResolver;
 
 /// The Resolver is used for performing DNS queries.
@@ -76,13 +76,12 @@ impl Resolver {
     ///
     /// A new `Resolver` or an error if there was an error with the configuration.
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> io::Result<Self> {
-        let mut builder = runtime::Builder::new();
-        builder.basic_scheduler();
+        let mut builder = runtime::Builder::new_current_thread();
         builder.enable_all();
 
         let runtime = builder.build()?;
-        let async_resolver = AsyncResolver::new(config, options, runtime.handle().clone())
-            .expect("failed to create resolver");
+        let async_resolver =
+            AsyncResolver::new(config, options, TokioHandle).expect("failed to create resolver");
 
         Ok(Resolver {
             runtime: Mutex::new(runtime),

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -33,15 +33,14 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::TokioAsyncResolver;
+    use crate::{TokioAsyncResolver, TokioHandle};
 
     fn tls_test(config: ResolverConfig) {
         //env_logger::try_init().ok();
-        let mut io_loop = Runtime::new().unwrap();
+        let io_loop = Runtime::new().unwrap();
 
-        let resolver =
-            TokioAsyncResolver::new(config, ResolverOpts::default(), io_loop.handle().clone())
-                .expect("failed to create resolver");
+        let resolver = TokioAsyncResolver::new(config, ResolverOpts::default(), TokioHandle)
+            .expect("failed to create resolver");
 
         let response = io_loop
             .block_on(resolver.lookup_ip("www.example.com."))

--- a/crates/rustls/Cargo.toml
+++ b/crates/rustls/Cargo.toml
@@ -51,9 +51,9 @@ futures-channel = { version = "0.3.5", default-features = false, features = ["st
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 log = "0.4"
-rustls = "0.18"
+rustls = "0.19"
 tokio = { version = "0.3.0", features = ["io-util", "net"] }
-tokio-rustls = { version = "0.20", features = ["early-data"] }
+tokio-rustls = { version = "0.21", features = ["early-data"] }
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["tokio-runtime"], default-features = false }
 webpki = "0.21"

--- a/crates/rustls/Cargo.toml
+++ b/crates/rustls/Cargo.toml
@@ -53,7 +53,7 @@ futures-util = { version = "0.3.5", default-features = false, features = ["std"]
 log = "0.4"
 rustls = "0.18"
 tokio = { version = "0.3.0", features = ["io-util", "net"] }
-tokio-rustls = { version = "0.14", features = ["early-data"] }
+tokio-rustls = { version = "0.20", features = ["early-data"] }
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["tokio-runtime"], default-features = false }
 webpki = "0.21"

--- a/crates/rustls/Cargo.toml
+++ b/crates/rustls/Cargo.toml
@@ -52,7 +52,7 @@ futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 log = "0.4"
 rustls = "0.18"
-tokio = { version = "0.2.22", features = ["tcp", "io-util"] }
+tokio = { version = "0.3.0", features = ["io-util", "net"] }
 tokio-rustls = { version = "0.14", features = ["early-data"] }
 # disables default features, i.e. openssl...
 trust-dns-proto = { version = "0.20.0-alpha.3", path = "../proto", features = ["tokio-runtime"], default-features = false }

--- a/crates/rustls/README.md
+++ b/crates/rustls/README.md
@@ -6,7 +6,7 @@ This library allows for TLS connections to be established to remote DNS servers.
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/rustls/src/tests.rs
+++ b/crates/rustls/src/tests.rs
@@ -82,7 +82,8 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
                 }
             }
 
-            panic!("timeout");
+            println!("Thread Killer has been awoken, killing process");
+            std::process::exit(-1);
         })
         .unwrap();
 

--- a/crates/rustls/src/tls_client_stream.rs
+++ b/crates/rustls/src/tls_client_stream.rs
@@ -17,7 +17,7 @@ use rustls::ClientConfig;
 use tokio::net::TcpStream as TokioTcpStream;
 
 use trust_dns_proto::error::ProtoError;
-use trust_dns_proto::iocompat::AsyncIo02As03;
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 use trust_dns_proto::tcp::TcpClientStream;
 use trust_dns_proto::xfer::BufDnsStreamHandle;
 
@@ -25,7 +25,7 @@ use crate::tls_stream::tls_connect;
 
 /// Type of TlsClientStream used with Rustls
 pub type TlsClientStream =
-    TcpClientStream<AsyncIo02As03<tokio_rustls::client::TlsStream<TokioTcpStream>>>;
+    TcpClientStream<AsyncIoTokioAsStd<tokio_rustls::client::TlsStream<TokioTcpStream>>>;
 
 /// Creates a new TlsStream to the specified name_server
 ///

--- a/crates/rustls/src/tls_stream.rs
+++ b/crates/rustls/src/tls_stream.rs
@@ -20,7 +20,7 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_rustls::TlsConnector;
 use webpki::{DNSName, DNSNameRef};
 
-use trust_dns_proto::iocompat::AsyncIo02As03;
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 use trust_dns_proto::tcp::{self, DnsTcpStream, TcpStream};
 use trust_dns_proto::xfer::{BufStreamHandle, StreamReceiver};
 
@@ -78,8 +78,9 @@ pub fn tls_connect(
 ) -> (
     Pin<
         Box<
-            dyn Future<Output = Result<TlsStream<AsyncIo02As03<TokioTlsClientStream>>, io::Error>>
-                + Send,
+            dyn Future<
+                    Output = Result<TlsStream<AsyncIoTokioAsStd<TokioTlsClientStream>>, io::Error>,
+                > + Send,
         >,
     >,
     BufStreamHandle,
@@ -105,7 +106,7 @@ async fn connect_tls(
     name_server: SocketAddr,
     dns_name: String,
     outbound_messages: StreamReceiver,
-) -> io::Result<TcpStream<AsyncIo02As03<TokioTlsClientStream>>> {
+) -> io::Result<TcpStream<AsyncIoTokioAsStd<TokioTlsClientStream>>> {
     let tcp = tcp::tokio::connect(&name_server).await?;
 
     let dns_name = DNSNameRef::try_from_ascii_str(&dns_name)
@@ -123,7 +124,7 @@ async fn connect_tls(
         .await?;
 
     Ok(TcpStream::from_stream_with_receiver(
-        AsyncIo02As03(s),
+        AsyncIoTokioAsStd(s),
         name_server,
         outbound_messages,
     ))

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -78,7 +78,7 @@ enum-as-inner = "0.3"
 env_logger = "0.8"
 futures-executor = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
-h2 = { version = "0.2.6", features = ["stream"], optional = true }
+h2 = { version = "0.3.0", features = ["stream"], optional = true }
 http = { version = "0.2", optional = true }
 log = "0.4"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
@@ -87,8 +87,8 @@ rustls = { version = "0.18", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.20"
 tokio = { version = "0.3.0", features = ["stream", "net"] }
-tokio-openssl = { version = "0.4.0", optional = true }
-tokio-rustls = { version = "0.14", optional = true }
+tokio-openssl = { version = "0.5.0", optional = true }
+tokio-rustls = { version = "0.20", optional = true }
 toml = "0.5"
 trust-dns-client= { version = "0.20.0-alpha.3", path = "../client" }
 trust-dns-https = { version = "0.20.0-alpha.3", path = "../https", optional = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -86,7 +86,7 @@ rusqlite = { version = "0.24.0", features = ["bundled", "chrono"], optional = tr
 rustls = { version = "0.18", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.20"
-tokio = { version = "0.2.22", features = ["stream", "tcp", "udp"] }
+tokio = { version = "0.3.0", features = ["stream", "net"] }
 tokio-openssl = { version = "0.4.0", optional = true }
 tokio-rustls = { version = "0.14", optional = true }
 toml = "0.5"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -71,7 +71,7 @@ name = "trust_dns_server"
 path = "src/lib.rs"
 
 [dependencies]
-bytes = "0.5"
+bytes = "0.6"
 cfg-if = "1"
 chrono = "0.4"
 enum-as-inner = "0.3"
@@ -83,12 +83,12 @@ http = { version = "0.2", optional = true }
 log = "0.4"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 rusqlite = { version = "0.24.0", features = ["bundled", "chrono"], optional = true }
-rustls = { version = "0.18", optional = true }
+rustls = { version = "0.19", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.20"
 tokio = { version = "0.3.0", features = ["stream", "net"] }
 tokio-openssl = { version = "0.5.0", optional = true }
-tokio-rustls = { version = "0.20", optional = true }
+tokio-rustls = { version = "0.21", optional = true }
 toml = "0.5"
 trust-dns-client= { version = "0.20.0-alpha.3", path = "../client" }
 trust-dns-https = { version = "0.20.0-alpha.3", path = "../https", optional = true }

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -24,7 +24,7 @@ This library contains basic implementations for DNS zone hosting. It is capable 
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.42`
+The current minimum rustc version for this project is `1.45`
 
 ## Versioning
 

--- a/crates/server/src/server/timeout_stream.rs
+++ b/crates/server/src/server/timeout_stream.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use futures_util::stream::{Stream, StreamExt};
 use futures_util::FutureExt;
 use log::{debug, warn};
-use tokio::time::Delay;
+use tokio::time::Sleep;
 
 /// This wraps the underlying Stream in a timeout.
 ///
@@ -15,7 +15,7 @@ use tokio::time::Delay;
 pub struct TimeoutStream<S> {
     stream: S,
     timeout_duration: Duration,
-    timeout: Option<Delay>,
+    timeout: Option<Sleep>,
 }
 
 impl<S> TimeoutStream<S> {
@@ -34,9 +34,9 @@ impl<S> TimeoutStream<S> {
         }
     }
 
-    fn timeout(timeout_duration: Duration) -> Option<Delay> {
+    fn timeout(timeout_duration: Duration) -> Option<Sleep> {
         if timeout_duration > Duration::from_millis(0) {
-            Some(tokio::time::delay_for(timeout_duration))
+            Some(tokio::time::sleep(timeout_duration))
         } else {
             None
         }

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -54,7 +54,6 @@ impl ForwardAuthority {
         origin: Name,
         _zone_type: ZoneType,
         config: &ForwardConfig,
-        runtime: TokioHandle,
     ) -> Result<Self, String> {
         info!("loading forwarder config: {}", origin);
 
@@ -62,7 +61,7 @@ impl ForwardAuthority {
         let options = config.options.unwrap_or_default();
         let config = ResolverConfig::from_parts(None, vec![], name_servers);
 
-        let resolver = TokioAsyncResolver::new(config, options, runtime)
+        let resolver = TokioAsyncResolver::new(config, options, TokioHandle)
             .map_err(|e| format!("error constructing new Resolver: {}", e))?;
 
         info!("forward resolver configured: {}: ", origin);

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -12,7 +12,6 @@ use std::task::{Context, Poll};
 
 use futures_util::{future, FutureExt};
 use log::info;
-use tokio::runtime::Handle;
 
 use crate::client::op::LowerQuery;
 use crate::client::op::ResponseCode;
@@ -21,7 +20,7 @@ use crate::client::rr::{LowerName, Name, Record, RecordType};
 use crate::resolver::config::ResolverConfig;
 use crate::resolver::error::ResolveError;
 use crate::resolver::lookup::Lookup as ResolverLookup;
-use crate::resolver::TokioAsyncResolver;
+use crate::resolver::{TokioAsyncResolver, TokioHandle};
 
 use crate::authority::{
     Authority, LookupError, LookupObject, MessageRequest, UpdateResult, ZoneType,
@@ -40,7 +39,7 @@ impl ForwardAuthority {
     /// TODO: change this name to create or something
     #[allow(clippy::new_without_default)]
     #[doc(hidden)]
-    pub async fn new(runtime: Handle) -> Result<Self, String> {
+    pub async fn new(runtime: TokioHandle) -> Result<Self, String> {
         let resolver = TokioAsyncResolver::from_system_conf(runtime)
             .map_err(|e| format!("error constructing new Resolver: {}", e))?;
 
@@ -55,7 +54,7 @@ impl ForwardAuthority {
         origin: Name,
         _zone_type: ZoneType,
         config: &ForwardConfig,
-        runtime: Handle,
+        runtime: TokioHandle,
     ) -> Result<Self, String> {
         info!("loading forwarder config: {}", origin);
 

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -7,14 +7,15 @@ use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 use trust_dns_client::rr::{Name, RecordType};
+use trust_dns_resolver::TokioHandle;
 use trust_dns_server::authority::{Authority, LookupObject};
 use trust_dns_server::store::forwarder::ForwardAuthority;
 
 #[ignore]
 #[test]
 fn test_lookup() {
-    let mut runtime = Runtime::new().expect("failed to create Tokio Runtime");
-    let forwarder = ForwardAuthority::new(runtime.handle().clone());
+    let runtime = Runtime::new().expect("failed to create Tokio Runtime");
+    let forwarder = ForwardAuthority::new(TokioHandle);
     let forwarder = runtime
         .block_on(forwarder)
         .expect("failed to create forwarder");

--- a/crates/server/tests/timeout_stream_tests.rs
+++ b/crates/server/tests/timeout_stream_tests.rs
@@ -13,7 +13,7 @@ fn test_no_timeout() {
     #[allow(deprecated)]
     let sequence =
         iter(vec![Ok(1), Err("error"), Ok(2)]).map_err(|e| io::Error::new(io::ErrorKind::Other, e));
-    let mut core = Runtime::new().expect("could not get core");
+    let core = Runtime::new().expect("could not get core");
 
     let timeout_stream = TimeoutStream::new(sequence, Duration::from_secs(360));
 
@@ -43,7 +43,7 @@ impl Stream for NeverStream {
 
 #[test]
 fn test_timeout() {
-    let mut core = Runtime::new().expect("could not get core");
+    let core = Runtime::new().expect("could not get core");
     let timeout_stream = TimeoutStream::new(NeverStream {}, Duration::from_millis(1));
 
     assert!(core

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -77,7 +77,7 @@ openssl = { version = "0.10", features = ["v102", "v110"] }
 rand = "0.7"
 rusqlite = { version = "0.24.0", features = ["bundled"] }
 rustls = "0.18"
-tokio = { version = "0.2.22", features = ["time", "rt-core"] }
+tokio = { version = "0.3.0", features = ["time", "rt"] }
 trust-dns-client= { version = "0.20.0-alpha.3", path = "../../crates/client" }
 trust-dns-https = { version = "0.20.0-alpha.3", path = "../../crates/https" }
 trust-dns-openssl = { version = "0.20.0-alpha.3", path = "../../crates/openssl" }

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -76,7 +76,7 @@ futures = "0.3.5"
 openssl = { version = "0.10", features = ["v102", "v110"] }
 rand = "0.7"
 rusqlite = { version = "0.24.0", features = ["bundled"] }
-rustls = "0.18"
+rustls = "0.19"
 tokio = { version = "0.3.0", features = ["time", "rt"] }
 trust-dns-client= { version = "0.20.0-alpha.3", path = "../../crates/client" }
 trust-dns-https = { version = "0.20.0-alpha.3", path = "../../crates/https" }
@@ -86,7 +86,7 @@ trust-dns-resolver = { version = "0.20.0-alpha.3", path = "../../crates/resolver
 trust-dns-rustls = { version = "0.20.0-alpha.3", path = "../../crates/rustls" }
 # TODO: fixup tests to not require openssl
 trust-dns-server = { version = "0.20.0-alpha.3", path = "../../crates/server" }
-webpki-roots = { version = "0.20", optional = true }
+webpki-roots = { version = "0.21", optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.5", features = ["thread-pool"] }

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -13,7 +13,7 @@ use std::task::{Context, Poll};
 use futures::channel::mpsc;
 use futures::stream::{Fuse, Stream, StreamExt};
 use futures::{future, Future, FutureExt};
-use tokio::time::{Delay, Duration, Instant};
+use tokio::time::{Duration, Instant, Sleep};
 
 use trust_dns_client::client::ClientConnection;
 use trust_dns_client::error::ClientResult;
@@ -175,7 +175,7 @@ impl fmt::Debug for TestClientStream {
 //  is no one listening to messages and shutdown...
 #[allow(dead_code)]
 pub struct NeverReturnsClientStream {
-    timeout: Delay,
+    timeout: Sleep,
     outbound_messages: Fuse<mpsc::UnboundedReceiver<Vec<u8>>>,
 }
 
@@ -191,7 +191,7 @@ impl NeverReturnsClientStream {
 
         let stream = Box::pin(future::lazy(|_| {
             Ok(NeverReturnsClientStream {
-                timeout: tokio::time::delay_for(Duration::from_secs(1)),
+                timeout: tokio::time::sleep(Duration::from_secs(1)),
                 outbound_messages: outbound_messages.fuse(),
             })
         }));

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -19,9 +19,12 @@ use trust_dns_client::rr::Record;
 use trust_dns_client::rr::{DNSClass, Name, RData, RecordSet, RecordType};
 use trust_dns_client::tcp::TcpClientStream;
 use trust_dns_client::udp::UdpClientStream;
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 #[cfg(feature = "dnssec")]
 use trust_dns_proto::xfer::{DnsExchangeBackground, DnsMultiplexer, DnsStreamHandle};
-use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, TokioTime};
+#[cfg(all(feature = "dnssec", feature = "sqlite"))]
+use trust_dns_proto::TokioTime;
+
 use trust_dns_server::authority::{Authority, Catalog};
 
 use trust_dns_integration::authority::create_example;

--- a/tests/integration-tests/tests/lookup_tests.rs
+++ b/tests/integration-tests/tests/lookup_tests.rs
@@ -27,7 +27,7 @@ fn test_lookup() {
     let mut catalog = Catalog::new();
     catalog.upsert(authority.origin().clone(), Box::new(authority));
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(Mutex::new(catalog)));
     let dns_conn = DnsMultiplexer::new(stream, Box::new(sender), NoopMessageFinalizer::new());
     let client = DnsExchange::connect::<_, _, TokioTime>(dns_conn);
@@ -55,7 +55,7 @@ fn test_lookup_hosts() {
     let mut catalog = Catalog::new();
     catalog.upsert(authority.origin().clone(), Box::new(authority));
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(Mutex::new(catalog)));
     let dns_conn = DnsMultiplexer::new(stream, Box::new(sender), NoopMessageFinalizer::new());
 
@@ -113,7 +113,7 @@ fn test_lookup_ipv4_like() {
     let mut catalog = Catalog::new();
     catalog.upsert(authority.origin().clone(), Box::new(authority));
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(Mutex::new(catalog)));
     let dns_conn = DnsMultiplexer::new(stream, Box::new(sender), NoopMessageFinalizer::new());
 
@@ -143,7 +143,7 @@ fn test_lookup_ipv4_like_fall_through() {
     let mut catalog = Catalog::new();
     catalog.upsert(authority.origin().clone(), Box::new(authority));
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(Mutex::new(catalog)));
     let dns_conn = DnsMultiplexer::new(stream, Box::new(sender), NoopMessageFinalizer::new());
 
@@ -185,7 +185,7 @@ fn test_mock_lookup() {
         CachingClient::new(0, client, false),
     );
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let lookup = io_loop.block_on(lookup).unwrap();
 
     assert_eq!(
@@ -216,7 +216,7 @@ fn test_cname_lookup() {
         CachingClient::new(0, client, false),
     );
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let lookup = io_loop.block_on(lookup).unwrap();
 
     assert_eq!(
@@ -252,7 +252,7 @@ fn test_cname_lookup_preserve() {
         CachingClient::new(0, client, true),
     );
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let lookup = io_loop.block_on(lookup).unwrap();
 
     let mut iter = lookup.iter();
@@ -290,7 +290,7 @@ fn test_chained_cname_lookup() {
         CachingClient::new(0, client, false),
     );
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let lookup = io_loop.block_on(lookup).unwrap();
 
     assert_eq!(
@@ -331,7 +331,7 @@ fn test_chained_cname_lookup_preserve() {
         CachingClient::new(0, client, true),
     );
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     let lookup = io_loop.block_on(lookup).unwrap();
 
     let mut iter = lookup.iter();
@@ -420,7 +420,7 @@ fn test_max_chained_lookup_depth() {
         client.clone(),
     );
 
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
 
     println!("performing max cname validation");
     assert!(io_loop.block_on(lookup).is_err());

--- a/tests/integration-tests/tests/mdns_tests.rs
+++ b/tests/integration-tests/tests/mdns_tests.rs
@@ -41,10 +41,10 @@ fn mdns_responsder(
     let join_handle = std::thread::Builder::new()
         .name(format!("{}:server", test_name))
         .spawn(move || {
-            let mut io_loop = Runtime::new().unwrap();
+            let io_loop = Runtime::new().unwrap();
 
             // a max time for the test to run
-            let mut timeout = tokio::time::delay_for(Duration::from_millis(100));
+            let mut timeout = tokio::time::sleep(Duration::from_millis(100));
 
             // TODO: ipv6 if is hardcoded, need a different strategy
             let (mdns_stream, mut mdns_handle) = MdnsStream::new(
@@ -87,7 +87,7 @@ fn mdns_responsder(
                     }
                     Either::Right(((), data_src_stream_tmp)) => {
                         stream = data_src_stream_tmp;
-                        timeout = tokio::time::delay_for(Duration::from_millis(100));
+                        timeout = tokio::time::sleep(Duration::from_millis(100));
                     }
                 }
             }
@@ -109,7 +109,7 @@ fn test_query_mdns_ipv4() {
     let _server_thread = mdns_responsder("test_query_mdns_ipv4", client_done.clone(), addr);
 
     // Check that the server is ready before sending...
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
     //let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
 
     // not using MdnsClientConnection here, b/c we need to change the IP for testing.
@@ -133,7 +133,7 @@ fn test_query_mdns_ipv6() {
     let addr = SocketAddr::new(*TEST_MDNS_IPV6, MDNS_PORT + 2);
     let client_done = Arc::new(AtomicBool::new(false));
     let _server_thread = mdns_responsder("test_query_mdns_ipv4", client_done.clone(), addr);
-    let mut io_loop = Runtime::new().unwrap();
+    let io_loop = Runtime::new().unwrap();
 
     // not using MdnsClientConnection here, b/c we need to change the IP for testing.
     // FIXME: ipv6 if is hardcoded...

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -159,7 +159,7 @@ fn test_server_www_tls() {
     let pkcs12_der = read_file(&format!("{}/tests/test-data/cert.p12", server_path));
 
     // Server address
-    let mut runtime = Runtime::new().expect("failed to create Tokio Runtime");
+    let runtime = Runtime::new().expect("failed to create Tokio Runtime");
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
     let tcp_listener = runtime.block_on(TcpListener::bind(&addr)).unwrap();
 
@@ -316,8 +316,6 @@ fn server_thread_tls(
     }));
 
     while server_continue.load(Ordering::Relaxed) {
-        io_loop.block_on(
-            future::lazy(|_| tokio::time::delay_for(Duration::from_millis(10))).flatten(),
-        );
+        io_loop.block_on(future::lazy(|_| tokio::time::sleep(Duration::from_millis(10))).flatten());
     }
 }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -65,4 +65,4 @@ trust-dns-resolver = { version = "0.20.0-alpha.3", features = ["dnssec-openssl"]
 log = "0.4"
 openssl = { version = "0.10", features = ["v102", "v110"] }
 structopt = "0.3"
-tokio = { version = "0.2.22", features = ["rt-threaded", "macros"] }
+tokio = { version = "0.3.0", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
Need to upgrade all crates:

- [x] proto
- [x] rustls - depends on tokio-rustls
- [x] https - dependecies on tokio-rustls, et al. (tests failing, temp impl on git master branch from h2)
- [x] client
- [x] openssl - depends on tokio-openssl
- [x] native-tls - requires move to tokio-native-tls
- [x] resolver
- [x] server
- [x] bin 
- [x] util
- [x] tests

Fixes: #1250

blocked on:

- [x] test failure: https_client_stream::tests::test_https_google in trust-dns-https
- [ ] h2 0.3 release with upgrade to Tokio 0.3