### PR TITLE
proto: add into_parts methods

### DIFF
--- a/crates/client/src/error/dnssec_error.rs
+++ b/crates/client/src/error/dnssec_error.rs
@@ -161,7 +161,7 @@ impl From<SslErrorStack> for Error {
 pub mod not_openssl {
     use std;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy)]
     pub struct SslErrorStack;
 
     impl std::fmt::Display for SslErrorStack {
@@ -181,10 +181,10 @@ pub mod not_openssl {
 pub mod not_ring {
     use std;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy)]
     pub struct KeyRejected;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy)]
     pub struct Unspecified;
 
     impl std::fmt::Display for KeyRejected {

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -354,7 +354,7 @@ pub mod not_ring {
     use std;
 
     /// The Unspecified error replacement
-    #[derive(Debug)]
+    #[derive(Debug, Copy, Clone)]
     pub struct Unspecified;
 
     impl std::fmt::Display for Unspecified {

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -332,7 +332,7 @@ pub mod not_openssl {
     use std;
 
     /// SslErrorStac stub
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy)]
     pub struct SslErrorStack;
 
     impl std::fmt::Display for SslErrorStack {

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -8,6 +8,7 @@
 
 #![warn(
     missing_docs,
+    missing_copy_implementations,
     clippy::dbg_macro,
     clippy::print_stdout,
     clippy::unimplemented
@@ -194,6 +195,7 @@ pub trait Time {
 
 /// New type which is implemented using tokio::time::{Delay, Timeout}
 #[cfg(any(test, feature = "tokio-runtime"))]
+#[derive(Debug, Clone, Copy)]
 pub struct TokioTime;
 
 #[cfg(any(test, feature = "tokio-runtime"))]

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -55,7 +55,7 @@ use crate::serialize::binary::*;
 ///
 /// ```
 ///
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
 pub struct Header {
     id: u16,
     message_type: MessageType,

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -110,6 +110,7 @@ pub fn update_header_counts(
 /// Tracks the counts of the records in the Message.
 ///
 /// This is only used internally during serialization.
+#[derive(Debug, Copy, Clone)]
 pub struct HeaderCounts {
     /// The number of queries in the Message
     pub query_count: usize,
@@ -743,6 +744,7 @@ pub trait MessageFinalizer: Send + Sync + 'static {
 /// A MessageFinalizer which does nothing
 ///
 /// *WARNING* This should only be used in None context, it will panic in all cases where finalize is called.
+#[derive(Debug, Clone, Copy)]
 pub struct NoopMessageFinalizer;
 
 impl NoopMessageFinalizer {

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -95,7 +95,8 @@ pub fn update_header_counts(
     assert!(counts.nameserver_count <= u16::max_value() as usize);
     assert!(counts.additional_count <= u16::max_value() as usize);
 
-    let mut header = current_header.clone();
+    // TODO: should the function just take by value?
+    let mut header = *current_header;
     header
         .set_query_count(counts.query_count as u16)
         .set_answer_count(counts.answer_count as u16)
@@ -677,6 +678,39 @@ impl Message {
         }
 
         Ok(())
+    }
+
+    #[allow(clippy::type_complexity)]
+    /// Consumes `Message` and returns into components
+    pub fn into_parts(
+        self,
+    ) -> (
+        Header,
+        Vec<Query>,
+        Vec<Record>,
+        Vec<Record>,
+        Vec<Record>,
+        Vec<Record>,
+        Option<Edns>,
+    ) {
+        let Message {
+            header,
+            queries,
+            answers,
+            name_servers,
+            additionals,
+            sig0,
+            edns,
+        } = self;
+        (
+            header,
+            queries,
+            answers,
+            name_servers,
+            additionals,
+            sig0,
+            edns,
+        )
     }
 }
 

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -681,19 +681,38 @@ impl Message {
         Ok(())
     }
 
-    #[allow(clippy::type_complexity)]
     /// Consumes `Message` and returns into components
-    pub fn into_parts(
-        self,
-    ) -> (
-        Header,
-        Vec<Query>,
-        Vec<Record>,
-        Vec<Record>,
-        Vec<Record>,
-        Vec<Record>,
-        Option<Edns>,
-    ) {
+    pub fn into_parts(self) -> MessageParts {
+        self.into()
+    }
+}
+
+/// Consumes `Message` giving public access to fields in `Message` so they can be
+/// destructured and taken by value
+/// ```rust
+///  let msg = Message::new();
+///  let MessageParts { queries, .. } = msg.into_parts();
+/// ```
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct MessageParts {
+    /// message header
+    pub header: Header,
+    /// message queries
+    pub queries: Vec<Query>,
+    /// message answers
+    pub answers: Vec<Record>,
+    /// message name_servers
+    pub name_servers: Vec<Record>,
+    /// message additional records
+    pub additionals: Vec<Record>,
+    /// sig0
+    pub sig0: Vec<Record>,
+    /// optional edns records
+    pub edns: Option<Edns>,
+}
+
+impl From<Message> for MessageParts {
+    fn from(msg: Message) -> Self {
         let Message {
             header,
             queries,
@@ -702,8 +721,8 @@ impl Message {
             additionals,
             sig0,
             edns,
-        } = self;
-        (
+        } = msg;
+        MessageParts {
             header,
             queries,
             answers,
@@ -711,7 +730,7 @@ impl Message {
             additionals,
             sig0,
             edns,
-        )
+        }
     }
 }
 

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -161,26 +161,41 @@ impl Query {
     }
 
     /// Consumes `Query` and returns it's components
+    pub fn into_parts(self) -> QueryParts {
+        self.into()
+    }
+}
+
+/// Consumes `Query` giving public access to fields of `Query` so they can
+/// be destructured and taken by value.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct QueryParts {
+    /// QNAME
+    pub name: Name,
+    /// QTYPE
+    pub query_type: RecordType,
+    /// QCLASS
+    pub query_class: DNSClass,
+    /// mDNS unicast-response bit set or not
     #[cfg(feature = "mdns")]
-    pub fn into_parts(self) -> (Name, RecordType, DNSClass, bool) {
+    pub mdns_unicast_response: bool,
+}
+
+impl From<Query> for QueryParts {
+    fn from(q: Query) -> Self {
         let Query {
             name,
             query_type,
             query_class,
             mdns_unicast_response,
-        } = self;
-        (name, query_type, query_class, mdns_unicast_response)
-    }
-
-    /// Consumes `Query` and returns it's components
-    #[cfg(not(feature = "mdns"))]
-    pub fn into_parts(self) -> (Name, RecordType, DNSClass) {
-        let Query {
+        } = q;
+        Self {
             name,
             query_type,
             query_class,
-        } = self;
-        (name, query_type, query_class)
+            #[cfg(feature = "mdns")]
+            mdns_unicast_response,
+        }
     }
 }
 

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -183,19 +183,22 @@ pub struct QueryParts {
 
 impl From<Query> for QueryParts {
     fn from(q: Query) -> Self {
-        #[cfg(feature = "mdns")]
-        let Query {
-            name,
-            query_type,
-            query_class,
-            mdns_unicast_response,
-        } = q;
-        #[cfg(not(feature = "mdns"))]
-        let Query {
-            name,
-            query_type,
-            query_class,
-        } = q;
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "mdns")] {
+                let Query {
+                    name,
+                    query_type,
+                    query_class,
+                    mdns_unicast_response,
+                } = q;
+            } else {
+                let Query {
+                    name,
+                    query_type,
+                    query_class,
+                } = q;
+            }
+        }
 
         Self {
             name,

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -159,6 +159,29 @@ impl Query {
     pub fn mdns_unicast_response(&self) -> bool {
         self.mdns_unicast_response
     }
+
+    /// Consumes `Query` and returns it's components
+    #[cfg(feature = "mdns")]
+    pub fn into_parts(self) -> (Name, RecordType, DNSClass, bool) {
+        let Query {
+            name,
+            query_type,
+            query_class,
+            mdns_unicast_response,
+        } = self;
+        (name, query_type, query_class, mdns_unicast_response)
+    }
+
+    /// Consumes `Query` and returns it's components
+    #[cfg(not(feature = "mdns"))]
+    pub fn into_parts(self) -> (Name, RecordType, DNSClass) {
+        let Query {
+            name,
+            query_type,
+            query_class,
+        } = self;
+        (name, query_type, query_class)
+    }
 }
 
 impl BinEncodable for Query {

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -183,12 +183,20 @@ pub struct QueryParts {
 
 impl From<Query> for QueryParts {
     fn from(q: Query) -> Self {
+        #[cfg(feature = "mdns")]
         let Query {
             name,
             query_type,
             query_class,
             mdns_unicast_response,
         } = q;
+        #[cfg(not(feature = "mdns"))]
+        let Query {
+            name,
+            query_type,
+            query_class,
+        } = q;
+
         Self {
             name,
             query_type,

--- a/crates/proto/src/rr/dnssec/ec_public_key.rs
+++ b/crates/proto/src/rr/dnssec/ec_public_key.rs
@@ -8,8 +8,7 @@
 use super::Algorithm;
 use crate::error::*;
 
-#[derive(Debug, Clone)]
-#[allow(missing_copy_implementations)]
+#[derive(Copy, Clone)]
 pub struct ECPublicKey {
     buf: [u8; MAX_LEN],
     len: usize,

--- a/crates/proto/src/rr/dnssec/ec_public_key.rs
+++ b/crates/proto/src/rr/dnssec/ec_public_key.rs
@@ -8,7 +8,8 @@
 use super::Algorithm;
 use crate::error::*;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
+#[allow(missing_copy_implementations)]
 pub struct ECPublicKey {
     buf: [u8; MAX_LEN],
     len: usize,

--- a/crates/proto/src/rr/dnssec/ec_public_key.rs
+++ b/crates/proto/src/rr/dnssec/ec_public_key.rs
@@ -8,6 +8,7 @@
 use super::Algorithm;
 use crate::error::*;
 
+#[derive(Debug, Clone, Copy)]
 pub struct ECPublicKey {
     buf: [u8; MAX_LEN],
     len: usize,

--- a/crates/proto/src/rr/dnssec/mod.rs
+++ b/crates/proto/src/rr/dnssec/mod.rs
@@ -49,6 +49,7 @@ pub use ring::digest::Digest;
 
 /// This is an empty type, enable Ring or OpenSSL for this feature
 #[cfg(not(any(feature = "openssl", feature = "ring")))]
+#[derive(Copy, Debug)]
 pub struct Digest;
 
 #[cfg(not(any(feature = "openssl", feature = "ring")))]

--- a/crates/proto/src/rr/dnssec/mod.rs
+++ b/crates/proto/src/rr/dnssec/mod.rs
@@ -49,7 +49,7 @@ pub use ring::digest::Digest;
 
 /// This is an empty type, enable Ring or OpenSSL for this feature
 #[cfg(not(any(feature = "openssl", feature = "ring")))]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Digest;
 
 #[cfg(not(any(feature = "openssl", feature = "ring")))]

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -186,6 +186,11 @@ impl OPT {
         &self.options
     }
 
+    /// The entire map of options
+    pub fn options_mut(&mut self) -> &mut HashMap<EdnsCode, EdnsOption> {
+        &mut self.options
+    }
+
     /// Get a single option based on the code
     pub fn get(&self, code: EdnsCode) -> Option<&EdnsOption> {
         self.options.get(&code)
@@ -199,6 +204,18 @@ impl OPT {
     /// Remove an option, the key is derived from the `EdnsOption`
     pub fn remove(&mut self, option: EdnsCode) {
         self.options.remove(&option);
+    }
+}
+
+impl AsMut<HashMap<EdnsCode, EdnsOption>> for OPT {
+    fn as_mut(&mut self) -> &mut HashMap<EdnsCode, EdnsOption> {
+        self.options_mut()
+    }
+}
+
+impl AsRef<HashMap<EdnsCode, EdnsOption>> for OPT {
+    fn as_ref(&self) -> &HashMap<EdnsCode, EdnsOption> {
+        self.options()
     }
 }
 

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -181,14 +181,10 @@ impl OPT {
         OPT { options }
     }
 
+    #[deprecated(note = "Please use as_ref() or as_mut() for shared/mutable references")]
     /// The entire map of options
     pub fn options(&self) -> &HashMap<EdnsCode, EdnsOption> {
         &self.options
-    }
-
-    /// The entire map of options
-    pub fn options_mut(&mut self) -> &mut HashMap<EdnsCode, EdnsOption> {
-        &mut self.options
     }
 
     /// Get a single option based on the code
@@ -209,13 +205,13 @@ impl OPT {
 
 impl AsMut<HashMap<EdnsCode, EdnsOption>> for OPT {
     fn as_mut(&mut self) -> &mut HashMap<EdnsCode, EdnsOption> {
-        self.options_mut()
+        &mut self.options
     }
 }
 
 impl AsRef<HashMap<EdnsCode, EdnsOption>> for OPT {
     fn as_ref(&self) -> &HashMap<EdnsCode, EdnsOption> {
-        self.options()
+        &self.options
     }
 }
 
@@ -294,7 +290,7 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
 
 /// Write the RData from the given Decoder
 pub fn emit(encoder: &mut BinEncoder<'_>, opt: &OPT) -> ProtoResult<()> {
-    for (edns_code, edns_option) in opt.options().iter() {
+    for (edns_code, edns_option) in opt.as_ref().iter() {
         encoder.emit_u16(u16::from(*edns_code))?;
         encoder.emit_u16(edns_option.len())?;
         edns_option.emit(encoder)?

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -291,6 +291,7 @@ pub struct RecordParts {
 
 impl From<Record> for RecordParts {
     fn from(record: Record) -> Self {
+        #[cfg(feature = "mdns")]
         let Record {
             name_labels,
             rr_type,
@@ -299,6 +300,16 @@ impl From<Record> for RecordParts {
             rdata,
             mdns_cache_flush,
         } = record;
+
+        #[cfg(not(feature = "mdns"))]
+        let Record {
+            name_labels,
+            rr_type,
+            dns_class,
+            ttl,
+            rdata,
+        } = record;
+
         RecordParts {
             name_labels,
             rr_type,

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -291,24 +291,26 @@ pub struct RecordParts {
 
 impl From<Record> for RecordParts {
     fn from(record: Record) -> Self {
-        #[cfg(feature = "mdns")]
-        let Record {
-            name_labels,
-            rr_type,
-            dns_class,
-            ttl,
-            rdata,
-            mdns_cache_flush,
-        } = record;
-
-        #[cfg(not(feature = "mdns"))]
-        let Record {
-            name_labels,
-            rr_type,
-            dns_class,
-            ttl,
-            rdata,
-        } = record;
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "mdns")] {
+                let Record {
+                    name_labels,
+                    rr_type,
+                    dns_class,
+                    ttl,
+                    rdata,
+                    mdns_cache_flush,
+                } = record;
+            } else {
+                let Record {
+                    name_labels,
+                    rr_type,
+                    dns_class,
+                    ttl,
+                    rdata,
+                } = record;
+            }
+        }
 
         RecordParts {
             name_labels,

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -264,6 +264,40 @@ impl Record {
     pub fn into_data(self) -> RData {
         self.rdata
     }
+
+    /// Consumes `Record` and returns its components
+    #[cfg(feature = "mdns")]
+    pub fn into_parts(self) -> (Name, RecordType, DNSClass, u32, RData, bool) {
+        let Record {
+            name_labels,
+            rr_type,
+            dns_class,
+            ttl,
+            rdata,
+            mdns_cache_flush,
+        } = self;
+        (
+            name_labels,
+            rr_type,
+            dns_class,
+            ttl,
+            rdata,
+            mdns_cache_flush,
+        )
+    }
+
+    /// Consumes `Record` and returns its components
+    #[cfg(not(feature = "mdns"))]
+    pub fn into_parts(self) -> (Name, RecordType, DNSClass, u32, RData) {
+        let Record {
+            name_labels,
+            rr_type,
+            dns_class,
+            ttl,
+            rdata,
+        } = self;
+        (name_labels, rr_type, dns_class, ttl, rdata)
+    }
 }
 
 #[allow(deprecated)]

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -266,37 +266,48 @@ impl Record {
     }
 
     /// Consumes `Record` and returns its components
-    #[cfg(feature = "mdns")]
-    pub fn into_parts(self) -> (Name, RecordType, DNSClass, u32, RData, bool) {
-        let Record {
-            name_labels,
-            rr_type,
-            dns_class,
-            ttl,
-            rdata,
-            mdns_cache_flush,
-        } = self;
-        (
-            name_labels,
-            rr_type,
-            dns_class,
-            ttl,
-            rdata,
-            mdns_cache_flush,
-        )
+    pub fn into_parts(self) -> RecordParts {
+        self.into()
     }
+}
 
-    /// Consumes `Record` and returns its components
-    #[cfg(not(feature = "mdns"))]
-    pub fn into_parts(self) -> (Name, RecordType, DNSClass, u32, RData) {
+/// Consumes `Record` giving public access to fields of `Record` so they can
+/// be destructured and taken by value
+pub struct RecordParts {
+    /// label names
+    pub name_labels: Name,
+    /// record type
+    pub rr_type: RecordType,
+    /// dns class
+    pub dns_class: DNSClass,
+    /// time to live
+    pub ttl: u32,
+    /// rdata
+    pub rdata: RData,
+    /// mDNS cache flush
+    #[cfg(feature = "mdns")]
+    pub mdns_cache_flush: bool,
+}
+
+impl From<Record> for RecordParts {
+    fn from(record: Record) -> Self {
         let Record {
             name_labels,
             rr_type,
             dns_class,
             ttl,
             rdata,
-        } = self;
-        (name_labels, rr_type, dns_class, ttl, rdata)
+            mdns_cache_flush,
+        } = record;
+        RecordParts {
+            name_labels,
+            rr_type,
+            dns_class,
+            ttl,
+            rdata,
+            #[cfg(feature = "mdns")]
+            mdns_cache_flush,
+        }
     }
 }
 

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -431,6 +431,30 @@ impl RecordSet {
 
         removed
     }
+
+    /// Consumes `RecordSet` and returns its components
+    pub fn into_parts(
+        self,
+    ) -> (
+        Name,
+        RecordType,
+        DNSClass,
+        u32,
+        Vec<Record>,
+        Vec<Record>,
+        u32,
+    ) {
+        let RecordSet {
+            name,
+            record_type,
+            dns_class,
+            ttl,
+            records,
+            rrsigs,
+            serial,
+        } = self;
+        (name, record_type, dns_class, ttl, records, rrsigs, serial)
+    }
 }
 
 impl From<Record> for RecordSet {

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -433,17 +433,26 @@ impl RecordSet {
     }
 
     /// Consumes `RecordSet` and returns its components
-    pub fn into_parts(
-        self,
-    ) -> (
-        Name,
-        RecordType,
-        DNSClass,
-        u32,
-        Vec<Record>,
-        Vec<Record>,
-        u32,
-    ) {
+    pub fn into_parts(self) -> RecordSetParts {
+        self.into()
+    }
+}
+
+/// Consumes `RecordSet` giving public access to fields of `RecordSet` so they can
+/// be destructured and taken by value
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordSetParts {
+    pub name: Name,
+    pub record_type: RecordType,
+    pub dns_class: DNSClass,
+    pub ttl: u32,
+    pub records: Vec<Record>,
+    pub rrsigs: Vec<Record>,
+    pub serial: u32, // serial number at which this record was modifie,
+}
+
+impl From<RecordSet> for RecordSetParts {
+    fn from(rset: RecordSet) -> Self {
         let RecordSet {
             name,
             record_type,
@@ -452,8 +461,16 @@ impl RecordSet {
             records,
             rrsigs,
             serial,
-        } = self;
-        (name, record_type, dns_class, ttl, records, rrsigs, serial)
+        } = rset;
+        RecordSetParts {
+            name,
+            record_type,
+            dns_class,
+            ttl,
+            records,
+            rrsigs,
+            serial,
+        }
     }
 }
 

--- a/crates/proto/src/xfer/dns_request.rs
+++ b/crates/proto/src/xfer/dns_request.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, DerefMut};
 use crate::op::Message;
 
 /// A set of options for expressing options to how requests should be treated
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct DnsRequestOptions {
     /// When true, the underlying DNS protocols will not return on the first response received.
     ///

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -443,7 +443,7 @@ impl From<SmallVec<[Message; 1]>> for DnsResponse {
 ///    NXT and SIG records MUST be added.
 ///
 /// ```
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone, Copy)]
 pub enum NegativeType {
     /// ```text
     ///            NXDOMAIN RESPONSE: TYPE 1.

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -177,7 +177,7 @@ where
 
         let response_message = client
             .client
-            .lookup(query.clone(), options.clone())
+            .lookup(query.clone(), options)
             .await
             .map_err(E::into);
 

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -245,7 +245,7 @@ where
 
         let query: Pin<Box<dyn Future<Output = Result<Lookup, ResolveError>> + Send>> = match name {
             Ok(name) => client_cache
-                .lookup(Query::query(name, record_type), options.clone())
+                .lookup(Query::query(name, record_type), options)
                 .boxed(),
             Err(err) => future::err(err).boxed(),
         };
@@ -287,7 +287,7 @@ where
             if should_retry {
                 if let Some(name) = self.names.pop() {
                     let record_type = self.record_type;
-                    let options = self.options.clone();
+                    let options = self.options;
 
                     // If there's another name left to try, build a new query
                     // for that next name and continue looping.

--- a/crates/resolver/src/lookup_ip.rs
+++ b/crates/resolver/src/lookup_ip.rs
@@ -166,7 +166,7 @@ where
                         name,
                         self.strategy,
                         self.client_cache.clone(),
-                        self.options.clone(),
+                        self.options,
                         self.hosts.clone(),
                     )
                     .boxed();
@@ -315,7 +315,7 @@ where
         hosts_lookup(
             Query::query(name.clone(), RecordType::A),
             client.clone(),
-            options.clone(),
+            options,
             hosts.clone(),
         )
         .boxed(),
@@ -414,7 +414,7 @@ where
     let res = hosts_lookup(
         Query::query(name.clone(), first_type),
         client,
-        options.clone(),
+        options,
         hosts.clone(),
     )
     .await;


### PR DESCRIPTION
summary:
- `Header` is `Copy`
~~- `options_mut` added to `OPT` (I had wanted this before but for some reason forgot to add it)~~
- `AsMut`/`AsRef` added to `OPT`
- `into_parts` methods added to `Message` `Record` `Query` `RData` -- these methods are useful for us because we want to consume a `Message` after we're done processing and transform it into a log struct, however we can only clone data currently. 

It occurred to me that it might be nice to have `into_ascii` that consumes `self` and returns a `String` as well as `to_ascii` for `Name` and `Label`. I have not added these here as I'm not sure if it's possible yet. Any thoughts?
