### PR TITLE
Enable RuntimeProvider in DoT implementations

### DIFF
--- a/bin/tests/named_openssl_tests.rs
+++ b/bin/tests/named_openssl_tests.rs
@@ -22,12 +22,14 @@ use std::io::*;
 use std::net::*;
 
 use native_tls::Certificate;
+use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 
 use trust_dns_client::client::*;
 use trust_dns_native_tls::TlsClientStreamBuilder;
 
 use server_harness::{named_test_harness, query_a};
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 
 #[test]
 fn test_example_tls_toml_startup() {
@@ -59,7 +61,8 @@ fn test_startup(toml: &'static str) {
             .unwrap()
             .next()
             .unwrap();
-        let mut tls_conn_builder = TlsClientStreamBuilder::new();
+        let mut tls_conn_builder =
+            TlsClientStreamBuilder::<AsyncIoTokioAsStd<TokioTcpStream>>::new();
         let cert = to_trust_anchor(&cert_der);
         tls_conn_builder.add_ca(cert);
         let (stream, sender) = tls_conn_builder.build(addr, "ns.example.com".to_string());
@@ -74,7 +77,8 @@ fn test_startup(toml: &'static str) {
             .unwrap()
             .next()
             .unwrap();
-        let mut tls_conn_builder = TlsClientStreamBuilder::new();
+        let mut tls_conn_builder =
+            TlsClientStreamBuilder::<AsyncIoTokioAsStd<TokioTcpStream>>::new();
         let cert = to_trust_anchor(&cert_der);
         tls_conn_builder.add_ca(cert);
         let (stream, sender) = tls_conn_builder.build(addr, "ns.example.com".to_string());

--- a/crates/native-tls/src/tests.rs
+++ b/crates/native-tls/src/tests.rs
@@ -26,8 +26,8 @@ use std::{thread, time};
 use futures_util::stream::StreamExt;
 use native_tls;
 use native_tls::{Certificate, TlsAcceptor};
-use tokio::runtime::Runtime;
 use tokio::net::TcpStream as TokioTcpStream;
+use tokio::runtime::Runtime;
 
 use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, xfer::SerialMessage};
 

--- a/crates/native-tls/src/tests.rs
+++ b/crates/native-tls/src/tests.rs
@@ -29,7 +29,8 @@ use native_tls::{Certificate, TlsAcceptor};
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 
-use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, xfer::SerialMessage};
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
+use trust_dns_proto::xfer::SerialMessage;
 
 #[allow(clippy::useless_attribute)]
 #[allow(unused)]

--- a/crates/native-tls/src/tests.rs
+++ b/crates/native-tls/src/tests.rs
@@ -27,8 +27,9 @@ use futures_util::stream::StreamExt;
 use native_tls;
 use native_tls::{Certificate, TlsAcceptor};
 use tokio::runtime::Runtime;
+use tokio::net::TcpStream as TokioTcpStream;
 
-use trust_dns_proto::xfer::SerialMessage;
+use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, xfer::SerialMessage};
 
 #[allow(clippy::useless_attribute)]
 #[allow(unused)]
@@ -193,7 +194,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     let trust_chain = Certificate::from_der(&root_cert_der).unwrap();
 
     // barrier.wait();
-    let mut builder = TlsStreamBuilder::new();
+    let mut builder = TlsStreamBuilder::<AsyncIoTokioAsStd<TokioTcpStream>>::new();
     builder.add_ca(trust_chain);
 
     // fix MTLS

--- a/crates/native-tls/src/tls_client_stream.rs
+++ b/crates/native-tls/src/tls_client_stream.rs
@@ -17,9 +17,10 @@ use native_tls::Certificate;
 use native_tls::Pkcs12;
 use tokio_native_tls::TlsStream as TokioTlsStream;
 
-use trust_dns_proto::{error::ProtoError, iocompat::AsyncIoStdAsTokio, tcp::Connect};
+use trust_dns_proto::error::ProtoError;
+use trust_dns_proto::iocompat::AsyncIoStdAsTokio;
 use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
-use trust_dns_proto::tcp::TcpClientStream;
+use trust_dns_proto::tcp::{Connect, TcpClientStream};
 use trust_dns_proto::xfer::BufDnsStreamHandle;
 
 use crate::TlsStreamBuilder;
@@ -27,7 +28,8 @@ use crate::TlsStreamBuilder;
 /// TlsClientStream secure DNS over TCP stream
 ///
 /// See TlsClientStreamBuilder::new()
-pub type TlsClientStream<S> = TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<AsyncIoStdAsTokio<S>>>>;
+pub type TlsClientStream<S> =
+    TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<AsyncIoStdAsTokio<S>>>>;
 
 /// Builder for TlsClientStream
 pub struct TlsClientStreamBuilder<S>(TlsStreamBuilder<S>);

--- a/crates/native-tls/src/tls_client_stream.rs
+++ b/crates/native-tls/src/tls_client_stream.rs
@@ -15,10 +15,9 @@ use futures_util::TryFutureExt;
 use native_tls::Certificate;
 #[cfg(feature = "mtls")]
 use native_tls::Pkcs12;
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio_native_tls::TlsStream as TokioTlsStream;
 
-use trust_dns_proto::error::ProtoError;
+use trust_dns_proto::{error::ProtoError, iocompat::AsyncIoStdAsTokio, tcp::Connect};
 use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 use trust_dns_proto::tcp::TcpClientStream;
 use trust_dns_proto::xfer::BufDnsStreamHandle;
@@ -28,14 +27,14 @@ use crate::TlsStreamBuilder;
 /// TlsClientStream secure DNS over TCP stream
 ///
 /// See TlsClientStreamBuilder::new()
-pub type TlsClientStream = TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<TokioTcpStream>>>;
+pub type TlsClientStream<S> = TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<AsyncIoStdAsTokio<S>>>>;
 
 /// Builder for TlsClientStream
-pub struct TlsClientStreamBuilder(TlsStreamBuilder);
+pub struct TlsClientStreamBuilder<S>(TlsStreamBuilder<S>);
 
-impl TlsClientStreamBuilder {
+impl<S: Connect> TlsClientStreamBuilder<S> {
     /// Creates a builder fo the construction of a TlsClientStream
-    pub fn new() -> TlsClientStreamBuilder {
+    pub fn new() -> TlsClientStreamBuilder<S> {
         TlsClientStreamBuilder(TlsStreamBuilder::new())
     }
 
@@ -64,7 +63,7 @@ impl TlsClientStreamBuilder {
         name_server: SocketAddr,
         dns_name: String,
     ) -> (
-        Pin<Box<dyn Future<Output = Result<TlsClientStream, ProtoError>> + Send>>,
+        Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
         BufDnsStreamHandle,
     ) {
         let (stream_future, sender) = self.0.build(name_server, dns_name);
@@ -81,7 +80,7 @@ impl TlsClientStreamBuilder {
     }
 }
 
-impl Default for TlsClientStreamBuilder {
+impl<S: Connect> Default for TlsClientStreamBuilder<S> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/native-tls/src/tls_stream.rs
+++ b/crates/native-tls/src/tls_stream.rs
@@ -7,23 +7,25 @@
 
 //! Base TlsStream
 
-use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::{future::Future, marker::PhantomData};
 
 use futures_util::TryFutureExt;
 use native_tls::Protocol::Tlsv12;
 use native_tls::{Certificate, Identity, TlsConnector};
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio_native_tls::{TlsConnector as TokioTlsConnector, TlsStream as TokioTlsStream};
 
-use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
-use trust_dns_proto::tcp::{self, TcpStream};
+use trust_dns_proto::tcp::TcpStream;
 use trust_dns_proto::xfer::{BufStreamHandle, StreamReceiver};
+use trust_dns_proto::{
+    iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd},
+    tcp::Connect,
+};
 
 /// A TlsStream counterpart to the TcpStream which embeds a secure TlsStream
-pub type TlsStream = TcpStream<AsyncIoTokioAsStd<TokioTlsStream<TokioTcpStream>>>;
+pub type TlsStream<S> = TcpStream<AsyncIoTokioAsStd<TokioTlsStream<AsyncIoStdAsTokio<S>>>>;
 
 fn tls_new(certs: Vec<Certificate>, pkcs12: Option<Identity>) -> io::Result<TlsConnector> {
     let mut builder = TlsConnector::builder();
@@ -47,10 +49,10 @@ fn tls_new(certs: Vec<Certificate>, pkcs12: Option<Identity>) -> io::Result<TlsC
 /// Initializes a TlsStream with an existing tokio_tls::TlsStream.
 ///
 /// This is intended for use with a TlsListener and Incoming connections
-pub fn tls_from_stream(
-    stream: TokioTlsStream<TokioTcpStream>,
+pub fn tls_from_stream<S: Connect>(
+    stream: TokioTlsStream<AsyncIoStdAsTokio<S>>,
     peer_addr: SocketAddr,
-) -> (TlsStream, BufStreamHandle) {
+) -> (TlsStream<S>, BufStreamHandle) {
     let (message_sender, outbound_messages) = BufStreamHandle::create();
 
     let stream = TcpStream::from_stream_with_receiver(
@@ -64,17 +66,19 @@ pub fn tls_from_stream(
 
 /// A builder for the TlsStream
 #[derive(Default)]
-pub struct TlsStreamBuilder {
+pub struct TlsStreamBuilder<S> {
     ca_chain: Vec<Certificate>,
     identity: Option<Identity>,
+    marker: PhantomData<S>,
 }
 
-impl TlsStreamBuilder {
+impl<S: Connect> TlsStreamBuilder<S> {
     /// Constructs a new TlsStreamBuilder
-    pub fn new() -> TlsStreamBuilder {
+    pub fn new() -> TlsStreamBuilder<S> {
         TlsStreamBuilder {
             ca_chain: vec![],
             identity: None,
+            marker: PhantomData,
         }
     }
 
@@ -123,7 +127,7 @@ impl TlsStreamBuilder {
         dns_name: String,
     ) -> (
         // TODO: change to impl?
-        Pin<Box<dyn Future<Output = Result<TlsStream, io::Error>> + Send>>,
+        Pin<Box<dyn Future<Output = Result<TlsStream<S>, io::Error>> + Send>>,
         BufStreamHandle,
     ) {
         let (message_sender, outbound_messages) = BufStreamHandle::create();
@@ -137,17 +141,17 @@ impl TlsStreamBuilder {
         name_server: SocketAddr,
         dns_name: String,
         outbound_messages: StreamReceiver,
-    ) -> Result<TlsStream, io::Error> {
+    ) -> Result<TlsStream<S>, io::Error> {
         use crate::tls_stream;
 
         let ca_chain = self.ca_chain.clone();
         let identity = self.identity;
 
-        let tcp_stream = tcp::tokio::connect(&name_server).await;
+        let tcp_stream = S::connect(name_server).await;
 
         // TODO: for some reason the above wouldn't accept a ?
         let tcp_stream = match tcp_stream {
-            Ok(tcp_stream) => tcp_stream,
+            Ok(tcp_stream) => AsyncIoStdAsTokio(tcp_stream),
             Err(err) => return Err(err),
         };
 

--- a/crates/native-tls/src/tls_stream.rs
+++ b/crates/native-tls/src/tls_stream.rs
@@ -17,12 +17,10 @@ use native_tls::Protocol::Tlsv12;
 use native_tls::{Certificate, Identity, TlsConnector};
 use tokio_native_tls::{TlsConnector as TokioTlsConnector, TlsStream as TokioTlsStream};
 
+use trust_dns_proto::iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd};
+use trust_dns_proto::tcp::Connect;
 use trust_dns_proto::tcp::TcpStream;
 use trust_dns_proto::xfer::{BufStreamHandle, StreamReceiver};
-use trust_dns_proto::{
-    iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd},
-    tcp::Connect,
-};
 
 /// A TlsStream counterpart to the TcpStream which embeds a secure TlsStream
 pub type TlsStream<S> = TcpStream<AsyncIoTokioAsStd<TokioTlsStream<AsyncIoStdAsTokio<S>>>>;

--- a/crates/openssl/src/tls_stream.rs
+++ b/crates/openssl/src/tls_stream.rs
@@ -5,10 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::{future::Future, marker::PhantomData};
 
 use futures_util::{future, TryFutureExt};
 use openssl::pkcs12::ParsedPkcs12;
@@ -17,12 +17,14 @@ use openssl::ssl::{ConnectConfiguration, SslConnector, SslContextBuilder, SslMet
 use openssl::stack::Stack;
 use openssl::x509::store::X509StoreBuilder;
 use openssl::x509::{X509Ref, X509};
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio_openssl::{self, SslStream as TokioTlsStream};
 
-use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
-use trust_dns_proto::tcp::{self, TcpStream};
+use trust_dns_proto::tcp::TcpStream;
 use trust_dns_proto::xfer::BufStreamHandle;
+use trust_dns_proto::{
+    iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd},
+    tcp::Connect,
+};
 
 pub trait TlsIdentityExt {
     fn identity(&mut self, pkcs12: &ParsedPkcs12) -> io::Result<()> {
@@ -57,7 +59,8 @@ impl TlsIdentityExt for SslContextBuilder {
 }
 
 /// A TlsStream counterpart to the TcpStream which embeds a secure TlsStream
-pub type TlsStream = TcpStream<AsyncIoTokioAsStd<TokioTlsStream<TokioTcpStream>>>;
+pub type TlsStream<S> = TcpStream<AsyncIoTokioAsStd<TokioTlsStream<S>>>;
+pub type CompatTlsStream<S> = TlsStream<AsyncIoStdAsTokio<S>>;
 
 fn new(certs: Vec<X509>, pkcs12: Option<ParsedPkcs12>) -> io::Result<SslConnector> {
     let mut tls = SslConnector::builder(SslMethod::tls()).map_err(|e| {
@@ -115,21 +118,21 @@ fn new(certs: Vec<X509>, pkcs12: Option<ParsedPkcs12>) -> io::Result<SslConnecto
 /// Initializes a TlsStream with an existing tokio_tls::TlsStream.
 ///
 /// This is intended for use with a TlsListener and Incoming connections
-pub fn tls_stream_from_existing_tls_stream(
-    stream: AsyncIoTokioAsStd<TokioTlsStream<TokioTcpStream>>,
+pub fn tls_stream_from_existing_tls_stream<S: Connect>(
+    stream: AsyncIoTokioAsStd<TokioTlsStream<AsyncIoStdAsTokio<S>>>,
     peer_addr: SocketAddr,
-) -> (TlsStream, BufStreamHandle) {
+) -> (CompatTlsStream<S>, BufStreamHandle) {
     let (message_sender, outbound_messages) = BufStreamHandle::create();
     let stream = TcpStream::from_stream_with_receiver(stream, peer_addr, outbound_messages);
     (stream, message_sender)
 }
 
-async fn connect_tls(
+async fn connect_tls<S: Connect>(
     tls_config: ConnectConfiguration,
     dns_name: String,
     name_server: SocketAddr,
-) -> Result<TokioTlsStream<TokioTcpStream>, io::Error> {
-    let tcp = tcp::tokio::connect(&name_server).await.map_err(|e| {
+) -> Result<TokioTlsStream<AsyncIoStdAsTokio<S>>, io::Error> {
+    let tcp = S::connect(name_server).await.map_err(|e| {
         io::Error::new(
             io::ErrorKind::ConnectionRefused,
             format!("tls error: {}", e),
@@ -137,7 +140,7 @@ async fn connect_tls(
     })?;
     let mut stream = tls_config
         .into_ssl(&dns_name)
-        .and_then(|ssl| TokioTlsStream::new(ssl, tcp))
+        .and_then(|ssl| TokioTlsStream::new(ssl, AsyncIoStdAsTokio(tcp)))
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("tls error: {}", e)))?;
     Pin::new(&mut stream).connect().await.map_err(|e| {
         io::Error::new(
@@ -150,17 +153,19 @@ async fn connect_tls(
 
 /// A builder for the TlsStream
 #[derive(Default)]
-pub struct TlsStreamBuilder {
+pub struct TlsStreamBuilder<S> {
     ca_chain: Vec<X509>,
     identity: Option<ParsedPkcs12>,
+    marker: PhantomData<S>,
 }
 
-impl TlsStreamBuilder {
+impl<S: Connect> TlsStreamBuilder<S> {
     /// A builder for associating trust information to the `TlsStream`.
     pub fn new() -> Self {
         TlsStreamBuilder {
             ca_chain: vec![],
             identity: None,
+            marker: PhantomData,
         }
     }
 
@@ -208,7 +213,7 @@ impl TlsStreamBuilder {
         name_server: SocketAddr,
         dns_name: String,
     ) -> (
-        Pin<Box<dyn Future<Output = Result<TlsStream, io::Error>> + Send>>,
+        Pin<Box<dyn Future<Output = Result<CompatTlsStream<S>, io::Error>> + Send>>,
         BufStreamHandle,
     ) {
         let (message_sender, outbound_messages) = BufStreamHandle::create();

--- a/crates/openssl/src/tls_stream.rs
+++ b/crates/openssl/src/tls_stream.rs
@@ -19,12 +19,10 @@ use openssl::x509::store::X509StoreBuilder;
 use openssl::x509::{X509Ref, X509};
 use tokio_openssl::{self, SslStream as TokioTlsStream};
 
+use trust_dns_proto::iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd};
+use trust_dns_proto::tcp::Connect;
 use trust_dns_proto::tcp::TcpStream;
 use trust_dns_proto::xfer::BufStreamHandle;
-use trust_dns_proto::{
-    iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd},
-    tcp::Connect,
-};
 
 pub trait TlsIdentityExt {
     fn identity(&mut self, pkcs12: &ParsedPkcs12) -> io::Result<()> {

--- a/crates/openssl/tests/openssl_tests.rs
+++ b/crates/openssl/tests/openssl_tests.rs
@@ -30,7 +30,9 @@ use openssl::pkcs12::*;
 use openssl::rsa::*;
 use openssl::x509::extension::*;
 
-use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, tcp::Connect, xfer::SerialMessage};
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
+use trust_dns_proto::tcp::Connect;
+use trust_dns_proto::xfer::SerialMessage;
 
 use trust_dns_openssl::TlsStreamBuilder;
 

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -158,7 +158,7 @@ where
                 let (stream, handle) =
                     { crate::tls::new_tls_stream::<R>(socket_addr, tls_dns_name, client_config) };
                 #[cfg(not(feature = "dns-over-rustls"))]
-                let (stream, handle) = { crate::tls::new_tls_stream(socket_addr, tls_dns_name) };
+                let (stream, handle) = { crate::tls::new_tls_stream::<R>(socket_addr, tls_dns_name) };
 
                 let dns_conn = DnsMultiplexer::with_timeout(
                     stream,

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -28,10 +28,7 @@ use proto;
 use proto::error::ProtoError;
 
 #[cfg(feature = "tokio-runtime")]
-use proto::{
-    iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd},
-    TokioTime,
-};
+use proto::{iocompat::AsyncIoTokioAsStd, TokioTime};
 
 #[cfg(feature = "mdns")]
 use proto::multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType};
@@ -158,7 +155,8 @@ where
                 let (stream, handle) =
                     { crate::tls::new_tls_stream::<R>(socket_addr, tls_dns_name, client_config) };
                 #[cfg(not(feature = "dns-over-rustls"))]
-                let (stream, handle) = { crate::tls::new_tls_stream::<R>(socket_addr, tls_dns_name) };
+                let (stream, handle) =
+                    { crate::tls::new_tls_stream::<R>(socket_addr, tls_dns_name) };
 
                 let dns_conn = DnsMultiplexer::with_timeout(
                     stream,
@@ -210,7 +208,7 @@ where
 
 #[cfg(feature = "dns-over-tls")]
 /// Predefined type for TLS client stream
-type TlsClientStream<S> = TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<AsyncIoStdAsTokio<S>>>>;
+type TlsClientStream<S> = TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<proto::iocompat::AsyncIoStdAsTokio<S>>>>;
 
 /// The variants of all supported connections for the Resolver
 #[allow(clippy::large_enum_variant, clippy::type_complexity)]

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -208,7 +208,8 @@ where
 
 #[cfg(feature = "dns-over-tls")]
 /// Predefined type for TLS client stream
-type TlsClientStream<S> = TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<proto::iocompat::AsyncIoStdAsTokio<S>>>>;
+type TlsClientStream<S> =
+    TcpClientStream<AsyncIoTokioAsStd<TokioTlsStream<proto::iocompat::AsyncIoStdAsTokio<S>>>>;
 
 /// The variants of all supported connections for the Resolver
 #[allow(clippy::large_enum_variant, clippy::type_complexity)]

--- a/crates/resolver/src/tls/dns_over_native_tls.rs
+++ b/crates/resolver/src/tls/dns_over_native_tls.rs
@@ -17,12 +17,14 @@ use proto::error::ProtoError;
 use proto::BufDnsStreamHandle;
 use trust_dns_native_tls::{TlsClientStream, TlsClientStreamBuilder};
 
+use crate::name_server::RuntimeProvider;
+
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_tls_stream(
+pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
     dns_name: String,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream, ProtoError>> + Send>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
     let tls_builder = TlsClientStreamBuilder::new();

--- a/crates/resolver/src/tls/dns_over_openssl.rs
+++ b/crates/resolver/src/tls/dns_over_openssl.rs
@@ -17,12 +17,14 @@ use proto::error::ProtoError;
 use proto::BufDnsStreamHandle;
 use trust_dns_openssl::{TlsClientStream, TlsClientStreamBuilder};
 
+use crate::name_server::RuntimeProvider;
+
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_tls_stream(
+pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
     dns_name: String,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream, ProtoError>> + Send>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
     let tls_builder = TlsClientStreamBuilder::new();

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -19,6 +19,7 @@ use proto::error::ProtoError;
 use proto::BufDnsStreamHandle;
 use trust_dns_rustls::{tls_client_connect, TlsClientStream};
 
+use crate::name_server::RuntimeProvider;
 use crate::config::TlsClientConfig;
 
 const ALPN_H2: &[u8] = b"h2";
@@ -40,12 +41,12 @@ lazy_static! {
 }
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_tls_stream(
+pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream, ProtoError>> + Send>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
     let client_config = client_config.map_or_else(

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -19,8 +19,8 @@ use proto::error::ProtoError;
 use proto::BufDnsStreamHandle;
 use trust_dns_rustls::{tls_client_connect, TlsClientStream};
 
-use crate::name_server::RuntimeProvider;
 use crate::config::TlsClientConfig;
+use crate::name_server::RuntimeProvider;
 
 const ALPN_H2: &[u8] = b"h2";
 

--- a/crates/rustls/src/tests.rs
+++ b/crates/rustls/src/tests.rs
@@ -26,9 +26,9 @@ use openssl::x509::*;
 use futures_util::stream::StreamExt;
 use rustls::Certificate;
 use rustls::ClientConfig;
-use tokio::runtime::Runtime;
+use tokio::{net::TcpStream as TokioTcpStream, runtime::Runtime};
 
-use trust_dns_proto::xfer::SerialMessage;
+use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, xfer::SerialMessage};
 
 use crate::tls_connect;
 
@@ -214,7 +214,11 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     //     config_mtls(&root_pkey, &root_name, &root_cert, &mut builder);
     // }
 
-    let (stream, mut sender) = tls_connect(server_addr, dns_name.to_string(), Arc::new(config));
+    let (stream, mut sender) = tls_connect::<AsyncIoTokioAsStd<TokioTcpStream>>(
+        server_addr,
+        dns_name.to_string(),
+        Arc::new(config),
+    );
 
     // TODO: there is a race failure here... a race with the server thread most likely...
     let mut stream = io_loop.block_on(stream).expect("run failed to get stream");

--- a/crates/rustls/src/tests.rs
+++ b/crates/rustls/src/tests.rs
@@ -26,9 +26,11 @@ use openssl::x509::*;
 use futures_util::stream::StreamExt;
 use rustls::Certificate;
 use rustls::ClientConfig;
-use tokio::{net::TcpStream as TokioTcpStream, runtime::Runtime};
+use tokio::net::TcpStream as TokioTcpStream;
+use tokio::runtime::Runtime;
 
-use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, xfer::SerialMessage};
+use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
+use trust_dns_proto::xfer::SerialMessage;
 
 use crate::tls_connect;
 

--- a/crates/rustls/src/tls_client_stream.rs
+++ b/crates/rustls/src/tls_client_stream.rs
@@ -15,9 +15,10 @@ use std::sync::Arc;
 use futures_util::TryFutureExt;
 use rustls::ClientConfig;
 
-use trust_dns_proto::{error::ProtoError, iocompat::AsyncIoStdAsTokio, tcp::Connect};
+use trust_dns_proto::error::ProtoError;
+use trust_dns_proto::iocompat::AsyncIoStdAsTokio;
 use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
-use trust_dns_proto::tcp::TcpClientStream;
+use trust_dns_proto::tcp::{Connect, TcpClientStream};
 use trust_dns_proto::xfer::BufDnsStreamHandle;
 
 use crate::tls_stream::tls_connect;

--- a/crates/rustls/src/tls_stream.rs
+++ b/crates/rustls/src/tls_stream.rs
@@ -20,12 +20,10 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio_rustls::TlsConnector;
 use webpki::{DNSName, DNSNameRef};
 
+use trust_dns_proto::iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd};
+use trust_dns_proto::tcp::Connect;
 use trust_dns_proto::tcp::{DnsTcpStream, TcpStream};
 use trust_dns_proto::xfer::{BufStreamHandle, StreamReceiver};
-use trust_dns_proto::{
-    iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd},
-    tcp::Connect,
-};
 
 /// Predefined type for abstracting the TlsClientStream with TokioTls
 pub type TokioTlsClientStream<S> = tokio_rustls::client::TlsStream<AsyncIoStdAsTokio<S>>;

--- a/tests/integration-tests/src/tls_client_connection.rs
+++ b/tests/integration-tests/src/tls_client_connection.rs
@@ -16,8 +16,9 @@ use futures::Future;
 
 use trust_dns_client::client::ClientConnection;
 use trust_dns_client::rr::dnssec::Signer;
+use trust_dns_proto::error::ProtoError;
+use trust_dns_proto::tcp::Connect;
 use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect};
-use trust_dns_proto::{error::ProtoError, tcp::Connect};
 
 use rustls::ClientConfig;
 use trust_dns_rustls::{tls_client_connect, TlsClientStream};

--- a/tests/integration-tests/src/tls_client_connection.rs
+++ b/tests/integration-tests/src/tls_client_connection.rs
@@ -8,16 +8,16 @@
 //! TLS based DNS client connection for Client impls
 //! TODO: This modules was moved from trust-dns-rustls, it really doesn't need to exist if tests are refactored...
 
-use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::{marker::PhantomData, net::SocketAddr};
 
 use futures::Future;
 
 use trust_dns_client::client::ClientConnection;
 use trust_dns_client::rr::dnssec::Signer;
-use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect};
+use trust_dns_proto::{error::ProtoError, tcp::Connect};
 
 use rustls::ClientConfig;
 use trust_dns_rustls::{tls_client_connect, TlsClientStream};
@@ -25,14 +25,15 @@ use trust_dns_rustls::{tls_client_connect, TlsClientStream};
 /// Tls client connection
 ///
 /// Use with `trust_dns_client::client::Client` impls
-pub struct TlsClientConnection {
+pub struct TlsClientConnection<T> {
     name_server: SocketAddr,
     dns_name: String,
     client_config: Arc<ClientConfig>,
+    marker: PhantomData<T>,
 }
 
 #[cfg(all(feature = "dns-over-openssl", not(feature = "dns-over-rustls")))]
-impl TlsClientConnection {
+impl<T> TlsClientConnection<T> {
     pub fn new(
         name_server: SocketAddr,
         dns_name: String,
@@ -42,16 +43,17 @@ impl TlsClientConnection {
             name_server,
             dns_name,
             client_config,
+            marker: PhantomData,
         }
     }
 }
 
 #[allow(clippy::type_complexity)]
-impl ClientConnection for TlsClientConnection {
-    type Sender = DnsMultiplexer<TlsClientStream, Signer>;
+impl<T: Connect> ClientConnection for TlsClientConnection<T> {
+    type Sender = DnsMultiplexer<TlsClientStream<T>, Signer>;
     type SenderFuture = DnsMultiplexerConnect<
-        Pin<Box<dyn Future<Output = Result<TlsClientStream, ProtoError>> + Send>>,
-        TlsClientStream,
+        Pin<Box<dyn Future<Output = Result<TlsClientStream<T>, ProtoError>> + Send>>,
+        TlsClientStream<T>,
         Signer,
     >;
 

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use futures::{future, Future, FutureExt};
 use tokio::net::TcpListener;
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio::net::UdpSocket;
 use tokio::runtime::Runtime;
 
@@ -16,8 +15,8 @@ use trust_dns_client::op::*;
 use trust_dns_client::rr::*;
 use trust_dns_client::tcp::TcpClientConnection;
 use trust_dns_client::udp::UdpClientConnection;
+use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::DnsRequestSender;
-use trust_dns_proto::{error::ProtoError, iocompat::AsyncIoTokioAsStd};
 
 use trust_dns_server::authority::{Authority, Catalog};
 use trust_dns_server::ServerFuture;
@@ -199,7 +198,7 @@ fn lazy_tls_client(
     ipaddr: SocketAddr,
     dns_name: String,
     cert_der: Vec<u8>,
-) -> TlsClientConnection<AsyncIoTokioAsStd<TokioTcpStream>> {
+) -> TlsClientConnection<trust_dns_proto::iocompat::AsyncIoTokioAsStd<tokio::net::TcpStream>> {
     use rustls::{Certificate, ClientConfig};
 
     let trust_chain = Certificate(cert_der);

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use futures::{future, Future, FutureExt};
 use tokio::net::TcpListener;
+use tokio::net::TcpStream as TokioTcpStream;
 use tokio::net::UdpSocket;
 use tokio::runtime::Runtime;
 
@@ -15,8 +16,8 @@ use trust_dns_client::op::*;
 use trust_dns_client::rr::*;
 use trust_dns_client::tcp::TcpClientConnection;
 use trust_dns_client::udp::UdpClientConnection;
-use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::DnsRequestSender;
+use trust_dns_proto::{error::ProtoError, iocompat::AsyncIoTokioAsStd};
 
 use trust_dns_server::authority::{Authority, Catalog};
 use trust_dns_server::ServerFuture;
@@ -194,7 +195,11 @@ fn lazy_tcp_client(ipaddr: SocketAddr) -> TcpClientConnection {
 }
 
 #[cfg(all(feature = "dns-over-openssl", not(feature = "dns-over-rustls")))]
-fn lazy_tls_client(ipaddr: SocketAddr, dns_name: String, cert_der: Vec<u8>) -> TlsClientConnection {
+fn lazy_tls_client(
+    ipaddr: SocketAddr,
+    dns_name: String,
+    cert_der: Vec<u8>,
+) -> TlsClientConnection<AsyncIoTokioAsStd<TokioTcpStream>> {
     use rustls::{Certificate, ClientConfig};
 
     let trust_chain = Certificate(cert_der);


### PR DESCRIPTION
I was surprised that `RuntimeProvider` does not work in DoT, which is not ideal for my application.

Most changes of this PR are just playing around with types, almost no changes have been made to the logic.