### PR TITLE
[async-std-resolver] Re-export AsyncStdConnection(Provider)

### DIFF
--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -80,8 +80,8 @@
 
 use trust_dns_resolver::AsyncResolver;
 
-use crate::runtime::AsyncStdConnection;
-use crate::runtime::AsyncStdConnectionProvider;
+pub use crate::runtime::AsyncStdConnection;
+pub use crate::runtime::AsyncStdConnectionProvider;
 use crate::runtime::AsyncStdRuntimeHandle;
 
 mod net;


### PR DESCRIPTION
Analogous to the definition of [`TokioAsyncResolver`](https://docs.rs/trust-dns-resolver/0.20.0/trust_dns_resolver/type.TokioAsyncResolver.html) with re-exported `TokioConnection` and `TokioConnectionProvider`, it would be useful to have `AsyncStdConnection` and `AsyncStdConnectionProvider` re-exported in the public API of `async-std-resolver`, so that types like this
```rust
struct Foo<C, P> {
   // ...
   resolver: AsyncResolver<C, P>
}
```
can be instantiated via
```rust
type AsyncStdFoo = Foo<AsyncStdConnection, AsyncStdConnectionProvider>;
```