### PR TITLE
Align the default EDNS buffer sizes with the DNS Day 2020 recommendations

### DIFF
--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -28,7 +28,9 @@ use crate::rr::dnssec::Signer;
 use crate::rr::{DNSClass, Name, Record, RecordSet, RecordType};
 
 // TODO: this should be configurable
-pub const MAX_PAYLOAD_LEN: u16 = 1500 - 40 - 8; // 1500 (general MTU) - 40 (ipv6 header) - 8 (udp header)
+// > An EDNS buffer size of 1232 bytes will avoid fragmentation on nearly all current networks.
+// https://dnsflagday.net/2020/
+pub const MAX_PAYLOAD_LEN: u16 = 1232;
 
 /// A DNS Client implemented over futures-rs.
 ///

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -18,7 +18,9 @@ use crate::op::{Message, MessageType, OpCode, Query};
 use crate::xfer::{DnsRequest, DnsRequestOptions, DnsResponse, SerialMessage};
 
 // TODO: this should be configurable
-const MAX_PAYLOAD_LEN: u16 = 1500 - 40 - 8; // 1500 (general MTU) - 40 (ipv6 header) - 8 (udp header)
+// > An EDNS buffer size of 1232 bytes will avoid fragmentation on nearly all current networks.
+// https://dnsflagday.net/2020/
+const MAX_PAYLOAD_LEN: u16 = 1232;
 
 /// The StreamHandle is the general interface for communicating with the DnsMultiplexer
 pub struct StreamHandle {


### PR DESCRIPTION
Use 1232 as the default buffer size for outgoing queries.
See https://dnsflagday.net/2020/ for details.