### PR TITLE
Upgrade socket2 dependency

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -76,7 +76,7 @@ rand = "0.7"
 ring = { version = "0.16", optional = true, features = ["std"] }
 serde = { version = "1.0", optional = true }
 smallvec = "1.2"
-socket2 = { version = "0.3.12", optional = true }
+socket2 = { version = "0.3.16", optional = true }
 thiserror = "1.0.20"
 tokio = { version = "0.3.0", optional = true }
 url = "2.1.0"


### PR DESCRIPTION
Upgrades to a version not making invalid assumptions about the memory layout of `std::net::SocketAddr`.

Helps unblock https://github.com/rust-lang/rust/pull/78802. See that PR for more details.