### PR TITLE
Fix typo

### DIFF
--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -479,7 +479,7 @@ impl Name {
         Self::from_encoded_str::<LabelEncUtf8>(name.as_ref(), None)
     }
 
-    /// First attempts to decode via `from_utf8`, if that fails IDNA checks, than falls back to
+    /// First attempts to decode via `from_utf8`, if that fails IDNA checks, then falls back to
     /// ascii decoding.
     ///
     /// # Examples


### PR DESCRIPTION
Hi, I'm using this crate to introduce DNS lookup functionality to Deno(TypeScript/JavaScript runtime written in Rust).
When I read through the documentation of `trust_dns_proto`, I noticed there was a typo that confused me a bit. This PR just fixes it :)