### PR TITLE
bump resolv-conf from 0.6.0 to 0.7.0

### DIFF
--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -71,7 +71,7 @@ futures = { version = "0.3.4", default-features = false, features = ["std"] }
 lazy_static = "1.0"
 log = "0.4"
 lru-cache = "0.1.2"
-resolv-conf = { version = "0.6.0", optional = true, features = ["system"] }
+resolv-conf = { version = "0.7.0", optional = true, features = ["system"] }
 rustls = {version  = "0.17", optional = true}
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.2"


### PR DESCRIPTION
Hello, thank you for trust-dns! We're run into a production issue where `read_system_conf` fails because `/etc/resolv.conf` contains unsupported options, specifically `options edns0 trust-ad`. This is an issue in the underlying library, https://github.com/tailhook/resolv-conf/issues/21, which has been fixed as of `resolv-conf 0.7.0`. This PR upgrades that dependency in the hope that we can get another release of the 0.19 series.