### PR TITLE
Replacing lru_cache with hashlink.

### DIFF
--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -70,7 +70,7 @@ cfg-if = "1.0.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 lazy_static = "1.0"
 log = "0.4"
-lru-cache = "0.1.2"
+hashlink = "0.6"
 parking_lot = "0.11"
 resolv-conf = { version = "0.7.0", optional = true, features = ["system"] }
 rustls = {version  = "0.18", optional = true}

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use lru_cache::LruCache;
+use hashlink::LruCache;
 use parking_lot::Mutex;
 
 use proto::op::Query;


### PR DESCRIPTION
## What this PR does

Rust 1.48 introduces a check that causes a panic if the inner types have mem::uninitialized and aren't initialised. The version of linked-hash-map(v0.5.0) used by lru_cache would now panic if an insert is attempted. Moreover, lru_cache and linked-hash-map are not actively maintained.

This PR replaces lru_cache with hashlink which is a fork of linked-hash-map and therefore keeps the same API and is actively maintained. 


References: https://github.com/rust-lang/rust/pull/71274/, 
https://github.com/rusqlite/rusqlite/pull/811