### PR TITLE
Take the current header truncated bit into account

### DIFF
--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -801,7 +801,8 @@ where
         nameserver_count: nameserver_count.0,
         additional_count: additional_count.0,
     };
-    let was_truncated = answer_count.1 || nameserver_count.1 || additional_count.1;
+    let was_truncated =
+        header.truncated() || answer_count.1 || nameserver_count.1 || additional_count.1;
 
     place.replace(encoder, update_header_counts(header, was_truncated, counts))?;
     Ok(())

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -564,7 +564,7 @@ impl Message {
     pub fn update_counts(&mut self) -> &mut Self {
         self.header = update_header_counts(
             &self.header,
-            false,
+            self.truncated(),
             HeaderCounts {
                 query_count: self.queries.len(),
                 answer_count: self.answers.len(),


### PR DESCRIPTION
We deserialize a message, examine the contents, and re-serialize it. We noticed that the new serialized message was missing the `truncate` bit. This patch fixes it in our case, but not sure if this is the correct approach in general. Welcome for feedback and suggestions on a different fix! 