### PR TITLE
6️⃣ Change default `LookupIpStrategy` back to `Ipv4AndIpv6`

### DIFF
--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -450,7 +450,7 @@ pub mod testing {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_eq!(response.iter().count(), 2);
         for address in response.iter() {
             if address.is_ipv4() {
                 assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));
@@ -572,7 +572,7 @@ pub mod testing {
             .expect("failed to run lookup");
 
         // TODO: this test is flaky, sometimes 1 is returned, sometimes 2...
-        //assert_eq!(response.iter().count(), 1);
+        //assert_eq!(response.iter().count(), 2);
         for address in response.iter() {
             if address.is_ipv4() {
                 assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -641,9 +641,9 @@ pub enum LookupIpStrategy {
 }
 
 impl Default for LookupIpStrategy {
-    /// Returns [`LookupIpStrategy::Ipv4thenIpv6`] as the default.
+    /// Returns [`LookupIpStrategy::Ipv4AndIpv6`] as the default.
     fn default() -> Self {
-        LookupIpStrategy::Ipv4thenIpv6
+        LookupIpStrategy::Ipv4AndIpv6
     }
 }
 

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -47,7 +47,7 @@ mod tests {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_eq!(response.iter().count(), 2);
         for address in response.iter() {
             if address.is_ipv4() {
                 assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));
@@ -66,7 +66,7 @@ mod tests {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_eq!(response.iter().count(), 2);
         for address in response.iter() {
             if address.is_ipv4() {
                 assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -170,7 +170,7 @@ mod tests {
         let response = resolver.lookup_ip("www.example.com.").unwrap();
         println!("response records: {:?}", response);
 
-        assert_eq!(response.iter().count(), 1);
+        assert_eq!(response.iter().count(), 2);
         for address in response.iter() {
             if address.is_ipv4() {
                 assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));
@@ -194,7 +194,7 @@ mod tests {
         let response = resolver.lookup_ip("www.example.com.").unwrap();
         println!("response records: {:?}", response);
 
-        assert_eq!(response.iter().count(), 1);
+        assert_eq!(response.iter().count(), 2);
         for address in response.iter() {
             if address.is_ipv4() {
                 assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -46,7 +46,7 @@ mod tests {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_eq!(response.iter().count(), 2);
         for address in response.iter() {
             if address.is_ipv4() {
                 assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));


### PR DESCRIPTION
- #300 doesn't make any sense. #301 seems like an arbitrary change to me.
- Reverts #301 6ec1ec3.