### PR TITLE
Don't kill a DnsExchangeBackground if a receiver is gone (see #1276)

### DIFF
--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -192,14 +192,14 @@ where
                     // if there is no peer, this connection should die...
                     let (dns_request, serial_response): (DnsRequest, _) = dns_request.into_parts();
 
+                    // Try to forward the `DnsResponseFuture` to the requesting task. If we fail,
+                    // it must be because the requesting task has gone away / is no longer
+                    // interested. In that case, we can just log a warning, but there's no need
+                    // to take any more serious measures (such as shutting down this task).
                     match serial_response.send_response(io_stream.send_message(dns_request)) {
                         Ok(()) => (),
                         Err(_) => {
                             warn!("failed to associate send_message response to the sender");
-
-                            return Poll::Ready(Err(
-                                "failed to associate send_message response to the sender".into(),
-                            ));
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #1276 