### PR TITLE
Streaming API for Resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "enum-as-inner",
  "env_logger",
  "futures-channel",
+ "futures-core",
  "futures-executor",
  "futures-io",
  "futures-util",

--- a/crates/client/src/client/async_secure_client.rs
+++ b/crates/client/src/client/async_secure_client.rs
@@ -10,6 +10,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use futures_util::stream::Stream;
 use futures_util::{ready, FutureExt};
 
 use crate::client::{AsyncClient, AsyncClientConnect};
@@ -68,8 +69,7 @@ impl Clone for AsyncDnssecClient {
 }
 
 impl DnsHandle for AsyncDnssecClient {
-    type Response =
-        Pin<Box<(dyn Future<Output = Result<DnsResponse, ProtoError>> + Send + 'static)>>;
+    type Response = Pin<Box<(dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + 'static)>>;
     type Error = ProtoError;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response {

--- a/crates/https/src/https_client_stream.rs
+++ b/crates/https/src/https_client_stream.rs
@@ -34,7 +34,7 @@ use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::iocompat::AsyncIoStdAsTokio;
 use trust_dns_proto::tcp::Connect;
 use trust_dns_proto::xfer::{
-    DnsRequest, DnsRequestSender, DnsResponse, DnsResponseFuture, SerialMessage,
+    DnsRequest, DnsRequestSender, DnsResponse, DnsResponseStream, SerialMessage,
 };
 
 const ALPN_H2: &[u8] = b"h2";
@@ -233,7 +233,7 @@ impl DnsRequestSender for HttpsClientStream {
     ///    (Unsupported Media Type) upon receiving a media type it is unable to
     ///    process.
     /// ```
-    fn send_message(&mut self, mut message: DnsRequest) -> DnsResponseFuture {
+    fn send_message(&mut self, mut message: DnsRequest) -> DnsResponseStream {
         if self.is_shutdown {
             panic!("can not send messages after stream is shutdown")
         }

--- a/crates/https/src/https_client_stream.rs
+++ b/crates/https/src/https_client_stream.rs
@@ -528,6 +528,7 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
     use std::str::FromStr;
 
+    use futures_util::stream::StreamExt;
     use rustls::{ClientConfig, KeyLogFile, ProtocolVersion, RootCertStore};
     use tokio::runtime::Runtime;
     use webpki_roots;
@@ -570,7 +571,8 @@ mod tests {
         let mut https = runtime.block_on(connect).expect("https connect failed");
 
         let response = runtime
-            .block_on(https.send_message(request))
+            .block_on(https.send_message(request).next())
+            .expect("stream canceled")
             .expect("send_message failed");
 
         let record = &response.answers()[0];
@@ -594,7 +596,8 @@ mod tests {
 
         for _ in 0..3 {
             let response = runtime
-                .block_on(https.send_message(request.clone()))
+                .block_on(https.send_message(request.clone()).next())
+                .expect("stream canceled")
                 .expect("send_message failed");
             if response.response_code() == ResponseCode::ServFail {
                 continue;
@@ -647,7 +650,8 @@ mod tests {
         let mut https = runtime.block_on(connect).expect("https connect failed");
 
         let response = runtime
-            .block_on(https.send_message(request))
+            .block_on(https.send_message(request).next())
+            .expect("stream canceled")
             .expect("send_message failed");
 
         let record = &response.answers()[0];
@@ -670,7 +674,8 @@ mod tests {
         let request = DnsRequest::new(request, Default::default());
 
         let response = runtime
-            .block_on(https.send_message(request))
+            .block_on(https.send_message(request).next())
+            .expect("stream canceled")
             .expect("send_message failed");
 
         let record = &response.answers()[0];

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -64,6 +64,7 @@ cfg-if = "1"
 data-encoding = "2.2.0"
 enum-as-inner = "0.3"
 futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-core = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 idna = "0.2.0"

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -280,7 +280,6 @@ async fn send_serial_message<S: UdpSocket + Send>(
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
     use crate::tests::udp_client_stream_test;
-    use crate::TokioTime;
     #[cfg(not(target_os = "linux"))]
     use std::net::Ipv6Addr;
     use std::net::{IpAddr, Ipv4Addr};
@@ -289,19 +288,17 @@ mod tests {
     #[test]
     fn test_udp_client_stream_ipv4() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        udp_client_stream_test::<TokioUdpSocket, Runtime, TokioTime>(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            io_loop,
-        )
+        io_loop.block_on(udp_client_stream_test::<TokioUdpSocket>(IpAddr::V4(
+            Ipv4Addr::new(127, 0, 0, 1),
+        )));
     }
 
     #[test]
     #[cfg(not(target_os = "linux"))] // ignored until Travis-CI fixes IPv6
     fn test_udp_client_stream_ipv6() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        udp_client_stream_test::<TokioUdpSocket, Runtime, TokioTime>(
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            io_loop,
-        )
+        io_loop.block_on(udp_client_stream_test::<TokioUdpSocket>(IpAddr::V6(
+            Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+        )));
     }
 }

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -21,7 +21,7 @@ use crate::error::ProtoError;
 use crate::op::message::NoopMessageFinalizer;
 use crate::op::{MessageFinalizer, OpCode};
 use crate::udp::udp_stream::{NextRandomUdpSocket, UdpSocket};
-use crate::xfer::{DnsRequest, DnsRequestSender, DnsResponse, DnsResponseFuture, SerialMessage};
+use crate::xfer::{DnsRequest, DnsRequestSender, DnsResponse, DnsResponseStream, SerialMessage};
 use crate::Time;
 
 /// A UDP client stream of DNS binary packets
@@ -107,7 +107,7 @@ fn random_query_id() -> u16 {
 impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> DnsRequestSender
     for UdpClientStream<S, MF>
 {
-    fn send_message(&mut self, mut message: DnsRequest) -> DnsResponseFuture {
+    fn send_message(&mut self, mut message: DnsRequest) -> DnsResponseStream {
         if self.is_shutdown {
             panic!("can not send messages after stream is shutdown")
         }

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -112,12 +112,12 @@ pub struct DnsExchangeSend {
     _sender: BufDnsRequestStreamHandle,
 }
 
-impl Future for DnsExchangeSend {
-    type Output = Result<DnsResponse, ProtoError>;
+impl Stream for DnsExchangeSend {
+    type Item = Result<DnsResponse, ProtoError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // as long as there is no result, poll the exchange
-        self.result.poll_unpin(cx)
+        self.result.poll_next_unpin(cx)
     }
 }
 

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -9,7 +9,7 @@
 use std::error::Error;
 
 use futures_channel::mpsc;
-use futures_util::future::Future;
+use futures_util::stream::Stream;
 use log::debug;
 use rand;
 
@@ -50,7 +50,7 @@ impl DnsStreamHandle for StreamHandle {
 /// A trait for implementing high level functions of DNS.
 pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
     /// The associated response from the response future, this should resolve to the Response message
-    type Response: Future<Output = Result<DnsResponse, Self::Error>> + Send + Unpin + 'static;
+    type Response: Stream<Item = Result<DnsResponse, Self::Error>> + Send + Unpin + 'static;
     /// Error of the response, generally this will be `ProtoError`
     type Error: From<ProtoError> + Error + Clone + Send + Unpin + 'static;
 

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -28,7 +28,7 @@ use crate::error::*;
 use crate::op::{Message, MessageFinalizer, OpCode};
 use crate::xfer::{
     ignore_send, DnsClientStream, DnsRequest, DnsRequestOptions, DnsRequestSender, DnsResponse,
-    DnsResponseFuture, SerialMessage, CHANNEL_BUFFER_SIZE,
+    DnsResponseStream, SerialMessage, CHANNEL_BUFFER_SIZE,
 };
 use crate::DnsStreamHandle;
 use crate::Time;
@@ -289,7 +289,7 @@ where
     S: DnsClientStream + Unpin + 'static,
     MF: MessageFinalizer + Send + Sync + 'static,
 {
-    fn send_message(&mut self, request: DnsRequest) -> DnsResponseFuture {
+    fn send_message(&mut self, request: DnsRequest) -> DnsResponseStream {
         if self.is_shutdown {
             panic!("can not send messages after stream is shutdown")
         }

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -97,7 +97,7 @@ impl ActiveRequest {
     /// Any error sending will be logged and ignored. This must only be called after associating a response,
     ///   otherwise an error will always be returned.
     /// FIXME: is this necessary after stream API?
-    fn complete(mut self) {
+    fn complete(self) {
         self.channel.close_channel();
     }
 }

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -14,8 +14,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures_channel::mpsc;
-use futures_core::Stream;
 use futures_util::ready;
+use futures_util::stream::Stream;
 
 use crate::error::{ProtoError, ProtoResult};
 use crate::op::{Message, ResponseCode};

--- a/crates/proto/src/xfer/retry_dns_handle.rs
+++ b/crates/proto/src/xfer/retry_dns_handle.rs
@@ -10,7 +10,7 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures_util::future::{Future, FutureExt};
+use futures_util::stream::{Stream, StreamExt};
 
 use crate::error::{ProtoError, ProtoErrorKind};
 use crate::xfer::{DnsRequest, DnsResponse};
@@ -51,7 +51,7 @@ where
     H: DnsHandle + Send + Unpin + 'static,
     H::Error: RetryableError,
 {
-    type Response = Pin<Box<dyn Future<Output = Result<DnsResponse, Self::Error>> + Send + Unpin>>;
+    type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, Self::Error>> + Send + Unpin>>;
     type Error = <H as DnsHandle>::Error;
 
     fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {
@@ -71,6 +71,7 @@ where
 }
 
 /// A future for retrying (on failure, for the remaining number of times specified)
+// FIXME: rename to RetrySendStream
 struct RetrySendFuture<H>
 where
     H: DnsHandle,
@@ -81,20 +82,20 @@ where
     remaining_attempts: usize,
 }
 
-impl<H: DnsHandle + Unpin> Future for RetrySendFuture<H>
+impl<H: DnsHandle + Unpin> Stream for RetrySendFuture<H>
 where
     <H as DnsHandle>::Error: RetryableError,
 {
-    type Output = Result<DnsResponse, <H as DnsHandle>::Error>;
+    type Item = Result<DnsResponse, <H as DnsHandle>::Error>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // loop over the future, on errors, spawn a new future
         //  on ready and not ready return.
         loop {
-            match self.future.poll_unpin(cx) {
-                Poll::Ready(Err(e)) => {
+            match self.future.poll_next_unpin(cx) {
+                Poll::Ready(Some(Err(e))) => {
                     if self.remaining_attempts == 0 || !e.should_retry() {
-                        return Poll::Ready(Err(e));
+                        return Poll::Ready(Some(Err(e)));
                     }
 
                     if e.attempted() {
@@ -137,6 +138,7 @@ mod test {
     use crate::op::*;
     use futures_executor::block_on;
     use futures_util::future::*;
+    use futures_util::stream;
     use std::sync::{
         atomic::{AtomicU16, Ordering},
         Arc,
@@ -151,7 +153,7 @@ mod test {
     }
 
     impl DnsHandle for TestClient {
-        type Response = Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send + Unpin>;
+        type Response = Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin>;
         type Error = ProtoError;
 
         fn send<R: Into<DnsRequest>>(&mut self, _: R) -> Self::Response {
@@ -160,11 +162,13 @@ mod test {
             if (i > self.retries || self.retries - i == 0) && self.last_succeed {
                 let mut message = Message::new();
                 message.set_id(i);
-                return Box::new(ok(message.into()));
+                return Box::new(stream::once(ok(message.into())));
             }
 
             self.attempts.fetch_add(1, Ordering::SeqCst);
-            Box::new(err(ProtoError::from("last retry set to fail")))
+            Box::new(stream::once(err(ProtoError::from(
+                "last retry set to fail",
+            ))))
         }
     }
 
@@ -179,7 +183,9 @@ mod test {
             2,
         );
         let test1 = Message::new();
-        let result = block_on(handle.send(test1)).expect("should have succeeded");
+        let result = block_on(handle.send(test1).next())
+            .expect("no message returned")
+            .expect("should have succeeded");
         assert_eq!(result.id(), 1); // this is checking the number of iterations the TestClient ran
     }
 
@@ -194,6 +200,8 @@ mod test {
             2,
         );
         let test1 = Message::new();
-        assert!(block_on(client.send(test1)).is_err());
+        assert!(block_on(client.send(test1).next())
+            .expect("expected error result")
+            .is_err());
     }
 }

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 use futures_util::future::Future;
 
 use proto::error::ProtoError;
-use proto::op::{Message, Query, ResponseCode};
+use proto::op::{Query, ResponseCode};
 use proto::rr::domain::usage::{
     ResolverUsage, DEFAULT, INVALID, IN_ADDR_ARPA_127, IP6_ARPA_1, LOCAL,
     LOCALHOST as LOCALHOST_usage,
@@ -328,7 +328,7 @@ where
                     // For SRV, the name added for the search becomes the target name.
                     //
                     // TODO: should this include the additionals?
-                    response.messages().flat_map(Message::answers).fold(
+                    response.message().answers().iter().fold(
                         (Cow::Borrowed(query.name()), INITIAL_TTL, false),
                         |(search_name, cname_ttl, was_cname), r| {
                             match *r.rdata() {
@@ -357,18 +357,9 @@ where
                 };
 
             // take all answers. // TODO: following CNAMES?
-            let answers: Vec<Record> = response
-                .messages_mut()
-                .flat_map(Message::take_answers)
-                .collect();
-            let additionals: Vec<Record> = response
-                .messages_mut()
-                .flat_map(Message::take_additionals)
-                .collect();
-            let name_servers: Vec<Record> = response
-                .messages_mut()
-                .flat_map(Message::take_name_servers)
-                .collect();
+            let answers: Vec<Record> = response.message_mut().take_answers();
+            let additionals: Vec<Record> = response.message_mut().take_additionals();
+            let name_servers: Vec<Record> = response.message_mut().take_name_servers();
 
             // set of names that still require resolution
             // TODO: this needs to be enhanced for SRV


### PR DESCRIPTION
Migrate resolver to streaming API

- [x] remove SmallVec from DNSResponse
- [ ] Change DnsHandle to return Stream on `send`
- [ ] Use channel instead of oneshot for DnsResponseFuture
- [ ] Introduce Resolver streaming API
- [ ] Deprecate old Resolver API?

fixes: #383

See discussion on common DNS api for Reqwest here: https://github.com/seanmonstar/reqwest/issues/1125