### PR TITLE
Make all warnings across crates and binaries consistent

### DIFF
--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -22,7 +22,17 @@
 //!    --tls-port=PORT         Override the listening port for TLS connections
 //! ```
 
-#![warn(missing_docs, clippy::dbg_macro, clippy::unimplemented)]
+// BINARY WARNINGS
+#![warn(
+    clippy::dbg_macro,
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![recursion_limit = "128"]
 
 #[macro_use]
@@ -230,14 +240,15 @@ const TLS_PORT_ARG: &str = "tls-port";
 const HTTPS_PORT_ARG: &str = "https-port";
 
 /// Args struct for all options
+#[allow(dead_code)]
 struct Args {
-    pub flag_quiet: bool,
-    pub flag_debug: bool,
-    pub flag_config: String,
-    pub flag_zonedir: Option<String>,
-    pub flag_port: Option<u16>,
-    pub flag_tls_port: Option<u16>,
-    pub flag_https_port: Option<u16>,
+    pub(crate) flag_quiet: bool,
+    pub(crate) flag_debug: bool,
+    pub(crate) flag_config: String,
+    pub(crate) flag_zonedir: Option<String>,
+    pub(crate) flag_port: Option<u16>,
+    pub(crate) flag_tls_port: Option<u16>,
+    pub(crate) flag_https_port: Option<u16>,
 }
 
 impl<'a> From<ArgMatches<'a>> for Args {

--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -5,6 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+// LIBRARY WARNINGS
+#![warn(
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![allow(clippy::needless_doctest_main)]
 
 //! The Resolver is responsible for performing recursive queries to lookup domain names.

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -33,7 +33,7 @@ impl UdpSocket for AsyncStdUdpSocket {
 
     fn poll_recv_from(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<(usize, SocketAddr)>> {
         let fut = self.0.recv_from(buf);
@@ -48,7 +48,7 @@ impl UdpSocket for AsyncStdUdpSocket {
 
     fn poll_send_to(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         buf: &[u8],
         target: SocketAddr,
     ) -> Poll<io::Result<usize>> {

--- a/crates/async-std-resolver/src/runtime.rs
+++ b/crates/async-std-resolver/src/runtime.rs
@@ -44,7 +44,7 @@ use crate::time::AsyncStdTime;
 /// [timer]: crate::time
 /// [mod]: index.html
 /// [`new`]: #method.new
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct AsyncStdRuntime;
 
 impl Executor for AsyncStdRuntime {
@@ -57,7 +57,7 @@ impl Executor for AsyncStdRuntime {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct AsyncStdRuntimeHandle;
 impl Spawn for AsyncStdRuntimeHandle {
     fn spawn_bg<F>(&mut self, future: F)
@@ -82,5 +82,8 @@ impl AsyncStdRuntime {
     }
 }
 
+/// AsyncStd default connection
 pub type AsyncStdConnection = GenericConnection;
+
+/// AsyncStd default connection provider
 pub type AsyncStdConnectionProvider = GenericConnectionProvider<AsyncStdRuntime>;

--- a/crates/async-std-resolver/src/time.rs
+++ b/crates/async-std-resolver/src/time.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use trust_dns_resolver::proto::Time;
 
 /// AsyncStd backed timer implementation
+#[derive(Clone, Copy)]
 pub struct AsyncStdTime;
 
 #[async_trait]

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -30,7 +30,7 @@ use crate::rr::{DNSClass, Name, Record, RecordSet, RecordType};
 // TODO: this should be configurable
 // > An EDNS buffer size of 1232 bytes will avoid fragmentation on nearly all current networks.
 // https://dnsflagday.net/2020/
-pub const MAX_PAYLOAD_LEN: u16 = 1232;
+pub(crate) const MAX_PAYLOAD_LEN: u16 = 1232;
 
 /// A DNS Client implemented over futures-rs.
 ///
@@ -144,7 +144,7 @@ where
 {
     type Output = Result<(AsyncClient, DnsExchangeBackground<S, TokioTime>), ProtoError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let result = ready!(self.0.poll_unpin(cx));
         let client_background = result.map(|(exchange, bg)| (AsyncClient { exchange }, bg));
 
@@ -584,7 +584,7 @@ where
 {
     type Output = Result<DnsResponse, ClientError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.poll_unpin(cx).map_err(ClientError::from)
     }
 }

--- a/crates/client/src/client/async_secure_client.rs
+++ b/crates/client/src/client/async_secure_client.rs
@@ -139,7 +139,7 @@ where
 {
     type Output = Result<(AsyncDnssecClient, DnsExchangeBackground<S, TokioTime>), ProtoError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let result = ready!(self.client_connect.poll_unpin(cx));
         let trust_anchor = self
             .trust_anchor

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -32,7 +32,7 @@ use crate::rr::dnssec::TrustAnchor;
 use crate::rr::{DNSClass, Name, Record, RecordSet, RecordType};
 
 #[allow(clippy::type_complexity)]
-pub type NewFutureObj<H> = Pin<
+pub(crate) type NewFutureObj<H> = Pin<
     Box<
         dyn Future<
                 Output = Result<

--- a/crates/client/src/client/rc_future.rs
+++ b/crates/client/src/client/rc_future.rs
@@ -15,7 +15,7 @@ use futures_util::{future::Fuse, ready, FutureExt};
 
 #[allow(clippy::type_complexity)]
 #[must_use = "futures do nothing unless polled"]
-pub struct RcFuture<F: Future>
+pub(crate) struct RcFuture<F: Future>
 where
     F: Future + Send + Unpin,
     F::Output: Clone + Send,
@@ -23,7 +23,7 @@ where
     future_and_result: Arc<Mutex<(Fuse<F>, Option<F::Output>)>>,
 }
 
-pub fn rc_future<F>(future: F) -> RcFuture<F>
+pub(crate) fn rc_future<F>(future: F) -> RcFuture<F>
 where
     F: Future + Unpin,
     F::Output: Clone + Send,
@@ -41,7 +41,7 @@ where
 {
     type Output = F::Output;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // try and get a mutable reference to execute the future
         // at least one caller should be able to get a mut reference... others will
         //  wait for it to complete.

--- a/crates/client/src/error/client_error.rs
+++ b/crates/client/src/error/client_error.rs
@@ -85,7 +85,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
             if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {

--- a/crates/client/src/error/dnssec_error.rs
+++ b/crates/client/src/error/dnssec_error.rs
@@ -27,6 +27,7 @@ use crate::proto::{trace, ExtBacktrace};
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// The error kind for dnssec errors that get returned in the crate
+#[allow(unreachable_pub)]
 #[derive(Debug, Error)]
 pub enum ErrorKind {
     /// An error with an arbitrary message, referenced as &'static str
@@ -92,7 +93,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
             if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {
@@ -157,15 +158,16 @@ impl From<SslErrorStack> for Error {
     }
 }
 
+#[allow(unreachable_pub)]
 #[cfg(not(feature = "openssl"))]
 pub mod not_openssl {
     use std;
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Clone, Copy, Debug)]
     pub struct SslErrorStack;
 
     impl std::fmt::Display for SslErrorStack {
-        fn fmt(&self, _: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
             Ok(())
         }
     }
@@ -177,18 +179,19 @@ pub mod not_openssl {
     }
 }
 
+#[allow(unreachable_pub)]
 #[cfg(not(feature = "ring"))]
 pub mod not_ring {
     use std;
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Clone, Copy, Debug)]
     pub struct KeyRejected;
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Clone, Copy, Debug)]
     pub struct Unspecified;
 
     impl std::fmt::Display for KeyRejected {
-        fn fmt(&self, _: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
             Ok(())
         }
     }
@@ -200,7 +203,7 @@ pub mod not_ring {
     }
 
     impl std::fmt::Display for Unspecified {
-        fn fmt(&self, _: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
             Ok(())
         }
     }

--- a/crates/client/src/error/lexer_error.rs
+++ b/crates/client/src/error/lexer_error.rs
@@ -83,7 +83,7 @@ impl From<ErrorKind> for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
             if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {

--- a/crates/client/src/error/parse_error.rs
+++ b/crates/client/src/error/parse_error.rs
@@ -116,7 +116,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
             if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// LIBRARY WARNINGS
+#![warn(
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![allow(
     clippy::needless_doctest_main,
     clippy::unknown_clippy_lints,
     clippy::single_component_path_imports
-)]
-#![warn(
-    missing_docs,
-    clippy::dbg_macro,
-    clippy::print_stdout,
-    clippy::unimplemented
 )]
 #![recursion_limit = "1024"]
 

--- a/crates/client/src/multicast/mdns_client_connection.rs
+++ b/crates/client/src/multicast/mdns_client_connection.rs
@@ -21,7 +21,7 @@ use crate::rr::dnssec::Signer;
 /// MDNS based DNS Client connection
 ///
 /// Use with `trust_dns_client::client::Client` impls
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct MdnsClientConnection {
     multicast_addr: SocketAddr,
     packet_ttl: Option<u32>,

--- a/crates/client/src/op/lower_query.rs
+++ b/crates/client/src/op/lower_query.rs
@@ -72,7 +72,7 @@ impl From<Query> for LowerQuery {
 }
 
 impl BinEncodable for LowerQuery {
-    fn emit(&self, encoder: &mut BinEncoder) -> ProtoResult<()> {
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         self.original.emit(encoder)
     }
 }
@@ -85,7 +85,7 @@ impl<'r> BinDecodable<'r> for LowerQuery {
 }
 
 impl Display for LowerQuery {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
             "name: {} type: {} class: {}",

--- a/crates/client/src/rr/dnssec/key_format.rs
+++ b/crates/client/src/rr/dnssec/key_format.rs
@@ -270,7 +270,7 @@ impl KeyFormat {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
-    pub use super::*;
+    use super::*;
 
     #[test]
     #[cfg(feature = "openssl")]

--- a/crates/client/src/rr/dnssec/mod.rs
+++ b/crates/client/src/rr/dnssec/mod.rs
@@ -66,11 +66,13 @@ mod faux_key_type {
     impl<K: HasPrivate> HasPublic for K {}
 
     /// Faux implementation of the Openssl Public key types
+    #[derive(Clone, Copy)]
     pub enum Public {}
 
     impl HasPublic for Public {}
 
     /// Faux implementation of the Openssl Public key types
+    #[derive(Clone, Copy)]
     pub enum Private {}
 
     impl HasPrivate for Private {}

--- a/crates/client/src/rr/dnssec/signer.rs
+++ b/crates/client/src/rr/dnssec/signer.rs
@@ -248,7 +248,7 @@ pub struct Signer {
 
 /// Placeholder type for when OpenSSL and *ring* are disabled; enable OpenSSL and Ring for support
 #[cfg(not(any(feature = "openssl", feature = "ring")))]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct Signer;
 
 #[cfg(any(feature = "openssl", feature = "ring"))]
@@ -587,7 +587,7 @@ mod tests {
     use crate::rr::rdata::{DNSSECRData, SIG};
     use crate::rr::{DNSClass, Name, Record, RecordType};
 
-    pub use super::*;
+    use super::*;
 
     fn assert_send_and_sync<T: Send + Sync>() {}
 

--- a/crates/client/src/rr/lower_name.rs
+++ b/crates/client/src/rr/lower_name.rs
@@ -144,7 +144,11 @@ impl LowerName {
     /// Emits the canonical version of the name to the encoder.
     ///
     /// In canonical form, there will be no pointers written to the encoder (i.e. no compression).
-    pub fn emit_as_canonical(&self, encoder: &mut BinEncoder, canonical: bool) -> ProtoResult<()> {
+    pub fn emit_as_canonical(
+        &self,
+        encoder: &mut BinEncoder<'_>,
+        canonical: bool,
+    ) -> ProtoResult<()> {
         self.0.emit_as_canonical(encoder, canonical)
     }
 
@@ -178,14 +182,14 @@ impl PartialEq<LowerName> for LowerName {
 }
 
 impl BinEncodable for LowerName {
-    fn emit(&self, encoder: &mut BinEncoder) -> ProtoResult<()> {
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         let is_canonical_names = encoder.is_canonical_names();
         self.emit_as_canonical(encoder, is_canonical_names)
     }
 }
 
 impl fmt::Display for LowerName {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -21,7 +21,7 @@ use crate::rr::rdata::DNSSECRecordType;
 use crate::rr::{Name, RData, RecordType};
 use crate::serialize::txt::rdata_parsers::*;
 
-pub trait RDataParser: Sized {
+pub(crate) trait RDataParser: Sized {
     fn parse<'i, I: Iterator<Item = &'i str>>(
         record_type: RecordType,
         tokens: I,

--- a/crates/client/src/serialize/txt/rdata_parsers/a.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/a.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 use crate::error::*;
 
 /// Parse the RData from a set of Tokens
-pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<Ipv4Addr> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<Ipv4Addr> {
     let address: Ipv4Addr = tokens
         .next()
         .ok_or_else(|| ParseError::from(ParseErrorKind::MissingToken("ipv4 address".to_string())))

--- a/crates/client/src/serialize/txt/rdata_parsers/aaaa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/aaaa.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 use crate::error::*;
 
 /// Parse the RData from a set of Tokens
-pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<Ipv6Addr> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<Ipv6Addr> {
     let address: Ipv6Addr = tokens
         .next()
         .ok_or_else(|| ParseError::from(ParseErrorKind::MissingToken("ipv6 address".to_string())))

--- a/crates/client/src/serialize/txt/rdata_parsers/caa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/caa.rs
@@ -45,7 +45,7 @@ use crate::rr::rdata::CAA;
 ///    Value:  Is the <character-string> encoding of the value field as
 ///       specified in [RFC1035], Section 5.1.
 /// ```
-pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<CAA> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<CAA> {
     let flags_str: &str = tokens
         .next()
         .ok_or_else(|| ParseError::from(ParseErrorKind::Message("caa flags not present")))?;

--- a/crates/client/src/serialize/txt/rdata_parsers/hinfo.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/hinfo.rs
@@ -16,7 +16,7 @@ use crate::rr::rdata::HINFO;
 /// IN HINFO DEC-2060 TOPS20
 /// IN HINFO VAX-11/780 UNIX
 /// ```
-pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<HINFO> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<HINFO> {
     let cpu = tokens
         .next()
         .ok_or_else(|| ParseError::from(ParseErrorKind::MissingToken("cpu".to_string())))

--- a/crates/client/src/serialize/txt/rdata_parsers/mod.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/mod.rs
@@ -19,17 +19,17 @@
 // TODO: these should each be it's own struct, it would make parsing and decoding a little cleaner
 //  and also a little more ergonomic when accessing.
 // each of these module's has the parser for that rdata embedded, to keep the file sizes down...
-pub mod a;
-pub mod aaaa;
-pub mod caa;
-pub mod hinfo;
-pub mod mx;
-pub mod name;
-pub mod naptr;
-pub mod null;
-pub mod openpgpkey;
-pub mod soa;
-pub mod srv;
-pub mod sshfp;
-pub mod tlsa;
-pub mod txt;
+pub(crate) mod a;
+pub(crate) mod aaaa;
+pub(crate) mod caa;
+pub(crate) mod hinfo;
+pub(crate) mod mx;
+pub(crate) mod name;
+pub(crate) mod naptr;
+pub(crate) mod null;
+pub(crate) mod openpgpkey;
+pub(crate) mod soa;
+pub(crate) mod srv;
+pub(crate) mod sshfp;
+pub(crate) mod tlsa;
+pub(crate) mod txt;

--- a/crates/client/src/serialize/txt/rdata_parsers/mx.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/mx.rs
@@ -21,7 +21,7 @@ use crate::rr::domain::Name;
 use crate::rr::rdata::MX;
 
 /// Parse the RData from a set of Tokens
-pub fn parse<'i, I: Iterator<Item = &'i str>>(
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(
     mut tokens: I,
     origin: Option<&Name>,
 ) -> ParseResult<MX> {

--- a/crates/client/src/serialize/txt/rdata_parsers/name.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/name.rs
@@ -20,7 +20,7 @@ use crate::error::*;
 use crate::rr::domain::Name;
 
 /// Parse the RData from a set of Tokens
-pub fn parse<'i, I: Iterator<Item = &'i str>>(
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(
     mut tokens: I,
     origin: Option<&Name>,
 ) -> ParseResult<Name> {

--- a/crates/client/src/serialize/txt/rdata_parsers/naptr.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/naptr.rs
@@ -21,7 +21,7 @@ use crate::rr::Name;
 /// IN NAPTR 100  50  "a"    "rcds+N2C"          ""   cidserver.example.com.
 /// IN NAPTR 100  50  "s"    "http+N2L+N2C+N2R"  ""   www.example.com.
 /// ```
-pub fn parse<'i, I: Iterator<Item = &'i str>>(
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(
     mut tokens: I,
     origin: Option<&Name>,
 ) -> ParseResult<NAPTR> {

--- a/crates/client/src/serialize/txt/rdata_parsers/null.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/null.rs
@@ -21,7 +21,7 @@ use crate::rr::rdata::NULL;
 
 /// Parse the RData from a set of Tokens
 #[allow(unused)]
-pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<NULL> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<NULL> {
     Err(ParseError::from(ParseErrorKind::Msg(
         "Parse is not implemented for NULL record".to_string(),
     )))

--- a/crates/client/src/serialize/txt/rdata_parsers/openpgpkey.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/openpgpkey.rs
@@ -22,7 +22,7 @@ use crate::rr::rdata::OPENPGPKEY;
 ///    Section 11.1 of [RFC4880] encoded in base64 as defined in Section 4
 ///    of [RFC4648].
 /// ```
-pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<OPENPGPKEY> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<OPENPGPKEY> {
     let encoded_public_key = tokens.next().ok_or(ParseErrorKind::Message(
         "OPENPGPKEY public key field is missing",
     ))?;

--- a/crates/client/src/serialize/txt/rdata_parsers/soa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/soa.rs
@@ -22,7 +22,7 @@ use crate::rr::domain::Name;
 use crate::rr::rdata::SOA;
 
 /// Parse the RData from a set of Tokens
-pub fn parse<'i, I: Iterator<Item = &'i str>>(
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(
     mut tokens: I,
     origin: Option<&Name>,
 ) -> ParseResult<SOA> {

--- a/crates/client/src/serialize/txt/rdata_parsers/srv.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/srv.rs
@@ -22,7 +22,7 @@ use crate::rr::domain::Name;
 use crate::rr::rdata::SRV;
 
 /// Parse the RData from a set of Tokens
-pub fn parse<'i, I: Iterator<Item = &'i str>>(
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(
     mut tokens: I,
     origin: Option<&Name>,
 ) -> ParseResult<SRV> {

--- a/crates/client/src/serialize/txt/rdata_parsers/sshfp.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/sshfp.rs
@@ -25,7 +25,7 @@ use crate::rr::rdata::{sshfp, SSHFP};
 ///
 ///    The use of mnemonics instead of numbers is not allowed.
 /// ```
-pub fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<SSHFP> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<SSHFP> {
     fn missing_field<E: From<ParseErrorKind>>(field: &str) -> E {
         ParseErrorKind::Msg(format!("SSHFP {} field missing", field)).into()
     }

--- a/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
@@ -39,7 +39,7 @@ fn to_u8(data: &str) -> ParseResult<u8> {
 ///       string of hexadecimal characters.  Whitespace is allowed within
 ///       the string of hexadecimal characters, as described in [RFC1035].
 /// ```
-pub fn parse<'i, I: Iterator<Item = &'i str>>(tokens: I) -> ParseResult<TLSA> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(tokens: I) -> ParseResult<TLSA> {
     let mut iter = tokens;
 
     let token: &str = iter

--- a/crates/client/src/serialize/txt/rdata_parsers/txt.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/txt.rs
@@ -20,7 +20,8 @@ use crate::error::*;
 use crate::rr::rdata::TXT;
 
 /// Parse the RData from a set of Tokens
-pub fn parse<'i, I: Iterator<Item = &'i str>>(tokens: I) -> ParseResult<TXT> {
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(tokens: I) -> ParseResult<TXT> {
     let txt_data: Vec<String> = tokens.map(ToString::to_string).collect();
     Ok(TXT::new(txt_data))
 }

--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -121,7 +121,7 @@ use crate::serialize::txt::zone_lex::{Lexer, Token};
 /// ;               Semicolon is used to start a comment; the remainder of
 ///                 the line is ignored.
 /// ```
-#[derive(Default)]
+#[derive(Clone, Copy, Default)]
 pub struct Parser;
 
 impl Parser {
@@ -137,7 +137,7 @@ impl Parser {
     /// A pair of the Zone origin name and a map of all Keys to RecordSets
     pub fn parse(
         &mut self,
-        lexer: Lexer,
+        lexer: Lexer<'_>,
         origin: Option<Name>,
         class: Option<DNSClass>,
     ) -> ParseResult<(Name, BTreeMap<RrKey, RecordSet>)> {

--- a/crates/client/src/serialize/txt/zone_lex.rs
+++ b/crates/client/src/serialize/txt/zone_lex.rs
@@ -19,7 +19,7 @@ pub struct Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     /// Creates a new lexer with the given data to parse
-    pub fn new(txt: &str) -> Lexer {
+    pub fn new(txt: &str) -> Lexer<'_> {
         Lexer {
             txt: txt.chars().peekable(),
             state: State::StartLine,
@@ -340,7 +340,7 @@ impl<'a> Lexer<'a> {
 
 #[doc(hidden)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub enum State {
+pub(crate) enum State {
     StartLine,
     RestOfLine,
     Blank,                      // only if the first part of the line
@@ -380,7 +380,7 @@ pub enum Token {
 mod lex_test {
     use super::*;
 
-    fn next_token(lexer: &mut Lexer) -> Option<Token> {
+    fn next_token(lexer: &mut Lexer<'_>) -> Option<Token> {
         let result = lexer.next_token();
         assert!(!result.is_err(), "{:?}", result);
         result.unwrap()

--- a/crates/client/src/tcp/tcp_client_connection.rs
+++ b/crates/client/src/tcp/tcp_client_connection.rs
@@ -23,7 +23,7 @@ use crate::rr::dnssec::Signer;
 /// Tcp client connection
 ///
 /// Use with `trust_dns_client::client::Client` impls
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct TcpClientConnection {
     name_server: SocketAddr,
     timeout: Duration,

--- a/crates/client/src/udp/udp_client_connection.rs
+++ b/crates/client/src/udp/udp_client_connection.rs
@@ -22,7 +22,7 @@ use tokio::net::UdpSocket;
 /// UDP based DNS Client connection
 ///
 /// Use with `trust_dns_client::client::Client` impls
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct UdpClientConnection {
     name_server: SocketAddr,
     timeout: Duration,

--- a/crates/https/src/error.rs
+++ b/crates/https/src/error.rs
@@ -60,7 +60,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
             if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {

--- a/crates/https/src/https_client_stream.rs
+++ b/crates/https/src/https_client_stream.rs
@@ -51,7 +51,7 @@ pub struct HttpsClientStream {
 }
 
 impl Display for HttpsClientStream {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             formatter,
             "HTTPS({},{})",
@@ -268,7 +268,7 @@ impl DnsRequestSender for HttpsClientStream {
 impl Stream for HttpsClientStream {
     type Item = Result<(), ProtoError>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if self.is_shutdown {
             return Poll::Ready(None);
         }
@@ -354,7 +354,7 @@ where
 {
     type Output = Result<HttpsClientStream, ProtoError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.poll_unpin(cx)
     }
 }
@@ -412,7 +412,7 @@ where
 {
     type Output = Result<HttpsClientStream, ProtoError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             let next = match *self {
                 HttpsClientConnectState::ConnectTcp {
@@ -518,7 +518,7 @@ pub struct HttpsClientResponse(
 impl Future for HttpsClientResponse {
     type Output = Result<DnsResponse, ProtoError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.as_mut().poll(cx).map_err(ProtoError::from)
     }
 }

--- a/crates/https/src/https_server.rs
+++ b/crates/https/src/https_server.rs
@@ -109,7 +109,7 @@ mod tests {
     impl Stream for TestBytesStream {
         type Item = Result<Bytes, h2::Error>;
 
-        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Option<Self::Item>> {
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
             match self.0.pop() {
                 Some(Ok(bytes)) => Poll::Ready(Some(Ok(bytes))),
                 Some(Err(err)) => Poll::Ready(Some(Err(err))),

--- a/crates/https/src/lib.rs
+++ b/crates/https/src/lib.rs
@@ -6,11 +6,18 @@
 // copied, modified, or distributed except according to those terms.
 
 //! TLS protocol related components for DNS over TLS
+
+// LIBRARY WARNINGS
 #![warn(
-    missing_docs,
     clippy::dbg_macro,
     clippy::print_stdout,
-    clippy::unimplemented
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
 )]
 #![allow(clippy::single_component_path_imports)]
 

--- a/crates/native-tls/src/lib.rs
+++ b/crates/native-tls/src/lib.rs
@@ -15,11 +15,18 @@
  */
 
 //! TLS protocol related components for DNS over TLS
+
+// LIBRARY WARNINGS
 #![warn(
-    missing_docs,
     clippy::dbg_macro,
     clippy::print_stdout,
-    clippy::unimplemented
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
 )]
 
 pub mod tls_client_stream;

--- a/crates/openssl/src/lib.rs
+++ b/crates/openssl/src/lib.rs
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
+// LIBRARY WARNINGS
 #![warn(
-    missing_docs,
     clippy::dbg_macro,
     clippy::print_stdout,
-    clippy::unimplemented
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
 )]
 
 //! TLS protocol related components for DNS over TLS

--- a/crates/openssl/src/tls_stream.rs
+++ b/crates/openssl/src/tls_stream.rs
@@ -24,7 +24,7 @@ use trust_dns_proto::tcp::Connect;
 use trust_dns_proto::tcp::TcpStream;
 use trust_dns_proto::xfer::BufStreamHandle;
 
-pub trait TlsIdentityExt {
+pub(crate) trait TlsIdentityExt {
     fn identity(&mut self, pkcs12: &ParsedPkcs12) -> io::Result<()> {
         self.identity_parts(&pkcs12.cert, &pkcs12.pkey, pkcs12.chain.as_ref())
     }
@@ -58,7 +58,7 @@ impl TlsIdentityExt for SslContextBuilder {
 
 /// A TlsStream counterpart to the TcpStream which embeds a secure TlsStream
 pub type TlsStream<S> = TcpStream<AsyncIoTokioAsStd<TokioTlsStream<S>>>;
-pub type CompatTlsStream<S> = TlsStream<AsyncIoStdAsTokio<S>>;
+pub(crate) type CompatTlsStream<S> = TlsStream<AsyncIoStdAsTokio<S>>;
 
 fn new(certs: Vec<X509>, pkcs12: Option<ParsedPkcs12>) -> io::Result<SslConnector> {
     let mut tls = SslConnector::builder(SslMethod::tls()).map_err(|e| {

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -332,11 +332,11 @@ pub mod not_openssl {
     use std;
 
     /// SslErrorStac stub
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Clone, Copy, Debug)]
     pub struct SslErrorStack;
 
     impl std::fmt::Display for SslErrorStack {
-        fn fmt(&self, _: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
             Ok(())
         }
     }
@@ -354,7 +354,7 @@ pub mod not_ring {
     use std;
 
     /// The Unspecified error replacement
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Clone, Copy, Debug)]
     pub struct Unspecified;
 
     impl std::fmt::Display for Unspecified {

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -6,12 +6,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+// LIBRARY WARNINGS
 #![warn(
-    missing_docs,
-    missing_copy_implementations,
     clippy::dbg_macro,
     clippy::print_stdout,
-    clippy::unimplemented
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
 )]
 #![allow(clippy::single_component_path_imports)]
 #![recursion_limit = "2048"]
@@ -195,7 +200,7 @@ pub trait Time {
 
 /// New type which is implemented using tokio::time::{Delay, Timeout}
 #[cfg(any(test, feature = "tokio-runtime"))]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TokioTime;
 
 #[cfg(any(test, feature = "tokio-runtime"))]

--- a/crates/proto/src/multicast/mdns_client_stream.rs
+++ b/crates/proto/src/multicast/mdns_client_stream.rs
@@ -77,7 +77,7 @@ impl MdnsClientStream {
 }
 
 impl Display for MdnsClientStream {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(formatter, "mDNS({})", self.mdns_stream.multicast_addr())
     }
 }
@@ -93,7 +93,7 @@ impl DnsClientStream for MdnsClientStream {
 impl Stream for MdnsClientStream {
     type Item = Result<SerialMessage, ProtoError>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mdns_stream = &mut self.as_mut().mdns_stream;
         mdns_stream.map_err(ProtoError::from).poll_next_unpin(cx)
         // match ready!(self.mdns_stream.poll_next_unpin(cx).map_err(ProtoError::from)) {
@@ -115,7 +115,7 @@ pub struct MdnsClientConnect(
 impl Future for MdnsClientConnect {
     type Output = Result<MdnsClientStream, ProtoError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.as_mut().poll_unpin(cx)
     }
 }

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -26,7 +26,7 @@ use crate::udp::UdpStream;
 use crate::xfer::SerialMessage;
 use crate::BufStreamHandle;
 
-pub const MDNS_PORT: u16 = 5353;
+pub(crate) const MDNS_PORT: u16 = 5353;
 lazy_static! {
     /// mDNS ipv4 address https://www.iana.org/assignments/multicast-addresses/multicast-addresses.xhtml
     pub static ref MDNS_IPV4: SocketAddr = SocketAddr::new(Ipv4Addr::new(224,0,0,251).into(), MDNS_PORT);
@@ -261,7 +261,7 @@ impl MdnsStream {
 impl Stream for MdnsStream {
     type Item = io::Result<SerialMessage>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         assert!(self.datagram.is_some() || self.multicast.is_some());
 
         // we poll the datagram socket first, if available, since it's a direct response or direct request
@@ -361,7 +361,7 @@ impl Future for NextRandomUdpSocket {
     /// polls until there is an available next random UDP port.
     ///
     /// if there is no port available after 10 attempts, returns NotReady
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // non-one-shot, i.e. continuous, always use one of the well-known mdns ports and bind to the multicast addr
         if !self.mdns_query_type.sender() {
             debug!("skipping sending stream");
@@ -412,7 +412,7 @@ impl Future for NextRandomUdpSocket {
 }
 
 #[cfg(test)]
-pub mod tests {
+pub(crate) mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
     use super::*;

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -55,7 +55,7 @@ use crate::serialize::binary::*;
 ///
 /// ```
 ///
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Header {
     id: u16,
     message_type: MessageType,

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -110,7 +110,7 @@ pub fn update_header_counts(
 /// Tracks the counts of the records in the Message.
 ///
 /// This is only used internally during serialization.
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct HeaderCounts {
     /// The number of queries in the Message
     pub query_count: usize,
@@ -763,7 +763,7 @@ pub trait MessageFinalizer: Send + Sync + 'static {
 /// A MessageFinalizer which does nothing
 ///
 /// *WARNING* This should only be used in None context, it will panic in all cases where finalize is called.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct NoopMessageFinalizer;
 
 impl NoopMessageFinalizer {

--- a/crates/proto/src/rr/dnssec/ec_public_key.rs
+++ b/crates/proto/src/rr/dnssec/ec_public_key.rs
@@ -8,7 +8,8 @@
 use super::Algorithm;
 use crate::error::*;
 
-#[derive(Copy, Clone)]
+#[allow(unreachable_pub)]
+#[derive(Clone, Copy)]
 pub struct ECPublicKey {
     buf: [u8; MAX_LEN],
     len: usize,
@@ -17,6 +18,7 @@ pub struct ECPublicKey {
 // The length of the longest supported EC public key (P-384).
 const MAX_LEN: usize = 1 + (2 * 48);
 
+#[allow(unreachable_pub)]
 impl ECPublicKey {
     // DNSSEC encodes uncompressed EC public keys without the standard 0x04
     // prefix that indicates they are uncompressed, but crypto libraries

--- a/crates/proto/src/rr/dnssec/mod.rs
+++ b/crates/proto/src/rr/dnssec/mod.rs
@@ -49,7 +49,7 @@ pub use ring::digest::Digest;
 
 /// This is an empty type, enable Ring or OpenSSL for this feature
 #[cfg(not(any(feature = "openssl", feature = "ring")))]
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Digest;
 
 #[cfg(not(any(feature = "openssl", feature = "ring")))]

--- a/crates/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -459,7 +459,7 @@ mod tests {
 
     #[test]
     #[cfg(any(feature = "openssl", feature = "ring"))]
-    pub fn test() {
+    fn test() {
         let rdata = DNSKEY::new(
             true,
             true,

--- a/crates/proto/src/rr/dnssec/rdata/ds.rs
+++ b/crates/proto/src/rr/dnssec/rdata/ds.rs
@@ -280,7 +280,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test() {
+    fn test() {
         let rdata = DS::new(
             0xF00F,
             Algorithm::RSASHA256,
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     #[cfg(any(feature = "openssl", feature = "ring"))]
-    pub fn test_covers() {
+    pub(crate) fn test_covers() {
         use crate::rr::dnssec::rdata::DNSKEY;
 
         let name = Name::parse("www.example.com.", None).unwrap();

--- a/crates/proto/src/rr/dnssec/rdata/key.rs
+++ b/crates/proto/src/rr/dnssec/rdata/key.rs
@@ -923,7 +923,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test() {
+    fn test() {
         let rdata = KEY::new(
             Default::default(),
             Default::default(),

--- a/crates/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec.rs
@@ -214,7 +214,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test() {
+    fn test() {
         use crate::rr::dnssec::rdata::DNSSECRecordType;
         use crate::rr::RecordType;
         use std::str::FromStr;

--- a/crates/proto/src/rr/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3.rs
@@ -562,7 +562,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test() {
+    fn test() {
         use crate::rr::dnssec::rdata::DNSSECRecordType;
 
         let rdata = NSEC3::new(
@@ -593,7 +593,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_dups() {
+    fn test_dups() {
         use crate::rr::dnssec::rdata::DNSSECRecordType;
 
         let rdata_with_dups = NSEC3::new(

--- a/crates/proto/src/rr/dnssec/rdata/nsec3param.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3param.rs
@@ -250,7 +250,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test() {
+    fn test() {
         let rdata = NSEC3PARAM::new(Nsec3HashAlgorithm::SHA1, true, 2, vec![1, 2, 3, 4, 5]);
 
         let mut bytes = Vec::new();

--- a/crates/proto/src/rr/dnssec/rsa_public_key.rs
+++ b/crates/proto/src/rr/dnssec/rsa_public_key.rs
@@ -7,13 +7,13 @@
 
 use crate::error::*;
 
-pub struct RSAPublicKey<'a> {
+pub(crate) struct RSAPublicKey<'a> {
     n: &'a [u8],
     e: &'a [u8],
 }
 
 impl<'a> RSAPublicKey<'a> {
-    pub fn try_from(encoded: &'a [u8]) -> ProtoResult<RSAPublicKey<'a>> {
+    pub(crate) fn try_from(encoded: &'a [u8]) -> ProtoResult<RSAPublicKey<'a>> {
         let (e_len_len, e_len) = match encoded.get(0) {
             Some(&0) if encoded.len() >= 3 => {
                 (3, (usize::from(encoded[1]) << 8) | usize::from(encoded[2]))
@@ -33,10 +33,10 @@ impl<'a> RSAPublicKey<'a> {
         Ok(Self { n, e })
     }
 
-    pub fn n(&self) -> &[u8] {
+    pub(crate) fn n(&self) -> &[u8] {
         self.n
     }
-    pub fn e(&self) -> &[u8] {
+    pub(crate) fn e(&self) -> &[u8] {
         self.e
     }
 }

--- a/crates/proto/src/rr/rdata/hinfo.rs
+++ b/crates/proto/src/rr/rdata/hinfo.rs
@@ -151,7 +151,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test() {
+    fn test() {
         let rdata = HINFO::new("cpu".to_string(), "os".to_string());
 
         let mut bytes = Vec::new();

--- a/crates/proto/src/rr/rdata/mx.rs
+++ b/crates/proto/src/rr/rdata/mx.rs
@@ -165,7 +165,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test() {
+    fn test() {
         use std::str::FromStr;
 
         let rdata = MX::new(16, Name::from_str("mail.example.com").unwrap());

--- a/crates/proto/src/rr/rdata/naptr.rs
+++ b/crates/proto/src/rr/rdata/naptr.rs
@@ -268,7 +268,7 @@ mod tests {
 
     use super::*;
     #[test]
-    pub fn test() {
+    fn test() {
         use std::str::FromStr;
 
         let rdata = NAPTR::new(
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_bad_data() {
+    fn test_bad_data() {
         use std::str::FromStr;
 
         let rdata = NAPTR::new(

--- a/crates/proto/src/rr/rdata/null.rs
+++ b/crates/proto/src/rr/rdata/null.rs
@@ -100,7 +100,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test() {
+    fn test() {
         let rdata = NULL::with(vec![0, 1, 2, 3, 4, 5, 6, 7]);
 
         let mut bytes = Vec::new();

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -512,7 +512,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "dnssec")]
-    pub fn test() {
+    fn test() {
         let mut rdata = OPT::default();
         rdata.insert(EdnsOption::DAU(SupportedAlgorithms::all()));
 

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -528,7 +528,7 @@ impl<'r> Iterator for RecordsAndRrsigsIter<'r> {
 /// An iterator that limits the record signatures by SupportedAlgorithms
 #[cfg(feature = "dnssec")]
 #[derive(Debug)]
-pub struct RrsigsByAlgorithms<'r> {
+pub(crate) struct RrsigsByAlgorithms<'r> {
     rrsigs: Iter<'r, Record>,
     supported_algorithms: SupportedAlgorithms,
 }

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -25,13 +25,13 @@ mod private {
     use crate::error::{ProtoErrorKind, ProtoResult};
 
     /// A wrapper for a buffer that guarantees writes never exceed a defined set of bytes
-    pub struct MaximalBuf<'a> {
+    pub(crate) struct MaximalBuf<'a> {
         max_size: usize,
         buffer: &'a mut Vec<u8>,
     }
 
     impl<'a> MaximalBuf<'a> {
-        pub fn new(max_size: u16, buffer: &'a mut Vec<u8>) -> Self {
+        pub(crate) fn new(max_size: u16, buffer: &'a mut Vec<u8>) -> Self {
             MaximalBuf {
                 max_size: max_size as usize,
                 buffer,
@@ -39,14 +39,14 @@ mod private {
         }
 
         /// Sets the maximum size to enforce
-        pub fn set_max_size(&mut self, max: u16) {
+        pub(crate) fn set_max_size(&mut self, max: u16) {
             self.max_size = max as usize;
         }
 
         /// returns an error if the maximum buffer size would be exceeded with the addition number of elements
         ///
         /// and reserves the additional space in the buffer
-        pub fn enforced_write<F>(&mut self, additional: usize, writer: F) -> ProtoResult<()>
+        pub(crate) fn enforced_write<F>(&mut self, additional: usize, writer: F) -> ProtoResult<()>
         where
             F: FnOnce(&mut Vec<u8>),
         {
@@ -64,22 +64,22 @@ mod private {
         }
 
         /// truncates are always safe
-        pub fn truncate(&mut self, len: usize) {
+        pub(crate) fn truncate(&mut self, len: usize) {
             self.buffer.truncate(len)
         }
 
         /// returns the length of the underlying buffer
-        pub fn len(&self) -> usize {
+        pub(crate) fn len(&self) -> usize {
             self.buffer.len()
         }
 
         /// Immutable reads are always safe
-        pub fn buffer(&'a self) -> &'a [u8] {
+        pub(crate) fn buffer(&'a self) -> &'a [u8] {
             self.buffer as &'a [u8]
         }
 
         /// Returns a reference to the internal buffer
-        pub fn into_bytes(self) -> &'a Vec<u8> {
+        pub(crate) fn into_bytes(self) -> &'a Vec<u8> {
             self.buffer
         }
     }
@@ -485,12 +485,12 @@ impl<T: EncodedSize> Place<T> {
 }
 
 /// A type representing a rollback point in a stream
-pub struct Rollback {
+pub(crate) struct Rollback {
     rollback_index: usize,
 }
 
 impl Rollback {
-    pub fn rollback(self, encoder: &mut BinEncoder<'_>) {
+    pub(crate) fn rollback(self, encoder: &mut BinEncoder<'_>) {
         encoder.set_offset(self.rollback_index)
     }
 }

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -60,7 +60,7 @@ enum WriteTcpState {
 }
 
 /// Current state of a TCP stream as it's being read.
-pub enum ReadTcpState {
+pub(crate) enum ReadTcpState {
     /// Currently reading the length of the TCP packet
     LenBytes {
         /// Current position in the buffer

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -37,7 +37,7 @@ where
     /// where the data came on success.
     fn poll_recv_from(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<(usize, SocketAddr)>>;
 
@@ -50,7 +50,7 @@ where
     /// Poll once to send data to the given address.
     fn poll_send_to(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         buf: &[u8],
         target: SocketAddr,
     ) -> Poll<io::Result<usize>>;
@@ -254,7 +254,7 @@ impl UdpSocket for tokio::net::UdpSocket {
 
     fn poll_recv_from(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<(usize, SocketAddr)>> {
         let mut buf = tokio::io::ReadBuf::new(buf);
@@ -266,7 +266,7 @@ impl UdpSocket for tokio::net::UdpSocket {
 
     fn poll_send_to(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         buf: &[u8],
         target: SocketAddr,
     ) -> Poll<io::Result<usize>> {

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -443,7 +443,7 @@ impl From<SmallVec<[Message; 1]>> for DnsResponse {
 ///    NXT and SIG records MUST be added.
 ///
 /// ```
-#[derive(Eq, PartialEq, Debug, Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum NegativeType {
     /// ```text
     ///            NXDOMAIN RESPONSE: TYPE 1.

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -30,10 +30,10 @@ use crate::xfer::{DnsRequest, DnsRequestOptions, DnsResponse};
 
 #[derive(Debug)]
 struct Rrset {
-    pub name: Name,
-    pub record_type: RecordType,
-    pub record_class: DNSClass,
-    pub records: Vec<Record>,
+    pub(crate) name: Name,
+    pub(crate) record_type: RecordType,
+    pub(crate) record_class: DNSClass,
+    pub(crate) records: Vec<Record>,
 }
 
 /// Performs DNSSec validation of all DNS responses from the wrapped DnsHandle

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -416,7 +416,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
 impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> fmt::Debug
     for AsyncResolver<C, P>
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AsyncResolver")
             .field("request_tx", &"...")
             .finish()

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -605,7 +605,8 @@ mod tests {
         );
     }
 
-    pub fn cname_message() -> Result<DnsResponse, ResolveError> {
+    #[allow(clippy::unnecessary_wraps)]
+    pub(crate) fn cname_message() -> Result<DnsResponse, ResolveError> {
         let mut message = Message::new();
         message.add_query(Query::query(
             Name::from_str("www.example.com.").unwrap(),
@@ -619,7 +620,8 @@ mod tests {
         Ok(message.into())
     }
 
-    pub fn srv_message() -> Result<DnsResponse, ResolveError> {
+    #[allow(clippy::unnecessary_wraps)]
+    pub(crate) fn srv_message() -> Result<DnsResponse, ResolveError> {
         let mut message = Message::new();
         message.add_query(Query::query(
             Name::from_str("_443._tcp.www.example.com.").unwrap(),

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -23,7 +23,7 @@ use crate::lookup::Lookup;
 
 /// Maximum TTL as defined in https://tools.ietf.org/html/rfc2181, 2147483647
 ///   Setting this to a value of 1 day, in seconds
-pub const MAX_TTL: u32 = 86400_u32;
+pub(crate) const MAX_TTL: u32 = 86400_u32;
 
 #[derive(Debug)]
 struct LruValue {
@@ -98,22 +98,22 @@ pub(crate) struct TtlConfig {
     ///
     /// Positive responses with TTLs under `positive_min_ttl` will use
     /// `positive_min_ttl` instead.
-    pub positive_min_ttl: Option<Duration>,
+    pub(crate) positive_min_ttl: Option<Duration>,
     /// An optional minimum TTL value for negative (`NXDOMAIN`) responses.
     ///
     /// `NXDOMAIN` responses with TTLs under `negative_min_ttl will use
     /// `negative_min_ttl` instead.
-    pub negative_min_ttl: Option<Duration>,
+    pub(crate) negative_min_ttl: Option<Duration>,
     /// An optional maximum TTL value for positive responses.
     ///
     /// Positive responses with TTLs positive `positive_max_ttl` will use
     /// `positive_max_ttl` instead.
-    pub positive_max_ttl: Option<Duration>,
+    pub(crate) positive_max_ttl: Option<Duration>,
     /// An optional maximum TTL value for negative (`NXDOMAIN`) responses.
     ///
     /// `NXDOMAIN` responses with TTLs over `negative_max_ttl` will use
     /// `negative_max_ttl` instead.
-    pub negative_max_ttl: Option<Duration>,
+    pub(crate) negative_max_ttl: Option<Duration>,
 }
 
 impl TtlConfig {

--- a/crates/resolver/src/dns_sd.rs
+++ b/crates/resolver/src/dns_sd.rs
@@ -77,7 +77,7 @@ pub struct ListServicesFuture(
 impl Future for ListServicesFuture {
     type Output = Result<ListServices, ResolveError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.0.as_mut().poll(cx) {
             Poll::Ready(Ok(lookup)) => Poll::Ready(Ok(ListServices(lookup))),
             Poll::Pending => Poll::Pending,
@@ -93,7 +93,7 @@ impl ListServices {
     /// Returns an iterator over the list of returned names of services.
     ///
     /// Each name can be queried for additional information. To lookup service entries see [`AsyncResolver::lookup_srv`]. To get parameters associated with the service, see `DnsSdFuture::service_info`.
-    pub fn iter(&self) -> ListServicesIter {
+    pub fn iter(&self) -> ListServicesIter<'_> {
         ListServicesIter(self.0.iter())
     }
 }
@@ -117,7 +117,7 @@ pub struct ServiceInfoFuture(
 impl Future for ServiceInfoFuture {
     type Output = Result<ServiceInfo, ResolveError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.0.as_mut().poll(cx) {
             Poll::Ready(Ok(lookup)) => Poll::Ready(Ok(ServiceInfo(lookup))),
             Poll::Pending => Poll::Pending,

--- a/crates/resolver/src/error.rs
+++ b/crates/resolver/src/error.rs
@@ -249,7 +249,7 @@ impl RetryableError for ResolveError {
 }
 
 impl fmt::Display for ResolveError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
             if #[cfg(feature = "with-backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {

--- a/crates/resolver/src/hosts.rs
+++ b/crates/resolver/src/hosts.rs
@@ -106,7 +106,7 @@ fn hosts_path() -> std::path::PathBuf {
 
 /// parse configuration from `path`
 #[cfg(any(unix, windows))]
-pub fn read_hosts_conf<P: AsRef<Path>>(path: P) -> io::Result<Hosts> {
+pub(crate) fn read_hosts_conf<P: AsRef<Path>>(path: P) -> io::Result<Hosts> {
     use std::fs::File;
     use std::io::{BufRead, BufReader};
 

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -167,11 +167,17 @@
 //!
 //! Multicast DNS is an experimental feature in Trust-DNS at the moment. It's support on different platforms is not yet ideal. Initial support is only for IPv4 mDNS, as there are some complexities to figure out with IPv6. Once enabled, an mDNS `NameServer` will automatically be added to the `Resolver` and used for any lookups performed in the `.local.` zone.
 
+// LIBRARY WARNINGS
 #![warn(
-    missing_docs,
     clippy::dbg_macro,
     clippy::print_stdout,
-    clippy::unimplemented
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
 )]
 #![recursion_limit = "128"]
 #![allow(

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -75,12 +75,12 @@ impl Lookup {
     }
 
     /// Returns a borrowed iterator of the returned IPs
-    pub fn iter(&self) -> LookupIter {
+    pub fn iter(&self) -> LookupIter<'_> {
         LookupIter(self.records.iter())
     }
 
     /// Returns a borrowed iterator of the returned IPs
-    pub fn record_iter(&self) -> LookupRecordIter {
+    pub fn record_iter(&self) -> LookupRecordIter<'_> {
         LookupRecordIter(self.records.iter())
     }
 
@@ -267,7 +267,7 @@ where
 {
     type Output = Result<Lookup, ResolveError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             // Try polling the underlying DNS query.
             let query = self.query.as_mut().poll_unpin(cx);
@@ -317,7 +317,7 @@ pub struct SrvLookup(Lookup);
 
 impl SrvLookup {
     /// Returns an iterator over the SRV RData
-    pub fn iter(&self) -> SrvLookupIter {
+    pub fn iter(&self) -> SrvLookupIter<'_> {
         SrvLookupIter(self.0.iter())
     }
 
@@ -329,7 +329,7 @@ impl SrvLookup {
     /// Returns the list of IPs associated with the SRV record.
     ///
     /// *Note*: That Trust-DNS performs a recursive lookup on SRV records for IPs if they were not included in the original request. If there are no IPs associated to the result, a subsequent query for the IPs via the `srv.target()` should not resolve to the IPs.
-    pub fn ip_iter(&self) -> LookupIpIter {
+    pub fn ip_iter(&self) -> LookupIpIter<'_> {
         LookupIpIter(self.0.iter())
     }
 
@@ -399,7 +399,7 @@ macro_rules! lookup_type {
 
         impl $l {
             /// Returns an iterator over the RData
-            pub fn iter(&self) -> $i {
+            pub fn iter(&self) -> $i<'_> {
                 $i(self.0.iter())
             }
 

--- a/crates/resolver/src/lookup_ip.rs
+++ b/crates/resolver/src/lookup_ip.rs
@@ -38,7 +38,7 @@ pub struct LookupIp(Lookup);
 
 impl LookupIp {
     /// Returns a borrowed iterator of the returned IPs
-    pub fn iter(&self) -> LookupIpIter {
+    pub fn iter(&self) -> LookupIpIter<'_> {
         LookupIpIter(self.0.iter())
     }
 
@@ -141,7 +141,7 @@ where
 {
     type Output = Result<LookupIp, ResolveError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             // Try polling the underlying DNS query.
             let query = self.query.as_mut().poll(cx);

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -270,7 +270,7 @@ pub struct ConnectionFuture<R: RuntimeProvider> {
 impl<R: RuntimeProvider> Future for ConnectionFuture<R> {
     type Output = Result<GenericConnection, ResolveError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(Ok(match &mut self.connect {
             ConnectionConnect::Udp(ref mut conn) => {
                 let (conn, bg) = ready!(conn.poll_unpin(cx))?;
@@ -324,17 +324,18 @@ pub struct ConnectionResponse(DnsExchangeSend);
 impl Future for ConnectionResponse {
     type Output = Result<DnsResponse, ResolveError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.poll_unpin(cx).map_err(ResolveError::from)
     }
 }
 
 #[cfg(feature = "tokio-runtime")]
+#[allow(unreachable_pub)]
 pub mod tokio_runtime {
     use super::*;
     use tokio::net::UdpSocket as TokioUdpSocket;
 
-    #[derive(Clone)]
+    #[derive(Clone, Copy)]
     pub struct TokioHandle;
     impl Spawn for TokioHandle {
         fn spawn_bg<F>(&mut self, future: F)
@@ -345,7 +346,7 @@ pub mod tokio_runtime {
         }
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, Copy)]
     pub struct TokioRuntime;
     impl RuntimeProvider for TokioRuntime {
         type Handle = TokioHandle;

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -42,7 +42,7 @@ pub struct NameServer<
 impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> Debug
     for NameServer<C, P>
 {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "config: {:?}, options: {:?}", self.config, self.options)
     }
 }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -359,7 +359,10 @@ mod mdns {
     use proto::DnsHandle;
 
     /// Returns true
-    pub fn maybe_local<C, P>(name_server: &mut NameServer<C, P>, request: DnsRequest) -> Local
+    pub(crate) fn maybe_local<C, P>(
+        name_server: &mut NameServer<C, P>,
+        request: DnsRequest,
+    ) -> Local
     where
         C: DnsHandle<Error = ResolveError> + 'static,
         P: ConnectionProvider<Conn = C> + 'static,
@@ -377,7 +380,7 @@ mod mdns {
     }
 }
 
-pub enum Local {
+pub(crate) enum Local {
     #[allow(dead_code)]
     ResolveFuture(Pin<Box<dyn Future<Output = Result<DnsResponse, ResolveError>> + Send>>),
     NotMdns(DnsRequest),
@@ -418,7 +421,7 @@ impl Local {
 impl Future for Local {
     type Output = Result<DnsResponse, ResolveError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match *self {
             Local::ResolveFuture(ref mut ns) => ns.as_mut().poll(cx),
             // TODO: making this a panic for now

--- a/crates/resolver/src/name_server/name_server_state.rs
+++ b/crates/resolver/src/name_server/name_server_state.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 use futures_util::lock::Mutex;
 use proto::op::Edns;
 
-pub struct NameServerState {
+pub(crate) struct NameServerState {
     conn_state: AtomicU8,
     remote_edns: Mutex<Arc<Option<Edns>>>,
 }
@@ -65,7 +65,7 @@ impl NameServerState {
     /// Set at the new Init state
     ///
     /// If send_dns is some, this will be sent on the first request when it is established
-    pub fn init(_send_edns: Option<Edns>) -> Self {
+    pub(crate) fn init(_send_edns: Option<Edns>) -> Self {
         // TODO: need to track send_edns
         NameServerState {
             conn_state: AtomicU8::new(NameServerStateInner::Init.into()),
@@ -76,7 +76,7 @@ impl NameServerState {
     /// Set at the new Init state
     ///
     /// If send_dns is some, this will be sent on the first request when it is established
-    pub fn reinit(&self, _send_edns: Option<Edns>) {
+    pub(crate) fn reinit(&self, _send_edns: Option<Edns>) {
         // eventually do this
         // self.send_edns.lock() = send_edns;
 
@@ -87,7 +87,7 @@ impl NameServerState {
     ///
     /// If remote_edns is Some, then it will be used to effect things like buffer sizes based on
     ///   the remote's support.
-    pub fn establish(&self, remote_edns: Option<Edns>) {
+    pub(crate) fn establish(&self, remote_edns: Option<Edns>) {
         if remote_edns.is_some() {
             // best effort locking, we'll assume a different user of this connection is storing the same thing...
             if let Some(mut current_edns) = self.remote_edns.try_lock() {
@@ -103,7 +103,7 @@ impl NameServerState {
     /// when is the time of the failure
     ///
     /// * when - deprecated
-    pub fn fail(&self, _when: /* FIXME: remove in 0.20 */ Instant) {
+    pub(crate) fn fail(&self, _when: /* FIXME: remove in 0.20 */ Instant) {
         self.store(NameServerStateInner::Failed);
     }
 

--- a/crates/resolver/src/name_server/name_server_stats.rs
+++ b/crates/resolver/src/name_server/name_server_stats.rs
@@ -22,18 +22,18 @@ impl Default for NameServerStats {
 }
 
 impl NameServerStats {
-    pub fn new(successes: usize, failures: usize) -> Self {
+    pub(crate) fn new(successes: usize, failures: usize) -> Self {
         NameServerStats {
             successes: AtomicUsize::new(successes),
             failures: AtomicUsize::new(failures),
         }
     }
 
-    pub fn next_success(&self) {
+    pub(crate) fn next_success(&self) {
         self.successes.fetch_add(1, atomic::Ordering::Release);
     }
 
-    pub fn next_failure(&self) {
+    pub(crate) fn next_failure(&self) {
         self.failures.fetch_add(1, atomic::Ordering::Release);
     }
 

--- a/crates/rustls/src/lib.rs
+++ b/crates/rustls/src/lib.rs
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
+// LIBRARY WARNINGS
 #![warn(
-    missing_docs,
     clippy::dbg_macro,
     clippy::print_stdout,
-    clippy::unimplemented
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
 )]
 #![allow(clippy::single_component_path_imports)]
 

--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -70,7 +70,7 @@ impl AuthLookup {
     }
 
     /// Conversion to an iterator
-    pub fn iter(&self) -> AuthLookupIter {
+    pub fn iter(&self) -> AuthLookupIter<'_> {
         self.into_iter()
     }
 
@@ -215,7 +215,7 @@ impl AnyRecords {
         }
     }
 
-    fn iter(&self) -> AnyRecordsIter {
+    fn iter(&self) -> AnyRecordsIter<'_> {
         self.into_iter()
     }
 }
@@ -344,7 +344,7 @@ impl LookupRecords {
     }
 
     /// Conversion to an iterator
-    pub fn iter(&self) -> LookupRecordsIter {
+    pub fn iter(&self) -> LookupRecordsIter<'_> {
         self.into_iter()
     }
 }

--- a/crates/server/src/authority/authority_object.rs
+++ b/crates/server/src/authority/authority_object.rs
@@ -283,6 +283,7 @@ pub trait LookupObject: Send {
 }
 
 /// A lookup that returns no records
+#[derive(Clone, Copy, Debug)]
 pub struct EmptyLookup;
 
 impl LookupObject for EmptyLookup {
@@ -325,7 +326,7 @@ impl BoxedLookupFuture {
 impl Future for BoxedLookupFuture {
     type Output = Result<Box<dyn LookupObject>, LookupError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.as_mut().poll(cx)
     }
 }

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -44,7 +44,7 @@ pub struct Catalog {
 
 fn send_response<R: ResponseHandler>(
     response_edns: Option<Edns>,
-    mut response: MessageResponse,
+    mut response: MessageResponse<'_, '_>,
     mut response_handle: R,
 ) -> io::Result<()> {
     if let Some(mut resp_edns) = response_edns {

--- a/crates/server/src/authority/message_request.rs
+++ b/crates/server/src/authority/message_request.rs
@@ -217,7 +217,7 @@ pub struct Queries {
 }
 
 impl Queries {
-    fn read_queries(decoder: &mut BinDecoder, count: usize) -> ProtoResult<Vec<LowerQuery>> {
+    fn read_queries(decoder: &mut BinDecoder<'_>, count: usize) -> ProtoResult<Vec<LowerQuery>> {
         let mut queries = Vec::with_capacity(count);
         for _ in 0..count {
             queries.push(LowerQuery::read(decoder)?);
@@ -226,7 +226,7 @@ impl Queries {
     }
 
     /// Read queries from a decoder
-    pub fn read(decoder: &mut BinDecoder, num_queries: usize) -> ProtoResult<Self> {
+    pub fn read(decoder: &mut BinDecoder<'_>, num_queries: usize) -> ProtoResult<Self> {
         let queries_start = decoder.index();
         let queries = Self::read_queries(decoder, num_queries)?;
         let original = decoder
@@ -252,7 +252,7 @@ impl Queries {
         self.original.as_ref()
     }
 
-    pub(crate) fn as_emit_and_count(&self) -> QueriesEmitAndCount {
+    pub(crate) fn as_emit_and_count(&self) -> QueriesEmitAndCount<'_> {
         QueriesEmitAndCount {
             length: self.queries.len(),
             original: self.original.as_ref(),
@@ -266,14 +266,14 @@ pub(crate) struct QueriesEmitAndCount<'q> {
 }
 
 impl<'q> EmitAndCount for QueriesEmitAndCount<'q> {
-    fn emit(&mut self, encoder: &mut BinEncoder) -> ProtoResult<usize> {
+    fn emit(&mut self, encoder: &mut BinEncoder<'_>) -> ProtoResult<usize> {
         encoder.emit_vec(self.original)?;
         Ok(self.length)
     }
 }
 
 impl BinEncodable for MessageRequest {
-    fn emit(&self, encoder: &mut BinEncoder) -> ProtoResult<()> {
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         message::emit_message_parts(
             &self.header,
             // we emit the queries, not the raw bytes, in order to guarantee canonical form

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -52,7 +52,7 @@ impl<'q> From<Option<&'q Queries>> for EmptyOrQueries<'q> {
 }
 
 impl<'q> EmitAndCount for EmptyOrQueries<'q> {
-    fn emit(&mut self, encoder: &mut BinEncoder) -> ProtoResult<usize> {
+    fn emit(&mut self, encoder: &mut BinEncoder<'_>) -> ProtoResult<usize> {
         match self {
             EmptyOrQueries::Empty => Ok(0),
             EmptyOrQueries::Queries(q) => q.emit(encoder),
@@ -79,7 +79,7 @@ where
     }
 
     /// Consumes self, and emits to the encoder.
-    pub fn destructive_emit(mut self, encoder: &mut BinEncoder) -> ProtoResult<()> {
+    pub fn destructive_emit(mut self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         // soa records are part of the nameserver section
         let mut name_servers = self.name_servers.chain(self.soa);
 

--- a/crates/server/src/error/config_error.rs
+++ b/crates/server/src/error/config_error.rs
@@ -44,7 +44,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
             if #[cfg(feature = "with-backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {

--- a/crates/server/src/error/persistence_error.rs
+++ b/crates/server/src/error/persistence_error.rs
@@ -63,7 +63,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
             if #[cfg(feature = "with-backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -13,11 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// LIBRARY WARNINGS
 #![warn(
-    missing_docs,
     clippy::dbg_macro,
     clippy::print_stdout,
-    clippy::unimplemented
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
 )]
 #![allow(clippy::single_component_path_imports)]
 #![recursion_limit = "2048"]

--- a/crates/server/src/logger.rs
+++ b/crates/server/src/logger.rs
@@ -34,7 +34,7 @@ where
     writeln!(fmt, "{}:{}:{}:{}:{}", now_secs, level, module, line, args)
 }
 
-fn plain_formatter(fmt: &mut Formatter, record: &log::Record) -> io::Result<()> {
+fn plain_formatter(fmt: &mut Formatter, record: &log::Record<'_>) -> io::Result<()> {
     format(
         fmt,
         record.level(),

--- a/crates/server/src/server/https_handler.rs
+++ b/crates/server/src/server/https_handler.rs
@@ -21,7 +21,7 @@ use crate::server::request_handler::RequestHandler;
 use crate::server::response_handler::ResponseHandler;
 use crate::server::server_future;
 
-pub async fn h2_handler<T, I>(
+pub(crate) async fn h2_handler<T, I>(
     handler: Arc<Mutex<T>>,
     io: I,
     src_addr: SocketAddr,
@@ -91,7 +91,7 @@ async fn handle_request<T>(
 struct HttpsResponseHandle(Arc<Mutex<::h2::server::SendResponse<Bytes>>>);
 
 impl ResponseHandler for HttpsResponseHandle {
-    fn send_response(&mut self, response: MessageResponse) -> io::Result<()> {
+    fn send_response(&mut self, response: MessageResponse<'_, '_>) -> io::Result<()> {
         use crate::proto::serialize::binary::BinEncoder;
         use trust_dns_https::response;
         use trust_dns_https::HttpsError;

--- a/crates/server/src/server/response_handler.rs
+++ b/crates/server/src/server/response_handler.rs
@@ -23,7 +23,7 @@ pub trait ResponseHandler: Clone + Send + Unpin + 'static {
     /// Serializes and sends a message to to the wrapped handle
     ///
     /// self is consumed as only one message should ever be sent in response to a Request
-    fn send_response(&mut self, response: MessageResponse) -> io::Result<()>;
+    fn send_response(&mut self, response: MessageResponse<'_, '_>) -> io::Result<()>;
 }
 
 /// A handler for wrapping a BufStreamHandle, which will properly serialize the message and add the
@@ -45,7 +45,7 @@ impl ResponseHandler for ResponseHandle {
     /// Serializes and sends a message to to the wrapped handle
     ///
     /// self is consumed as only one message should ever be sent in response to a Request
-    fn send_response(&mut self, response: MessageResponse) -> io::Result<()> {
+    fn send_response(&mut self, response: MessageResponse<'_, '_>) -> io::Result<()> {
         info!(
             "response: {} response_code: {}",
             response.header().id(),
@@ -53,7 +53,7 @@ impl ResponseHandler for ResponseHandle {
         );
         let mut buffer = Vec::with_capacity(512);
         let encode_result = {
-            let mut encoder: BinEncoder = BinEncoder::new(&mut buffer);
+            let mut encoder = BinEncoder::new(&mut buffer);
             response.destructive_emit(&mut encoder)
         };
 

--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -601,7 +601,7 @@ pub(crate) enum HandleRawRequest<F: Future<Output = ()>> {
 impl<F: Future<Output = ()> + Unpin> Future for HandleRawRequest<F> {
     type Output = ();
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match *self {
             HandleRawRequest::HandleRequest(ref mut f) => f.poll_unpin(cx),
             HandleRawRequest::Result(ref res) => {

--- a/crates/server/src/server/timeout_stream.rs
+++ b/crates/server/src/server/timeout_stream.rs
@@ -50,7 +50,7 @@ where
     type Item = Result<I, io::Error>;
 
     // somehow insert a timeout here...
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // if the timer isn't set, set one now
         if self.timeout.is_none() {
             let timeout = Self::timeout(self.timeout_duration);

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -164,7 +164,7 @@ impl LookupObject for ForwardLookup {
     }
 }
 
-pub struct ForwardLookupFuture<
+pub(crate) struct ForwardLookupFuture<
     F: Future<Output = Result<ResolverLookup, ResolveError>> + Send + Unpin + 'static,
 >(F);
 
@@ -173,7 +173,7 @@ impl<F: Future<Output = Result<ResolverLookup, ResolveError>> + Send + Unpin> Fu
 {
     type Output = Result<ForwardLookup, LookupError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.0.poll_unpin(cx) {
             Poll::Ready(Ok(f)) => Poll::Ready(Ok(ForwardLookup(f))),
             Poll::Pending => Poll::Pending,

--- a/crates/server/src/store/sqlite/persistence.rs
+++ b/crates/server/src/store/sqlite/persistence.rs
@@ -52,7 +52,7 @@ impl Journal {
     }
 
     /// Returns a reference to the Sqlite Connection
-    pub fn conn(&self) -> MutexGuard<Connection> {
+    pub fn conn(&self) -> MutexGuard<'_, Connection> {
         self.conn.lock().expect("conn poisoned")
     }
 
@@ -62,7 +62,7 @@ impl Journal {
     }
 
     /// this returns an iterator from the beginning of time, to be used to recreate an authority
-    pub fn iter(&self) -> JournalIter {
+    pub fn iter(&self) -> JournalIter<'_> {
         JournalIter::new(self)
     }
 

--- a/util/src/bind_dnskey_to_pem.rs
+++ b/util/src/bind_dnskey_to_pem.rs
@@ -5,6 +5,21 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
+
+//! The bind_dnskey_to_pem program
+
+// BINARY WARNINGS
+#![warn(
+    clippy::dbg_macro,
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Lines, Write};
 use std::str::FromStr;
@@ -41,6 +56,7 @@ fn args<'a>() -> ArgMatches<'a> {
         .get_matches()
 }
 
+/// Run the bind_dnskey_to_pem program
 pub fn main() {
     env_logger::init();
     let matches = args();

--- a/util/src/get_root_ksks.rs
+++ b/util/src/get_root_ksks.rs
@@ -5,6 +5,21 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
+
+//! The get_root_ksks program
+
+// BINARY WARNINGS
+#![warn(
+    clippy::dbg_macro,
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
@@ -24,6 +39,7 @@ fn args<'a>() -> ArgMatches<'a> {
     app_from_crate!().bin_name("get-root-ksks").get_matches()
 }
 
+/// Run the get_root_ksks program
 pub fn main() {
     env_logger::init();
     let _matches = args();

--- a/util/src/pem_to_public_dnskey.rs
+++ b/util/src/pem_to_public_dnskey.rs
@@ -4,6 +4,21 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
+
+//! The pem_to_public_dnskey program
+
+// BINARY WARNINGS
+#![warn(
+    clippy::dbg_macro,
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Write};
 
@@ -39,6 +54,7 @@ fn args<'a>() -> ArgMatches<'a> {
         .get_matches()
 }
 
+/// Run the pem_to_public_dnskey program
 pub fn main() {
     env_logger::init();
     let matches = args();

--- a/util/src/resolve.rs
+++ b/util/src/resolve.rs
@@ -5,6 +5,20 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+//! The resolve program
+
+// BINARY WARNINGS
+#![warn(
+    clippy::dbg_macro,
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
 use std::net::SocketAddr;
 
 use console::style;
@@ -91,6 +105,7 @@ struct Opts {
     error: bool,
 }
 
+/// Run the resolve program
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts: Opts = Opts::from_args();


### PR DESCRIPTION
@leshow, Here's that PR. This makes all warnings across the crates consistent. I adopted most of your recommendations, except for the `Debug` one. That would have been really messy because there are a lot of external types that are not themselves Debug.

We can merge this after your PR, since it has the overlap on `Copy` in the `proto` crate

depends on: #1397