### PR TITLE
proto: minor cleanups

### DIFF
--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -96,11 +96,12 @@ pub fn update_header_counts(
     assert!(counts.additional_count <= u16::max_value() as usize);
 
     let mut header = current_header.clone();
-    header.set_query_count(counts.query_count as u16);
-    header.set_answer_count(counts.answer_count as u16);
-    header.set_name_server_count(counts.nameserver_count as u16);
-    header.set_additional_count(counts.additional_count as u16);
-    header.set_truncated(is_truncated);
+    header
+        .set_query_count(counts.query_count as u16)
+        .set_answer_count(counts.answer_count as u16)
+        .set_name_server_count(counts.nameserver_count as u16)
+        .set_additional_count(counts.additional_count as u16)
+        .set_truncated(is_truncated);
 
     header
 }
@@ -141,29 +142,23 @@ impl Message {
     /// * `op_code` - operation of the request
     /// * `response_code` - the error code for the response
     pub fn error_msg(id: u16, op_code: OpCode, response_code: ResponseCode) -> Message {
-        let mut message: Message = Message::new();
-        message.set_message_type(MessageType::Response);
-        message.set_id(id);
-        message.set_response_code(response_code);
-        message.set_op_code(op_code);
+        let mut message = Message::new();
+        message
+            .set_message_type(MessageType::Response)
+            .set_id(id)
+            .set_response_code(response_code)
+            .set_op_code(op_code);
 
         message
     }
 
     /// Truncates a Message, this blindly removes all response fields and sets truncated to `true`
     pub fn truncate(&self) -> Self {
-        let mut truncated: Message = Message::new();
-        truncated.set_id(self.id());
-        truncated.set_message_type(self.message_type());
-        truncated.set_op_code(self.op_code());
-        truncated.set_authoritative(self.authoritative());
+        let mut truncated = self.clone();
         truncated.set_truncated(true);
-        truncated.set_recursion_desired(self.recursion_desired());
-        truncated.set_recursion_available(self.recursion_available());
-        truncated.set_response_code(self.response_code());
-        if self.edns().is_some() {
-            truncated.set_edns(self.edns().unwrap().clone());
-        }
+        truncated.take_additionals();
+        truncated.take_answers();
+        truncated.take_queries();
 
         // TODO, perhaps just quickly add a few response records here? that we know would fit?
         truncated

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -156,6 +156,7 @@ impl Message {
     pub fn truncate(&self) -> Self {
         let mut truncated = self.clone();
         truncated.set_truncated(true);
+        // drops additional/answer/queries so len is 0
         truncated.take_additionals();
         truncated.take_answers();
         truncated.take_queries();

--- a/crates/proto/src/rr/domain/try_parse_ip.rs
+++ b/crates/proto/src/rr/domain/try_parse_ip.rs
@@ -18,24 +18,25 @@ pub trait TryParseIp {
 
 impl TryParseIp for str {
     fn try_parse_ip(&self) -> Option<RData> {
-        match IpAddr::from_str(self) {
-            Ok(IpAddr::V4(ip4)) => Some(RData::A(ip4)),
-            Ok(IpAddr::V6(ip6)) => Some(RData::AAAA(ip6)),
-            Err(_) => None,
+        RData::from_str(self).ok()
+    }
+}
+
+impl FromStr for RData {
+    type Err = std::net::AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<IpAddr>() {
+            Ok(IpAddr::V4(ip4)) => Ok(RData::A(ip4)),
+            Ok(IpAddr::V6(ip6)) => Ok(RData::AAAA(ip6)),
+            Err(err) => Err(err),
         }
     }
 }
 
-// impl<'a> TryParseIp for &'a str {
-//     fn try_parse_ip(&self) -> Option<RData> {
-//         TryParseIp::try_parse_ip(*self)
-//     }
-// }
-
 impl TryParseIp for String {
     fn try_parse_ip(&self) -> Option<RData> {
-        let this = self as &str;
-        this.try_parse_ip()
+        (&self[..]).try_parse_ip()
     }
 }
 

--- a/crates/proto/src/rr/domain/try_parse_ip.rs
+++ b/crates/proto/src/rr/domain/try_parse_ip.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use std::net::IpAddr;
-use std::str::FromStr;
 
 use crate::rr::{Name, RData};
 
@@ -18,19 +17,12 @@ pub trait TryParseIp {
 
 impl TryParseIp for str {
     fn try_parse_ip(&self) -> Option<RData> {
-        RData::from_str(self).ok()
-    }
-}
-
-impl FromStr for RData {
-    type Err = std::net::AddrParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.parse::<IpAddr>() {
+        match self.parse::<IpAddr>() {
             Ok(IpAddr::V4(ip4)) => Ok(RData::A(ip4)),
             Ok(IpAddr::V6(ip6)) => Ok(RData::AAAA(ip6)),
             Err(err) => Err(err),
         }
+        .ok()
     }
 }
 

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -287,7 +287,7 @@ impl<S: DnsTcpStream> Stream for TcpStream<S> {
                     // already handled above, here to make sure the poll() pops the next message
                     Poll::Ready(Some(message)) => {
                         // if there is no peer, this connection should die...
-                        let (buffer, dst) = message.into_parts();
+                        let (buffer, dst) = message.into();
 
                         // This is an error if the destination is not our peer (this is TCP after all)
                         //  This will kill the connection...

--- a/crates/proto/src/xfer/serial_message.rs
+++ b/crates/proto/src/xfer/serial_message.rs
@@ -35,7 +35,12 @@ impl SerialMessage {
 
     /// Unwrap the Bytes and address
     pub fn into_parts(self) -> (Vec<u8>, SocketAddr) {
-        (self.message, self.addr)
+        self.into()
+    }
+
+    /// Build a `SerialMessage` from some bytes and an address
+    pub fn from_parts(message: Vec<u8>, addr: SocketAddr) -> Self {
+        (message, addr).into()
     }
 
     /// Deserializes the inner data into a Message
@@ -52,6 +57,7 @@ impl From<(Vec<u8>, SocketAddr)> for SerialMessage {
 
 impl From<SerialMessage> for (Vec<u8>, SocketAddr) {
     fn from(msg: SerialMessage) -> Self {
-        msg.into_parts()
+        let SerialMessage { message, addr } = msg;
+        (message, addr)
     }
 }

--- a/crates/proto/src/xfer/serial_message.rs
+++ b/crates/proto/src/xfer/serial_message.rs
@@ -43,3 +43,15 @@ impl SerialMessage {
         Message::from_vec(&self.message)
     }
 }
+
+impl From<(Vec<u8>, SocketAddr)> for SerialMessage {
+    fn from((message, addr): (Vec<u8>, SocketAddr)) -> Self {
+        SerialMessage { message, addr }
+    }
+}
+
+impl From<SerialMessage> for (Vec<u8>, SocketAddr) {
+    fn from(msg: SerialMessage) -> Self {
+        msg.into_parts()
+    }
+}


### PR DESCRIPTION
I was putzing around in `proto` and saw some stuff written in an older style I figured I may as well clean up.

Is there a reason the `IntoName` trait couldn't just be `Into<Name>`? The other question I had was around `TryParseIp`, which almost seems like it should be a `TryInto<RData>` just judging by it's method, in any case I didn't grasp the reason why `TryParseIp for Name` is `None`.

All of this is very non-critical, just wondering if we can't move to some std traits for a few of these things.