### PR TITLE
Add serde support for the RecordType in the proto crate

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -74,7 +74,7 @@ log = "0.4"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 rand = "0.7"
 ring = { version = "0.16", optional = true, features = ["std"] }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.2"
 socket2 = { version = "0.3.16", optional = true }
 thiserror = "1.0.20"

--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -33,6 +33,8 @@ use std::str::FromStr;
 
 use enum_as_inner::EnumAsInner;
 use log::trace;
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
 
 use crate::error::*;
 use crate::rr::rdata::null;
@@ -48,6 +50,7 @@ pub use self::nsec3param::NSEC3PARAM;
 pub use self::sig::SIG;
 
 /// The type of the resource record, for DNSSEC-specific records.
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum DNSSECRecordType {
     //  CDS,        //	59	RFC 7344	Child DS

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -22,6 +22,9 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::serialize::binary::*;
 
@@ -35,6 +38,7 @@ use crate::rr::dnssec::rdata::DNSSECRecordType;
 /// The type of the resource record.
 ///
 /// This specifies the type of data in the RData field of the Resource Record
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 #[allow(dead_code)]
 pub enum RecordType {


### PR DESCRIPTION
This partially fixes #1318. For `RData`, I think serde may not be a good idea as it is overcomplicated.