### PR TITLE
Add new HTTPS and SVCB record types

### DIFF
--- a/copyright.txt
+++ b/copyright.txt
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Benjamin Fry <benjaminfry@me.com>
+// Copyright 2015-2021 Benjamin Fry <benjaminfry@me.com>
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or

--- a/crates/client/src/error/parse_error.rs
+++ b/crates/client/src/error/parse_error.rs
@@ -196,6 +196,12 @@ impl From<ProtoError> for Error {
     }
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(_e: std::convert::Infallible) -> Error {
+        panic!("infallible")
+    }
+}
+
 impl From<Error> for io::Error {
     fn from(e: Error) -> Self {
         match *e.kind() {

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -46,6 +46,9 @@ impl RDataParser for RData {
             RecordType::CAA => caa::parse(tokens).map(RData::CAA)?,
             RecordType::CNAME => RData::CNAME(name::parse(tokens, origin)?),
             RecordType::HINFO => RData::HINFO(hinfo::parse(tokens)?),
+            // FIXME: actually implement this
+            #[allow(clippy::unimplemented)]
+            RecordType::HTTPS => unimplemented!("HTTPS records not yet supported in zone files"),
             RecordType::IXFR => panic!("parsing IXFR doesn't make sense"), // valid panic, never should happen
             RecordType::MX => RData::MX(mx::parse(tokens, origin)?),
             RecordType::NAPTR => RData::NAPTR(naptr::parse(tokens, origin)?),
@@ -57,6 +60,9 @@ impl RDataParser for RData {
             RecordType::SOA => RData::SOA(soa::parse(tokens, origin)?),
             RecordType::SRV => RData::SRV(srv::parse(tokens, origin)?),
             RecordType::SSHFP => RData::SSHFP(sshfp::parse(tokens)?),
+            // FIXME: actually implement this
+            #[allow(clippy::unimplemented)]
+            RecordType::SVCB => unimplemented!("SVCB records not yet supported in zone files"),
             RecordType::TLSA => RData::TLSA(tlsa::parse(tokens)?),
             RecordType::TXT => RData::TXT(txt::parse(tokens)?),
             RecordType::DNSSEC(DNSSECRecordType::SIG) => panic!("parsing SIG doesn't make sense"), // valid panic, never should happen

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -46,8 +46,7 @@ impl RDataParser for RData {
             RecordType::CAA => caa::parse(tokens).map(RData::CAA)?,
             RecordType::CNAME => RData::CNAME(name::parse(tokens, origin)?),
             RecordType::HINFO => RData::HINFO(hinfo::parse(tokens)?),
-            // FIXME: actually implement this
-            RecordType::HTTPS => unimplemented!("HTTPS records not yet supported in zone files"),
+            RecordType::HTTPS => svcb::parse(tokens).map(RData::SVCB)?,
             RecordType::IXFR => panic!("parsing IXFR doesn't make sense"), // valid panic, never should happen
             RecordType::MX => RData::MX(mx::parse(tokens, origin)?),
             RecordType::NAPTR => RData::NAPTR(naptr::parse(tokens, origin)?),
@@ -59,8 +58,7 @@ impl RDataParser for RData {
             RecordType::SOA => RData::SOA(soa::parse(tokens, origin)?),
             RecordType::SRV => RData::SRV(srv::parse(tokens, origin)?),
             RecordType::SSHFP => RData::SSHFP(sshfp::parse(tokens)?),
-            // FIXME: actually implement this
-            RecordType::SVCB => unimplemented!("SVCB records not yet supported in zone files"),
+            RecordType::SVCB => svcb::parse(tokens).map(RData::SVCB)?,
             RecordType::TLSA => RData::TLSA(tlsa::parse(tokens)?),
             RecordType::TXT => RData::TXT(txt::parse(tokens)?),
             RecordType::DNSSEC(DNSSECRecordType::SIG) => panic!("parsing SIG doesn't make sense"), // valid panic, never should happen

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -47,7 +47,6 @@ impl RDataParser for RData {
             RecordType::CNAME => RData::CNAME(name::parse(tokens, origin)?),
             RecordType::HINFO => RData::HINFO(hinfo::parse(tokens)?),
             // FIXME: actually implement this
-            #[allow(clippy::unimplemented)]
             RecordType::HTTPS => unimplemented!("HTTPS records not yet supported in zone files"),
             RecordType::IXFR => panic!("parsing IXFR doesn't make sense"), // valid panic, never should happen
             RecordType::MX => RData::MX(mx::parse(tokens, origin)?),
@@ -61,7 +60,6 @@ impl RDataParser for RData {
             RecordType::SRV => RData::SRV(srv::parse(tokens, origin)?),
             RecordType::SSHFP => RData::SSHFP(sshfp::parse(tokens)?),
             // FIXME: actually implement this
-            #[allow(clippy::unimplemented)]
             RecordType::SVCB => unimplemented!("SVCB records not yet supported in zone files"),
             RecordType::TLSA => RData::TLSA(tlsa::parse(tokens)?),
             RecordType::TXT => RData::TXT(txt::parse(tokens)?),

--- a/crates/client/src/serialize/txt/rdata_parsers/mod.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/mod.rs
@@ -31,5 +31,6 @@ pub(crate) mod openpgpkey;
 pub(crate) mod soa;
 pub(crate) mod srv;
 pub(crate) mod sshfp;
+pub(crate) mod svcb;
 pub(crate) mod tlsa;
 pub(crate) mod txt;

--- a/crates/client/src/serialize/txt/rdata_parsers/svcb.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/svcb.rs
@@ -1,0 +1,414 @@
+// Copyright 2015-2021 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! SVCB records in presentation format
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use crate::error::*;
+use crate::rr::rdata::svcb::*;
+use crate::rr::Name;
+use crate::serialize::txt::{Lexer, Token};
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-2.2)
+///
+/// ```text
+/// 2.1.  Zone file presentation format
+///
+///   The presentation format of the record is:
+///
+///   Name TTL IN SVCB SvcPriority TargetName SvcParams
+///
+///   The SVCB record is defined specifically within the Internet ("IN")
+///   Class ([RFC1035]).
+///
+///   SvcPriority is a number in the range 0-65535, TargetName is a domain
+///   name, and the SvcParams are a whitespace-separated list, with each
+///   SvcParam consisting of a SvcParamKey=SvcParamValue pair or a
+///   standalone SvcParamKey.  SvcParamKeys are subject to IANA control
+///   (Section 14.3).
+///
+///   Each SvcParamKey SHALL appear at most once in the SvcParams.  In
+///   presentation format, SvcParamKeys are lower-case alphanumeric
+///   strings.  Key names should contain 1-63 characters from the ranges
+///   "a"-"z", "0"-"9", and "-".  In ABNF [RFC5234],
+///
+///   alpha-lc      = %x61-7A   ;  a-z
+///   SvcParamKey   = 1*63(alpha-lc / DIGIT / "-")
+///   SvcParam      = SvcParamKey ["=" SvcParamValue]
+///   SvcParamValue = char-string
+///   value         = *OCTET
+///
+///   The SvcParamValue is parsed using the character-string decoding
+///   algorithm (Appendix A), producing a "value".  The "value" is then
+///   validated and converted into wire-format in a manner specific to each
+///   key.
+///
+///   When the "=" is omitted, the "value" is interpreted as empty.
+///
+///   Unrecognized keys are represented in presentation format as
+///   "keyNNNNN" where NNNNN is the numeric value of the key type without
+///   leading zeros.  A SvcParam in this form SHALL be parsed as specified
+///   above, and the decoded "value" SHALL be used as its wire format
+///   encoding.
+///
+///   For some SvcParamKeys, the "value" corresponds to a list or set of
+///   items.  Presentation formats for such keys SHOULD use a comma-
+///   separated list (Appendix A.1).
+///
+///   SvcParams in presentation format MAY appear in any order, but keys
+///   MUST NOT be repeated.
+/// ```
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<SVCB> {
+    // SvcPriority
+    let svc_priority: u16 = tokens
+        .next()
+        .ok_or_else(|| ParseError::from(ParseErrorKind::MissingToken("SvcPriority".to_string())))
+        .and_then(|s| s.parse().map_err(Into::into))?;
+
+    // svcb target
+    let target_name: Name = tokens
+        .next()
+        .ok_or_else(|| ParseError::from(ParseErrorKind::MissingToken("Target".to_string())))
+        .and_then(|s| Name::from_str(s).map_err(ParseError::from))?;
+
+    // Loop over all of the
+    let mut svc_params = Vec::new();
+    for token in tokens {
+        // first need to split the key and (optional) value
+        let mut key_value = token.splitn(2, '=');
+        let key = key_value.next().ok_or_else(|| {
+            ParseError::from(ParseErrorKind::MissingToken(
+                "SVCB SvcbParams missing".to_string(),
+            ))
+        })?;
+
+        // get the value, and remove any quotes
+        let value = key_value.next();
+        svc_params.push(into_svc_param(key, value)?);
+    }
+
+    Ok(SVCB::new(svc_priority, target_name, svc_params))
+}
+
+// first take the param and convert to
+fn into_svc_param(
+    key: &str,
+    value: Option<&str>,
+) -> Result<(SvcParamKey, SvcParamValue), ParseError> {
+    let key = SvcParamKey::from_str(key)?;
+    let value = parse_value(key, value)?;
+
+    Ok((key, value))
+}
+
+fn parse_value(key: SvcParamKey, value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    match key {
+        SvcParamKey::Mandatory => parse_mandatory(value),
+        SvcParamKey::Alpn => parse_alpn(value),
+        SvcParamKey::NoDefaultAlpn => parse_no_default_alpn(value),
+        SvcParamKey::Port => parse_port(value),
+        SvcParamKey::Ipv4Hint => parse_ipv4_hint(value),
+        SvcParamKey::EchConfig => parse_ech_config(value),
+        SvcParamKey::Ipv6Hint => parse_ipv6_hint(value),
+        SvcParamKey::Key(_) => parse_unknown(value),
+        SvcParamKey::Key65535 | SvcParamKey::Unknown(_) => {
+            Err(ParseError::from(ParseErrorKind::Message(
+                "Bad Key type or unsupported, see generic key option, e.g. key1234",
+            )))
+        }
+    }
+}
+
+fn parse_char_data(value: &str) -> Result<String, ParseError> {
+    let mut lex = Lexer::new(value);
+    let ch_data = lex
+        .next_token()?
+        .ok_or_else(|| ParseError::from(ParseErrorKind::Message("expected character data")))?;
+
+    match ch_data {
+        Token::CharData(data) => Ok(data),
+        _ => Err(ParseError::from(ParseErrorKind::Message(
+            "expected character data",
+        ))),
+    }
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-7)
+/// ```text
+/// The presentation "value" SHALL be a comma-separated list
+///   (Appendix A.1) of one or more valid SvcParamKeys, either by their
+///   registered name or in the unknown-key format (Section 2.1).  Keys MAY
+///   appear in any order, but MUST NOT appear more than once.  For self-
+///   consistency (Section 2.4.3), listed keys MUST also appear in the
+///   SvcParams.
+///
+///   To enable simpler parsing, this SvcParamValue MUST NOT contain escape
+///   sequences.
+///
+///   For example, the following is a valid list of SvcParams:
+///
+///   echconfig=... key65333=ex1 key65444=ex2 mandatory=key65444,echconfig
+/// ```
+///
+/// Currently this does not validate that the mandatory section matches the other keys
+fn parse_mandatory(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    let value = value.ok_or_else(|| {
+        ParseError::from(ParseErrorKind::Message(
+            "expected at least one Mandatory field",
+        ))
+    })?;
+
+    let mandatories = parse_list::<SvcParamKey>(value)?;
+    Ok(SvcParamValue::Mandatory(Mandatory(mandatories)))
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-6.1)
+/// ```text
+/// ALPNs are identified by their registered "Identification Sequence"
+///   ("alpn-id"), which is a sequence of 1-255 octets.
+///
+///   alpn-id = 1*255OCTET
+///
+///   The presentation "value" SHALL be a comma-separated list
+///   (Appendix A.1) of one or more "alpn-id"s.
+/// ```
+///
+/// This does not currently check to see if the ALPN code is legitimate
+fn parse_alpn(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    let value = value.ok_or_else(|| {
+        ParseError::from(ParseErrorKind::Message("expected at least one ALPN code"))
+    })?;
+
+    let alpns = parse_list::<String>(value).expect("infallible");
+    Ok(SvcParamValue::Alpn(Alpn(alpns)))
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-6.1)
+/// ```text
+/// For "no-default-alpn", the presentation and wire format values MUST
+///   be empty.  When "no-default-alpn" is specified in an RR, "alpn" must
+///   also be specified in order for the RR to be "self-consistent"
+///   (Section 2.4.3).
+/// ```
+fn parse_no_default_alpn(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    if value.is_some() {
+        return Err(ParseErrorKind::Message("no value expected for NoDefaultAlpn").into());
+    }
+
+    Ok(SvcParamValue::NoDefaultAlpn)
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-6.2)
+/// ```text
+/// The presentation "value" of the SvcParamValue is a single decimal
+///   integer between 0 and 65535 in ASCII.  Any other "value" (e.g. an
+///   empty value) is a syntax error.  To enable simpler parsing, this
+///   SvcParam MUST NOT contain escape sequences.
+/// ```
+fn parse_port(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    let value = value.ok_or_else(|| {
+        ParseError::from(ParseErrorKind::Message("a port number for the port option"))
+    })?;
+
+    let value = parse_char_data(value)?;
+    let port = u16::from_str(&value)?;
+    Ok(SvcParamValue::Port(port))
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-6.4)
+/// ```text
+/// The presentation "value" SHALL be a comma-separated list
+///   (Appendix A.1) of one or more IP addresses of the appropriate family
+///   in standard textual format [RFC5952].  To enable simpler parsing,
+///   this SvcParamValue MUST NOT contain escape sequences.
+/// ```
+fn parse_ipv4_hint(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    let value = value.ok_or_else(|| {
+        ParseError::from(ParseErrorKind::Message("expected at least one ipv4 hint"))
+    })?;
+
+    let hints = parse_list::<Ipv4Addr>(value)?;
+    Ok(SvcParamValue::Ipv4Hint(IpHint(hints)))
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-9)
+/// ```text
+/// In presentation format, the value is a
+///   single ECHConfigs encoded in Base64 [base64].  Base64 is used here to
+///   simplify integration with TLS server software.  To enable simpler
+///   parsing, this SvcParam MUST NOT contain escape sequences.
+/// ```
+fn parse_ech_config(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    let value = value.ok_or_else(|| {
+        ParseError::from(ParseErrorKind::Message(
+            "expected a base64 encoded string for EchConfig",
+        ))
+    })?;
+
+    let value = parse_char_data(value)?;
+    let ech_config_bytes = data_encoding::BASE64.decode(value.as_bytes())?;
+    Ok(SvcParamValue::EchConfig(EchConfig(ech_config_bytes)))
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-6.4)
+/// ```text
+/// The presentation "value" SHALL be a comma-separated list
+///   (Appendix A.1) of one or more IP addresses of the appropriate family
+///   in standard textual format [RFC5952].  To enable simpler parsing,
+///   this SvcParamValue MUST NOT contain escape sequences.
+/// ```
+fn parse_ipv6_hint(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    let value = value.ok_or_else(|| {
+        ParseError::from(ParseErrorKind::Message("expected at least one ipv6 hint"))
+    })?;
+
+    let hints = parse_list::<Ipv6Addr>(value)?;
+    Ok(SvcParamValue::Ipv6Hint(IpHint(hints)))
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-2.1)
+/// ```text
+/// Unrecognized keys are represented in presentation format as
+///   "keyNNNNN" where NNNNN is the numeric value of the key type without
+///   leading zeros.  A SvcParam in this form SHALL be parsed as specified
+///   above, and the decoded "value" SHALL be used as its wire format
+///   encoding.
+///
+///   For some SvcParamKeys, the "value" corresponds to a list or set of
+///   items.  Presentation formats for such keys SHOULD use a comma-
+///   separated list (Appendix A.1).
+///
+///   SvcParams in presentation format MAY appear in any order, but keys
+///   MUST NOT be repeated.
+/// ```
+#[allow(clippy::unnecessary_wraps)]
+fn parse_unknown(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
+    let unknown: Vec<Vec<u8>> = if let Some(value) = value {
+        let unknown = parse_list::<String>(value).expect("infallible");
+
+        unknown.into_iter().map(|s| s.as_bytes().to_vec()).collect()
+    } else {
+        Vec::new()
+    };
+
+    Ok(SvcParamValue::Unknown(Unknown(unknown)))
+}
+
+fn parse_list<T>(value: &str) -> Result<Vec<T>, ParseError>
+where
+    T: FromStr,
+    T::Err: Into<ParseError>,
+{
+    let mut result = Vec::new();
+
+    let values = value.trim_end_matches(',').split(',');
+    for value in values {
+        let value = parse_char_data(value)?;
+        let value = T::from_str(&value).map_err(|e| e.into())?;
+        result.push(value);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rr::DNSClass;
+    use crate::serialize::txt::{Lexer, Parser};
+
+    use super::*;
+
+    // this assumes that only a single record is parsed
+    // TODO: make Parser return an iterator over all records in a stream.
+    fn parse_record(txt: &str) -> SVCB {
+        let lex = Lexer::new(txt);
+        let mut parser = Parser::new();
+
+        let records = parser
+            .parse(lex, Some(Name::root()), Some(DNSClass::IN))
+            .expect("failed to parse record")
+            .1;
+        let record_set = records.into_iter().next().expect("no record found").1;
+        record_set
+            .into_iter()
+            .next()
+            .unwrap()
+            .rdata()
+            .as_svcb()
+            .expect("Not an SVCB record")
+            .clone()
+    }
+
+    #[test]
+    fn test_parsing() {
+        let svcb = parse_record("crypto.cloudflare.com. 299 IN SVCB 1 . alpn=h2, ipv4hint=162.159.135.79,162.159.136.79, echconfig=\"/gkAQwATY2xvdWRmbGFyZS1lc25pLmNvbQAgUbBtC3UeykwwE6C87TffqLJ/1CeaAvx3iESGyds85l8AIAAEAAEAAQAAAAA=\" ipv6hint=2606:4700:7::a29f:874f,2606:4700:7::a29f:884f,");
+
+        assert_eq!(svcb.svc_priority(), 1);
+        assert_eq!(*svcb.target_name(), Name::root());
+
+        let mut params = svcb.svc_params().iter();
+
+        // alpn
+        let param = params.next().expect("not alpn");
+        assert_eq!(param.0, SvcParamKey::Alpn);
+        assert_eq!(param.1.as_alpn().expect("not alpn").0, &["h2"]);
+
+        // ipv4 hint
+        let param = params.next().expect("ipv4hint");
+        assert_eq!(SvcParamKey::Ipv4Hint, param.0);
+        assert_eq!(
+            param.1.as_ipv4_hint().expect("ipv4hint").0,
+            &[
+                Ipv4Addr::from([162, 159, 135, 79]),
+                Ipv4Addr::from([162, 159, 136, 79])
+            ]
+        );
+
+        // echconfig
+        let param = params.next().expect("echconfig");
+        assert_eq!(SvcParamKey::EchConfig, param.0);
+        assert_eq!(
+            param.1.as_ech_config().expect("echconfig").0,
+            data_encoding::BASE64.decode("/gkAQwATY2xvdWRmbGFyZS1lc25pLmNvbQAgUbBtC3UeykwwE6C87TffqLJ/1CeaAvx3iESGyds85l8AIAAEAAEAAQAAAAA=".as_bytes()).unwrap()
+        );
+
+        // ipv6 hint
+        let param = params.next().expect("ipv6hint");
+        assert_eq!(SvcParamKey::Ipv6Hint, param.0);
+        assert_eq!(
+            param.1.as_ipv6_hint().expect("ipv6hint").0,
+            &[
+                Ipv6Addr::from([0x2606, 0x4700, 0x7, 0, 0, 0, 0xa29f, 0x874f]),
+                Ipv6Addr::from([0x2606, 0x4700, 0x7, 0, 0, 0, 0xa29f, 0x884f])
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_display() {
+        let svcb = parse_record("crypto.cloudflare.com. 299 IN SVCB 1 . alpn=h2, ipv4hint=162.159.135.79,162.159.136.79, echconfig=\"/gkAQwATY2xvdWRmbGFyZS1lc25pLmNvbQAgUbBtC3UeykwwE6C87TffqLJ/1CeaAvx3iESGyds85l8AIAAEAAEAAQAAAAA=\" ipv6hint=2606:4700:7::a29f:874f,2606:4700:7::a29f:884f,");
+
+        let svcb_display = svcb.to_string();
+
+        // add back the name, etc...
+        let svcb_display = format!("crypto.cloudflare.com. 299 IN SVCB {}", svcb_display);
+        let svcb_display = parse_record(&svcb_display);
+
+        assert_eq!(svcb, svcb_display);
+    }
+
+    /// sanity check for https
+    #[test]
+    fn test_parsing_https() {
+        let svcb = parse_record("crypto.cloudflare.com. 299 IN HTTPS 1 . alpn=h2, ipv4hint=162.159.135.79,162.159.136.79, echconfig=\"/gkAQwATY2xvdWRmbGFyZS1lc25pLmNvbQAgUbBtC3UeykwwE6C87TffqLJ/1CeaAvx3iESGyds85l8AIAAEAAEAAQAAAAA=\" ipv6hint=2606:4700:7::a29f:874f,2606:4700:7::a29f:884f,");
+
+        assert_eq!(svcb.svc_priority(), 1);
+        assert_eq!(*svcb.target_name(), Name::root());
+    }
+}

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -218,6 +218,10 @@ pub enum ProtoErrorKind {
     #[error("error parsing utf8 string")]
     Utf8(#[from] std::str::Utf8Error),
 
+    /// A utf8 parsing error
+    #[error("error parsing utf8 string")]
+    FromUtf8(#[from] std::string::FromUtf8Error),
+
     /// An int parsing error
     #[error("error parsing int")]
     ParseInt(#[from] std::num::ParseIntError),
@@ -335,6 +339,12 @@ impl From<url::ParseError> for ProtoError {
 
 impl From<std::str::Utf8Error> for ProtoError {
     fn from(e: std::str::Utf8Error) -> ProtoError {
+        ProtoErrorKind::from(e).into()
+    }
+}
+
+impl From<std::string::FromUtf8Error> for ProtoError {
+    fn from(e: std::string::FromUtf8Error) -> ProtoError {
         ProtoErrorKind::from(e).into()
     }
 }
@@ -458,6 +468,7 @@ impl Clone for ProtoErrorKind {
             Timer => Timer,
             UrlParsing(ref e) => UrlParsing(*e),
             Utf8(ref e) => Utf8(*e),
+            FromUtf8(ref e) => FromUtf8(e.clone()),
             ParseInt(ref e) => ParseInt(e.clone()),
         }
     }

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -690,6 +690,8 @@ impl Message {
 /// Consumes `Message` giving public access to fields in `Message` so they can be
 /// destructured and taken by value
 /// ```rust
+/// use trust_dns_proto::op::{Message, MessageParts};
+///
 ///  let msg = Message::new();
 ///  let MessageParts { queries, .. } = msg.into_parts();
 /// ```

--- a/crates/proto/src/op/mod.rs
+++ b/crates/proto/src/op/mod.rs
@@ -27,7 +27,7 @@ pub mod response_code;
 pub use self::edns::Edns;
 pub use self::header::Header;
 pub use self::header::MessageType;
-pub use self::message::{Message, MessageFinalizer, NoopMessageFinalizer};
+pub use self::message::{Message, MessageFinalizer, MessageParts, NoopMessageFinalizer};
 pub use self::op_code::OpCode;
 pub use self::query::Query;
 pub use self::response_code::ResponseCode;

--- a/crates/proto/src/rr/rdata/mod.rs
+++ b/crates/proto/src/rr/rdata/mod.rs
@@ -32,6 +32,7 @@ pub mod opt;
 pub mod soa;
 pub mod srv;
 pub mod sshfp;
+pub mod svcb;
 pub mod tlsa;
 pub mod txt;
 
@@ -45,5 +46,6 @@ pub use self::opt::OPT;
 pub use self::soa::SOA;
 pub use self::srv::SRV;
 pub use self::sshfp::SSHFP;
+pub use self::svcb::SVCB;
 pub use self::tlsa::TLSA;
 pub use self::txt::TXT;

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -1,0 +1,448 @@
+// Copyright 2015-2021 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! SSHFP records for SSH public key fingerprints
+use std::cmp::{Ord, Ordering, PartialOrd};
+use std::fmt;
+
+use crate::error::*;
+use crate::rr::Name;
+use crate::serialize::binary::*;
+
+///  [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-2.2)
+///
+/// ```text
+/// 2.2.  RDATA wire format
+///
+///   The RDATA for the SVCB RR consists of:
+///
+///   *  a 2 octet field for SvcPriority as an integer in network byte
+///      order.
+///   *  the uncompressed, fully-qualified TargetName, represented as a
+///      sequence of length-prefixed labels as in Section 3.1 of [RFC1035].
+///   *  the SvcParams, consuming the remainder of the record (so smaller
+///      than 65535 octets and constrained by the RDATA and DNS message
+///      sizes).
+///
+///   When the list of SvcParams is non-empty (ServiceMode), it contains a
+///   series of SvcParamKey=SvcParamValue pairs, represented as:
+///
+///   *  a 2 octet field containing the SvcParamKey as an integer in
+///      network byte order.  (See Section 14.3.2 for the defined values.)
+///   *  a 2 octet field containing the length of the SvcParamValue as an
+///      integer between 0 and 65535 in network byte order (but constrained
+///      by the RDATA and DNS message sizes).
+///   *  an octet string of this length whose contents are in a format
+///      determined by the SvcParamKey.
+///
+///   SvcParamKeys SHALL appear in increasing numeric order.
+///
+///   Clients MUST consider an RR malformed if:
+///
+///   *  the end of the RDATA occurs within a SvcParam.
+///   *  SvcParamKeys are not in strictly increasing numeric order.
+///   *  the SvcParamValue for an SvcParamKey does not have the expected
+///      format.
+///
+///   Note that the second condition implies that there are no duplicate
+///   SvcParamKeys.
+///
+///   If any RRs are malformed, the client MUST reject the entire RRSet and
+///   fall back to non-SVCB connection establishment.
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct SVCB {
+    svc_priority: u16,
+    target_name: Name,
+    svc_params: Vec<(SvcParamKey, SvcParamValue)>,
+}
+
+impl SVCB {
+    /// Create a new SVCB record from parts
+    ///
+    /// It is up to the caller to validate the data going into the record
+    pub fn new(
+        svc_priority: u16,
+        target_name: Name,
+        svc_params: Vec<(SvcParamKey, SvcParamValue)>,
+    ) -> Self {
+        Self {
+            svc_priority,
+            target_name,
+            svc_params,
+        }
+    }
+}
+
+/// ```text
+/// 14.3.2.  Initial contents
+///
+///   The "Service Binding (SVCB) Parameter Registry" shall initially be
+///   populated with the registrations below:
+///
+///   +=============+=================+======================+===========+
+///   | Number      | Name            | Meaning              | Reference |
+///   +=============+=================+======================+===========+
+///   | 0           | mandatory       | Mandatory keys in    | (This     |
+///   |             |                 | this RR              | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///   | 1           | alpn            | Additional supported | (This     |
+///   |             |                 | protocols            | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///   | 2           | no-default-alpn | No support for       | (This     |
+///   |             |                 | default protocol     | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///   | 3           | port            | Port for alternative | (This     |
+///   |             |                 | endpoint             | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///   | 4           | ipv4hint        | IPv4 address hints   | (This     |
+///   |             |                 |                      | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///   | 5           | echconfig       | Encrypted            | (This     |
+///   |             |                 | ClientHello info     | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///   | 6           | ipv6hint        | IPv6 address hints   | (This     |
+///   |             |                 |                      | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///   | 65280-65534 | keyNNNNN        | Private Use          | (This     |
+///   |             |                 |                      | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///   | 65535       | key65535        | Reserved ("Invalid   | (This     |
+///   |             |                 | key")                | document) |
+///   +-------------+-----------------+----------------------+-----------+
+///
+/// parsing done via:
+///   *  a 2 octet field containing the SvcParamKey as an integer in
+///      network byte order.  (See Section 14.3.2 for the defined values.)
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum SvcParamKey {
+    /// Mandatory keys in this RR
+    Mandatory,
+    /// Additional supported protocols
+    Alpn,
+    /// No support for default protocol
+    NoDefaultAlpn,
+    /// Port for alternative endpoint
+    Port,
+    /// IPv4 address hints
+    Ipv4Hint,
+    /// Encrypted ClientHello info
+    EchConfig,
+    /// IPv6 address hints
+    Ipv6Hint,
+    /// Private Use
+    Key(u16),
+    /// Reserved ("Invalid key")
+    Key65535,
+    /// Unknown
+    Unknown(u16),
+}
+
+impl From<u16> for SvcParamKey {
+    fn from(val: u16) -> Self {
+        match val {
+            0 => SvcParamKey::Mandatory,
+            1 => SvcParamKey::Alpn,
+            2 => SvcParamKey::NoDefaultAlpn,
+            3 => SvcParamKey::Port,
+            4 => SvcParamKey::Ipv4Hint,
+            5 => SvcParamKey::EchConfig,
+            6 => SvcParamKey::Ipv6Hint,
+            65280..=65534 => SvcParamKey::Key(val),
+            65535 => SvcParamKey::Key65535,
+            _ => SvcParamKey::Unknown(val),
+        }
+    }
+}
+
+impl From<SvcParamKey> for u16 {
+    fn from(val: SvcParamKey) -> Self {
+        match val {
+            SvcParamKey::Mandatory => 0,
+            SvcParamKey::Alpn => 1,
+            SvcParamKey::NoDefaultAlpn => 2,
+            SvcParamKey::Port => 3,
+            SvcParamKey::Ipv4Hint => 4,
+            SvcParamKey::EchConfig => 5,
+            SvcParamKey::Ipv6Hint => 6,
+            SvcParamKey::Key(val) => val,
+            SvcParamKey::Key65535 => 65535,
+            SvcParamKey::Unknown(val) => val,
+        }
+    }
+}
+
+impl fmt::Display for SvcParamKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let mut write_key = |name| write!(f, "{}", name);
+
+        match *self {
+            SvcParamKey::Mandatory => write_key("mandatory")?,
+            SvcParamKey::Alpn => write_key("alpn")?,
+            SvcParamKey::NoDefaultAlpn => write_key("no-default-alpn")?,
+            SvcParamKey::Port => write_key("port")?,
+            SvcParamKey::Ipv4Hint => write_key("ipv4hint")?,
+            SvcParamKey::EchConfig => write_key("echconfig")?,
+            SvcParamKey::Ipv6Hint => write_key("ipv6hint")?,
+            SvcParamKey::Key(val) => write!(f, "key{}", val)?,
+            SvcParamKey::Key65535 => write_key("key65535")?,
+            SvcParamKey::Unknown(val) => write!(f, "unknown{}", val)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Ord for SvcParamKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u16::from(*self).cmp(&u16::from(*other))
+    }
+}
+
+impl PartialOrd for SvcParamKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Warning, it is currently up to users of this type to validate the data against that expected by the key
+///
+/// ```text
+///   *  a 2 octet field containing the length of the SvcParamValue as an
+///      integer between 0 and 65535 in network byte order (but constrained
+///      by the RDATA and DNS message sizes).
+///   *  an octet string of this length whose contents are in a format
+///      determined by the SvcParamKey.
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[repr(transparent)]
+pub struct SvcParamValue(Vec<u8>);
+
+impl SvcParamValue {
+    /// Return the inner data as a slice of bytes
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for SvcParamValue {
+    fn from(val: Vec<u8>) -> Self {
+        Self(val)
+    }
+}
+
+impl From<SvcParamValue> for Vec<u8> {
+    fn from(val: SvcParamValue) -> Self {
+        val.0
+    }
+}
+
+/// Reads the SVCB record from the decoder.
+///
+/// ```text
+///   Clients MUST consider an RR malformed if:
+///
+///   *  the end of the RDATA occurs within a SvcParam.
+///   *  SvcParamKeys are not in strictly increasing numeric order.
+///   *  the SvcParamValue for an SvcParamKey does not have the expected
+///      format.
+///
+///   Note that the second condition implies that there are no duplicate
+///   SvcParamKeys.
+///
+///   If any RRs are malformed, the client MUST reject the entire RRSet and
+///   fall back to non-SVCB connection establishment.
+/// ```
+pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoResult<SVCB> {
+    let start_index = decoder.index();
+
+    let svc_priority = decoder.read_u16()?.unverified(/*any u16 is valid*/);
+    let target_name = Name::read(decoder)?;
+
+    let mut remainder_len = rdata_length.map(|len| len as usize - (decoder.index() - start_index)).unverified(/*valid len*/);
+    let mut svc_params: Vec<(SvcParamKey, SvcParamValue)> = Vec::new();
+
+    // must have at least 4 bytes left for the key and the length
+    while remainder_len >= 4 {
+        // a 2 octet field containing the SvcParamKey as an integer in
+        //      network byte order.  (See Section 14.3.2 for the defined values.)
+        let key: SvcParamKey = decoder.read_u16()?.unverified(/*any u16 is valid*/).into();
+
+        // a 2 octet field containing the length of the SvcParamValue as an
+        //      integer between 0 and 65535 in network byte order (but constrained
+        //      by the RDATA and DNS message sizes).
+        let len: u16 = decoder
+            .read_u16()?
+            .verify_unwrap(|len| *len as usize <= remainder_len)
+            .map_err(|u| {
+                ProtoError::from(format!(
+                    "length of SvcParamValue ({}) exceeds remainder in RDATA ({})",
+                    u, remainder_len
+                ))
+            })?;
+
+        // an octet string of this length whose contents are in a format
+        //      determined by the SvcParamKey.
+        let value = decoder.read_vec(len as usize)?.unverified(/*char data for users*/);
+
+        if let Some(last_key) = svc_params.last().map(|(key, _)| key) {
+            if last_key >= &key {
+                return Err(ProtoError::from("SvcParams out of order"));
+            }
+        }
+
+        svc_params.push((key, value.into()));
+        remainder_len = rdata_length.map(|len| len as usize - (decoder.index() - start_index)).unverified(/*valid len*/);
+    }
+
+    Ok(SVCB {
+        svc_priority,
+        target_name,
+        svc_params,
+    })
+}
+
+/// Write the RData from the given Decoder
+pub fn emit(encoder: &mut BinEncoder<'_>, svcb: &SVCB) -> ProtoResult<()> {
+    svcb.svc_priority.emit(encoder)?;
+    svcb.target_name.emit(encoder)?;
+
+    let mut last_key: Option<SvcParamKey> = None;
+    for (key, param) in svcb.svc_params.iter() {
+        if let Some(last_key) = last_key {
+            if key <= &last_key {
+                return Err(ProtoError::from("SvcParams out of order"));
+            }
+        }
+
+        if param.as_slice().len() > u16::MAX as usize {
+            return Err(ProtoError::from("SvcParams exceeds u16 max size"));
+        }
+
+        encoder.emit_u16((*key).into())?;
+        encoder.emit_u16(param.as_slice().len() as u16)?;
+        encoder.emit_vec(param.as_slice())?;
+
+        last_key = Some(*key);
+    }
+
+    Ok(())
+}
+
+/// [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-10.3)
+///
+/// ```text
+/// simple.example. 7200 IN HTTPS 1 . alpn=h3
+/// pool  7200 IN HTTPS 1 h3pool alpn=h2,h3 echconfig="123..."
+///               HTTPS 2 .      alpn=h2 echconfig="abc..."
+/// @     7200 IN HTTPS 0 www
+/// _8765._baz.api.example.com. 7200 IN SVCB 0 svc4-baz.example.net.
+/// ```
+impl fmt::Display for SVCB {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{svc_priority} {target_name}",
+            svc_priority = self.svc_priority,
+            target_name = self.target_name,
+        )?;
+
+        for (key, param) in self.svc_params.iter() {
+            let param = String::from_utf8_lossy(param.as_slice());
+            write!(f, " {key}=\"{param}\"", key = key, param = param)?
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_svcb_key() {
+        assert_eq!(SvcParamKey::Mandatory, 0.into());
+        assert_eq!(SvcParamKey::Alpn, 1.into());
+        assert_eq!(SvcParamKey::NoDefaultAlpn, 2.into());
+        assert_eq!(SvcParamKey::Port, 3.into());
+        assert_eq!(SvcParamKey::Ipv4Hint, 4.into());
+        assert_eq!(SvcParamKey::EchConfig, 5.into());
+        assert_eq!(SvcParamKey::Ipv6Hint, 6.into());
+        assert_eq!(SvcParamKey::Key(65280), 65280.into());
+        assert_eq!(SvcParamKey::Key(65534), 65534.into());
+        assert_eq!(SvcParamKey::Key65535, 65535.into());
+        assert_eq!(SvcParamKey::Unknown(65279), 65279.into());
+    }
+
+    #[test]
+    fn read_svcb_key_to_u16() {
+        assert_eq!(u16::from(SvcParamKey::Mandatory), 0);
+        assert_eq!(u16::from(SvcParamKey::Alpn), 1);
+        assert_eq!(u16::from(SvcParamKey::NoDefaultAlpn), 2);
+        assert_eq!(u16::from(SvcParamKey::Port), 3);
+        assert_eq!(u16::from(SvcParamKey::Ipv4Hint), 4);
+        assert_eq!(u16::from(SvcParamKey::EchConfig), 5);
+        assert_eq!(u16::from(SvcParamKey::Ipv6Hint), 6);
+        assert_eq!(u16::from(SvcParamKey::Key(65280)), 65280);
+        assert_eq!(u16::from(SvcParamKey::Key(65534)), 65534);
+        assert_eq!(u16::from(SvcParamKey::Key65535), 65535);
+        assert_eq!(u16::from(SvcParamKey::Unknown(65279)), 65279);
+    }
+
+    #[track_caller]
+    fn test_encode_decode(rdata: SVCB) {
+        let mut bytes = Vec::new();
+        let mut encoder: BinEncoder<'_> = BinEncoder::new(&mut bytes);
+        emit(&mut encoder, &rdata).expect("failed to emit SVCB");
+        let bytes = encoder.into_bytes();
+
+        println!("svcb: {}", rdata);
+        println!("bytes: {:?}", bytes);
+
+        let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
+        let read_rdata =
+            read(&mut decoder, Restrict::new(bytes.len() as u16)).expect("failed to read back");
+        assert_eq!(rdata, read_rdata);
+    }
+
+    #[test]
+    fn test_encode_decode_svcb() {
+        test_encode_decode(SVCB::new(
+            0,
+            Name::from_utf8("www.example.com.").unwrap(),
+            vec![],
+        ));
+        test_encode_decode(SVCB::new(
+            0,
+            Name::from_utf8(".").unwrap(),
+            vec![(SvcParamKey::Alpn, "h2".as_bytes().to_vec().into())],
+        ));
+        test_encode_decode(SVCB::new(
+            0,
+            Name::from_utf8("example.com.").unwrap(),
+            vec![
+                (SvcParamKey::Mandatory, "alpn".as_bytes().to_vec().into()),
+                (SvcParamKey::Alpn, "h2".as_bytes().to_vec().into()),
+            ],
+        ));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_encode_decode_svcb_bad_order() {
+        test_encode_decode(SVCB::new(
+            0,
+            Name::from_utf8(".").unwrap(),
+            vec![
+                (SvcParamKey::Alpn, "h2".as_bytes().to_vec().into()),
+                (SvcParamKey::Mandatory, "alpn".as_bytes().to_vec().into()),
+            ],
+        ));
+    }
+}

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -5,9 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! SSHFP records for SSH public key fingerprints
-use std::cmp::{Ord, Ordering, PartialOrd};
-use std::fmt;
+//! SVCB records, see [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03)
+
+use std::{
+    cmp::{Ord, Ordering, PartialOrd},
+    convert::TryFrom,
+    fmt,
+    net::Ipv4Addr,
+    net::Ipv6Addr,
+};
 
 use crate::error::*;
 use crate::rr::Name;
@@ -177,6 +183,22 @@ impl From<SvcParamKey> for u16 {
     }
 }
 
+impl<'r> BinDecodable<'r> for SvcParamKey {
+    // a 2 octet field containing the SvcParamKey as an integer in
+    //      network byte order.  (See Section 14.3.2 for the defined values.)
+    fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Self> {
+        Ok(decoder.read_u16()?.unverified(/*any u16 is valid*/).into())
+    }
+}
+
+impl BinEncodable for SvcParamKey {
+    // a 2 octet field containing the SvcParamKey as an integer in
+    //      network byte order.  (See Section 14.3.2 for the defined values.)
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        encoder.emit_u16((*self).into())
+    }
+}
+
 impl fmt::Display for SvcParamKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let mut write_key = |name| write!(f, "{}", name);
@@ -220,25 +242,620 @@ impl PartialOrd for SvcParamKey {
 ///      determined by the SvcParamKey.
 /// ```
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
-#[repr(transparent)]
-pub struct SvcParamValue(Vec<u8>);
+pub enum SvcParamValue {
+    ///    In a ServiceMode RR, a SvcParamKey is considered "mandatory" if the
+    ///    RR will not function correctly for clients that ignore this
+    ///    SvcParamKey.  Each SVCB protocol mapping SHOULD specify a set of keys
+    ///    that are "automatically mandatory", i.e. mandatory if they are
+    ///    present in an RR.  The SvcParamKey "mandatory" is used to indicate
+    ///    any mandatory keys for this RR, in addition to any automatically
+    ///    mandatory keys that are present.
+    ///
+    /// see `Mandatory`
+    Mandatory(Mandatory),
+    /// The "alpn" and "no-default-alpn" SvcParamKeys together indicate the
+    ///    set of Application Layer Protocol Negotiation (ALPN) protocol
+    ///    identifiers [ALPN] and associated transport protocols supported by
+    ///    this service endpoint.
+    Alpn(Alpn),
+    /// For "no-default-alpn", the presentation and wire format values MUST
+    ///    be empty.
+    /// See also `Alpn`
+    NoDefaultAlpn,
+    /// ```text
+    ///    6.2.  "port"
+    ///
+    ///   The "port" SvcParamKey defines the TCP or UDP port that should be
+    ///   used to reach this alternative endpoint.  If this key is not present,
+    ///   clients SHALL use the authority endpoint's port number.
+    ///
+    ///   The presentation "value" of the SvcParamValue is a single decimal
+    ///   integer between 0 and 65535 in ASCII.  Any other "value" (e.g. an
+    ///   empty value) is a syntax error.  To enable simpler parsing, this
+    ///   SvcParam MUST NOT contain escape sequences.
+    ///
+    ///   The wire format of the SvcParamValue is the corresponding 2 octet
+    ///   numeric value in network byte order.
+    ///
+    ///   If a port-restricting firewall is in place between some client and
+    ///   the service endpoint, changing the port number might cause that
+    ///   client to lose access to the service, so operators should exercise
+    ///   caution when using this SvcParamKey to specify a non-default port.
+    /// ```
+    Port(u16),
+    ///   The "ipv4hint" and "ipv6hint" keys convey IP addresses that clients
+    ///   MAY use to reach the service.  If A and AAAA records for TargetName
+    ///   are locally available, the client SHOULD ignore these hints.
+    ///   Otherwise, clients SHOULD perform A and/or AAAA queries for
+    ///   TargetName as in Section 3, and clients SHOULD use the IP address in
+    ///   those responses for future connections.  Clients MAY opt to terminate
+    ///   any connections using the addresses in hints and instead switch to
+    ///   the addresses in response to the TargetName query.  Failure to use A
+    ///   and/or AAAA response addresses could negatively impact load balancing
+    ///   or other geo-aware features and thereby degrade client performance.
+    ///
+    /// see `IpHint`
+    Ipv4Hint(IpHint<Ipv4Addr>),
+    /// ```text
+    /// 6.3.  "echconfig"
+    ///
+    ///   The SvcParamKey to enable Encrypted ClientHello (ECH) is "echconfig".
+    ///   Its value is defined in Section 9.  It is applicable to most TLS-
+    ///   based protocols.
+    ///
+    ///   When publishing a record containing an "echconfig" parameter, the
+    ///   publisher MUST ensure that all IP addresses of TargetName correspond
+    ///   to servers that have access to the corresponding private key or are
+    ///   authoritative for the public name.  (See Section 7.2.2 of [ECH] for
+    ///   more details about the public name.)  This yields an anonymity set of
+    ///   cardinality equal to the number of ECH-enabled server domains
+    ///   supported by a given client-facing server.  Thus, even with an
+    ///   encrypted ClientHello, an attacker who can enumerate the set of ECH-
+    ///   enabled domains supported by a client-facing server can guess the
+    ///   correct SNI with probability at least 1/K, where K is the size of
+    ///   this ECH-enabled server anonymity set.  This probability may be
+    ///   increased via traffic analysis or other mechanisms.
+    /// ```
+    EchConfig(EchConfig),
+    /// See `IpHint`
+    Ipv6Hint(IpHint<Ipv6Addr>),
+    /// Unparsed network data. Refer to documents on the associated key value
+    ///
+    /// This will be left as is when read off the wire, and encoded in bas64
+    ///    for presentation.
+    Unknown(Vec<u8>),
+}
 
 impl SvcParamValue {
-    /// Return the inner data as a slice of bytes
-    pub fn as_slice(&self) -> &[u8] {
-        &self.0
+    // a 2 octet field containing the length of the SvcParamValue as an
+    //      integer between 0 and 65535 in network byte order (but constrained
+    //      by the RDATA and DNS message sizes).
+    fn read(key: SvcParamKey, decoder: &mut BinDecoder<'_>) -> ProtoResult<Self> {
+        let len: usize = decoder
+            .read_u16()?
+            .verify_unwrap(|len| *len as usize <= decoder.len())
+            .map(|len| len as usize)
+            .map_err(|u| {
+                ProtoError::from(format!(
+                    "length of SvcParamValue ({}) exceeds remainder in RDATA ({})",
+                    u,
+                    decoder.len()
+                ))
+            })?;
+
+        let param_data = decoder.read_slice(len)?.unverified(/*verification to be done by individual param types*/);
+        let mut decoder = BinDecoder::new(param_data);
+
+        let value = match key {
+            SvcParamKey::Mandatory => Self::Mandatory(Mandatory::read(&mut decoder)?),
+            SvcParamKey::Alpn => Self::Alpn(Alpn::read(&mut decoder)?),
+            // should always be empty
+            SvcParamKey::NoDefaultAlpn => {
+                if len > 0 {
+                    return Err(ProtoError::from("Alpn expects at least one value"));
+                }
+
+                Self::NoDefaultAlpn
+            }
+            // The wire format of the SvcParamValue is the corresponding 2 octet
+            // numeric value in network byte order.
+            SvcParamKey::Port => {
+                let port = decoder.read_u16()?.unverified(/*all values are legal ports*/);
+                Self::Port(port)
+            }
+            SvcParamKey::Ipv4Hint => Self::Ipv4Hint(IpHint::<Ipv4Addr>::read(&mut decoder)?),
+            SvcParamKey::EchConfig => Self::EchConfig(EchConfig::read(&mut decoder)?),
+            SvcParamKey::Ipv6Hint => Self::Ipv6Hint(IpHint::<Ipv6Addr>::read(&mut decoder)?),
+            SvcParamKey::Key(_) | SvcParamKey::Key65535 | SvcParamKey::Unknown(_) => {
+                let data = decoder.read_vec(len)?.unverified(/*Consumer must verify the data*/);
+                Self::Unknown(data)
+            }
+        };
+
+        Ok(value)
     }
 }
 
-impl From<Vec<u8>> for SvcParamValue {
-    fn from(val: Vec<u8>) -> Self {
-        Self(val)
+impl BinEncodable for SvcParamValue {
+    // a 2 octet field containing the length of the SvcParamValue as an
+    //      integer between 0 and 65535 in network byte order (but constrained
+    //      by the RDATA and DNS message sizes).
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        // set the place for the length...
+        let place = encoder.place::<u16>()?;
+
+        match self {
+            SvcParamValue::Mandatory(mandatory) => mandatory.emit(encoder)?,
+            SvcParamValue::Alpn(alpn) => alpn.emit(encoder)?,
+            SvcParamValue::NoDefaultAlpn => (),
+            SvcParamValue::Port(port) => encoder.emit_u16(*port)?,
+            SvcParamValue::Ipv4Hint(ip_hint) => ip_hint.emit(encoder)?,
+            SvcParamValue::EchConfig(ech_config) => ech_config.emit(encoder)?,
+            SvcParamValue::Ipv6Hint(ip_hint) => ip_hint.emit(encoder)?,
+            SvcParamValue::Unknown(data) => encoder.emit_vec(data.as_slice())?,
+        }
+
+        // go back and set the length
+        let len = u16::try_from(encoder.len_since_place(&place))
+            .map_err(|_| ProtoError::from("Total length of SvcParamValue exceeds u16::MAX"))?;
+        place.replace(encoder, len)?;
+
+        Ok(())
     }
 }
 
-impl From<SvcParamValue> for Vec<u8> {
-    fn from(val: SvcParamValue) -> Self {
-        val.0
+impl fmt::Display for SvcParamValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            SvcParamValue::Mandatory(mandatory) => write!(f, "{}", mandatory)?,
+            SvcParamValue::Alpn(alpn) => write!(f, "{}", alpn)?,
+            SvcParamValue::NoDefaultAlpn => (),
+            SvcParamValue::Port(port) => write!(f, "{}", port)?,
+            SvcParamValue::Ipv4Hint(ip_hint) => write!(f, "{}", ip_hint)?,
+            SvcParamValue::EchConfig(ech_config) => write!(f, "{}", ech_config)?,
+            SvcParamValue::Ipv6Hint(ip_hint) => write!(f, "{}", ip_hint)?,
+            SvcParamValue::Unknown(data) => write!(f, "{}", data_encoding::BASE64.encode(data))?,
+        }
+
+        Ok(())
+    }
+}
+
+/// ```text
+/// 7.  ServiceMode RR compatibility and mandatory keys
+///
+///    In a ServiceMode RR, a SvcParamKey is considered "mandatory" if the
+///    RR will not function correctly for clients that ignore this
+///    SvcParamKey.  Each SVCB protocol mapping SHOULD specify a set of keys
+///    that are "automatically mandatory", i.e. mandatory if they are
+///    present in an RR.  The SvcParamKey "mandatory" is used to indicate
+///    any mandatory keys for this RR, in addition to any automatically
+///    mandatory keys that are present.
+///
+///    A ServiceMode RR is considered "compatible" with a client if the
+///    client recognizes all the mandatory keys, and their values indicate
+///    that successful connection establishment is possible.  If the SVCB
+///    RRSet contains no compatible RRs, the client will generally act as if
+///    the RRSet is empty.
+///
+///    The presentation "value" SHALL be a comma-separated list
+///    (Appendix A.1) of one or more valid SvcParamKeys, either by their
+///    registered name or in the unknown-key format (Section 2.1).  Keys MAY
+///    appear in any order, but MUST NOT appear more than once.  For self-
+///    consistency (Section 2.4.3), listed keys MUST also appear in the
+///    SvcParams.
+///
+///    To enable simpler parsing, this SvcParamValue MUST NOT contain escape
+///    sequences.
+///
+///    For example, the following is a valid list of SvcParams:
+///
+///    echconfig=... key65333=ex1 key65444=ex2 mandatory=key65444,echconfig
+///
+///    In wire format, the keys are represented by their numeric values in
+///    network byte order, concatenated in ascending order.
+///
+///    This SvcParamKey is always automatically mandatory, and MUST NOT
+///    appear in its own value-list.  Other automatically mandatory keys
+///    SHOULD NOT appear in the list either.  (Including them wastes space
+///    and otherwise has no effect.)
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[repr(transparent)]
+pub struct Mandatory(Vec<SvcParamKey>);
+
+impl<'r> BinDecodable<'r> for Mandatory {
+    /// This expects the decoder to be limited to only this field, i.e. the end of input for the decoder
+    ///   is the end of input for the fields
+    ///
+    /// ```text
+    ///    In wire format, the keys are represented by their numeric values in
+    ///    network byte order, concatenated in ascending order.
+    /// ```
+    fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Self> {
+        let mut keys = Vec::with_capacity(1);
+
+        while decoder.peek().is_some() {
+            keys.push(SvcParamKey::read(decoder)?);
+        }
+
+        if keys.is_empty() {
+            return Err(ProtoError::from("Mandatory expects at least one value"));
+        }
+
+        Ok(Mandatory(keys))
+    }
+}
+
+impl BinEncodable for Mandatory {
+    /// This expects the decoder to be limited to only this field, i.e. the end of input for the decoder
+    ///   is the end of input for the fields
+    ///
+    /// ```text
+    ///    In wire format, the keys are represented by their numeric values in
+    ///    network byte order, concatenated in ascending order.
+    /// ```
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        if self.0.is_empty() {
+            return Err(ProtoError::from("Alpn expects at least one value"));
+        }
+
+        // TODO: order by key value
+        for key in self.0.iter() {
+            key.emit(encoder)?
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for Mandatory {
+    ///    The presentation "value" SHALL be a comma-separated list
+    ///    (Appendix A.1) of one or more valid SvcParamKeys, either by their
+    ///    registered name or in the unknown-key format (Section 2.1).  Keys MAY
+    ///    appear in any order, but MUST NOT appear more than once.  For self-
+    ///    consistency (Section 2.4.3), listed keys MUST also appear in the
+    ///    SvcParams.
+    ///
+    ///    To enable simpler parsing, this SvcParamValue MUST NOT contain escape
+    ///    sequences.
+    ///
+    ///    For example, the following is a valid list of SvcParams:
+    ///
+    ///    echconfig=... key65333=ex1 key65444=ex2 mandatory=key65444,echconfig
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        for key in self.0.iter() {
+            // TODO: confirm in the RFC that trailing commas are ok
+            write!(f, "{},", key)?;
+        }
+
+        Ok(())
+    }
+}
+
+///  [draft-ietf-dnsop-svcb-https-03 SVCB and HTTPS RRs for DNS, February 2021](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-6.1)
+///
+/// ```text
+/// 6.1.  "alpn" and "no-default-alpn"
+///
+///   The "alpn" and "no-default-alpn" SvcParamKeys together indicate the
+///   set of Application Layer Protocol Negotiation (ALPN) protocol
+///   identifiers [ALPN] and associated transport protocols supported by
+///   this service endpoint.
+///
+///   As with Alt-Svc [AltSvc], the ALPN protocol identifier is used to
+///   identify the application protocol and associated suite of protocols
+///   supported by the endpoint (the "protocol suite").  Clients filter the
+///   set of ALPN identifiers to match the protocol suites they support,
+///   and this informs the underlying transport protocol used (such as
+///   QUIC-over-UDP or TLS-over-TCP).
+///
+///   ALPNs are identified by their registered "Identification Sequence"
+///   ("alpn-id"), which is a sequence of 1-255 octets.
+///
+///   alpn-id = 1*255OCTET
+///
+///   The presentation "value" SHALL be a comma-separated list
+///   (Appendix A.1) of one or more "alpn-id"s.
+///
+///   The wire format value for "alpn" consists of at least one "alpn-id"
+///   prefixed by its length as a single octet, and these length-value
+///   pairs are concatenated to form the SvcParamValue.  These pairs MUST
+///   exactly fill the SvcParamValue; otherwise, the SvcParamValue is
+///   malformed.
+///
+///   For "no-default-alpn", the presentation and wire format values MUST
+///   be empty.  When "no-default-alpn" is specified in an RR, "alpn" must
+///   also be specified in order for the RR to be "self-consistent"
+///   (Section 2.4.3).
+///
+///   Each scheme that uses this SvcParamKey defines a "default set" of
+///   supported ALPNs, which SHOULD NOT be empty.  To determine the set of
+///   protocol suites supported by an endpoint (the "SVCB ALPN set"), the
+///   client adds the default set to the list of "alpn-id"s unless the "no-
+///   default-alpn" SvcParamKey is present.  The presence of an ALPN
+///   protocol in the SVCB ALPN set indicates that this service endpoint,
+///   described by TargetName and the other parameters (e.g. "port") offers
+///   service with the protocol suite associated with this ALPN protocol.
+///
+///   ALPN protocol names that do not uniquely identify a protocol suite
+///   (e.g. an Identification Sequence that can be used with both TLS and
+///   DTLS) are not compatible with this SvcParamKey and MUST NOT be
+///   included in the SVCB ALPN set.
+///
+///   To establish a connection to the endpoint, clients MUST
+///
+///   1.  Let SVCB-ALPN-Intersection be the set of protocols in the SVCB
+///       ALPN set that the client supports.
+///
+///   2.  Let Intersection-Transports be the set of transports (e.g.  TLS,
+///       DTLS, QUIC) implied by the protocols in SVCB-ALPN-Intersection.
+///
+///   3.  For each transport in Intersection-Transports, construct a
+///       ProtocolNameList containing the Identification Sequences of all
+///       the client's supported ALPN protocols for that transport, without
+///       regard to the SVCB ALPN set.
+///
+///   For example, if the SVCB ALPN set is ["http/1.1", "h3"], and the
+///   client supports HTTP/1.1, HTTP/2, and HTTP/3, the client could
+///   attempt to connect using TLS over TCP with a ProtocolNameList of
+///   ["http/1.1", "h2"], and could also attempt a connection using QUIC,
+///   with a ProtocolNameList of ["h3"].
+///
+///   Once the client has constructed a ClientHello, protocol negotiation
+///   in that handshake proceeds as specified in [ALPN], without regard to
+///   the SVCB ALPN set.
+///
+///   With this procedure in place, an attacker who can modify DNS and
+///   network traffic can prevent a successful transport connection, but
+///   cannot otherwise interfere with ALPN protocol selection.  This
+///   procedure also ensures that each ProtocolNameList includes at least
+///   one protocol from the SVCB ALPN set.
+///
+///   Clients SHOULD NOT attempt connection to a service endpoint whose
+///   SVCB ALPN set does not contain any supported protocols.  To ensure
+///   consistency of behavior, clients MAY reject the entire SVCB RRSet and
+///   fall back to basic connection establishment if all of the RRs
+///   indicate "no-default-alpn", even if connection could have succeeded
+///   using a non-default alpn.
+///
+///   For compatibility with clients that require default transports, zone
+///   operators SHOULD ensure that at least one RR in each RRSet supports
+///   the default transports.
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[repr(transparent)]
+pub struct Alpn(Vec<String>);
+
+impl<'r> BinDecodable<'r> for Alpn {
+    /// This expects the decoder to be limited to only this field, i.e. the end of input for the decoder
+    ///   is the end of input for the fields
+    ///
+    /// ```text
+    ///   The wire format value for "alpn" consists of at least one "alpn-id"
+    ///   prefixed by its length as a single octet, and these length-value
+    ///   pairs are concatenated to form the SvcParamValue.  These pairs MUST
+    ///   exactly fill the SvcParamValue; otherwise, the SvcParamValue is
+    ///   malformed.
+    /// ```
+    fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Self> {
+        let mut alpns = Vec::with_capacity(1);
+
+        while decoder.peek().is_some() {
+            let alpn = decoder.read_character_data()?.unverified(/*will rely on string parser*/);
+            let alpn = String::from_utf8(alpn.to_vec())?;
+            alpns.push(alpn);
+        }
+
+        if alpns.is_empty() {
+            return Err(ProtoError::from("Alpn expects at least one value"));
+        }
+
+        Ok(Alpn(alpns))
+    }
+}
+
+impl BinEncodable for Alpn {
+    ///   The wire format value for "alpn" consists of at least one "alpn-id"
+    ///   prefixed by its length as a single octet, and these length-value
+    ///   pairs are concatenated to form the SvcParamValue.  These pairs MUST
+    ///   exactly fill the SvcParamValue; otherwise, the SvcParamValue is
+    ///   malformed.
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        if self.0.is_empty() {
+            return Err(ProtoError::from("Alpn expects at least one value"));
+        }
+
+        for alpn in self.0.iter() {
+            encoder.emit_character_data(alpn)?
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for Alpn {
+    ///   The presentation "value" SHALL be a comma-separated list
+    ///   (Appendix A.1) of one or more "alpn-id"s.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        for alpn in self.0.iter() {
+            // TODO: confirm in the RFC that trailing commas are ok
+            write!(f, "{},", alpn)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// ```text
+/// 9.  SVCB/HTTPS RR parameter for ECH configuration
+///
+///   The SVCB "echconfig" parameter is defined for conveying the ECH
+///   configuration of an alternative endpoint.  In wire format, the value
+///   of the parameter is an ECHConfigs vector [ECH], including the
+///   redundant length prefix.  In presentation format, the value is a
+///   single ECHConfigs encoded in Base64 [base64].  Base64 is used here to
+///   simplify integration with TLS server software.  To enable simpler
+///   parsing, this SvcParam MUST NOT contain escape sequences.
+///
+///   When ECH is in use, the TLS ClientHello is divided into an
+///   unencrypted "outer" and an encrypted "inner" ClientHello.  The outer
+///   ClientHello is an implementation detail of ECH, and its contents are
+///   controlled by the ECHConfig in accordance with [ECH].  The inner
+///   ClientHello is used for establishing a connection to the service, so
+///   its contents may be influenced by other SVCB parameters.  For
+///   example, the requirements on the ProtocolNameList in Section 6.1
+///   apply only to the inner ClientHello.  Similarly, it is the inner
+///   ClientHello whose Server Name Indication identifies the desired
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[repr(transparent)]
+pub struct EchConfig(Vec<u8>);
+
+impl<'r> BinDecodable<'r> for EchConfig {
+    /// In wire format, the value
+    ///   of the parameter is an ECHConfigs vector [ECH], including the
+    ///   redundant length prefix (a 2 octet field containing the length of the SvcParamValue
+    ///   as an integer between 0 and 65535 in network byte order).
+    fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Self> {
+        let redundant_len = decoder
+            .read_u16()?
+            .map(|len| len as usize)
+            .verify_unwrap(|len| *len <= decoder.len())
+            .map_err(|_| ProtoError::from("ECH value length exceeds max size of u16::MAX"))?;
+
+        let data =
+            decoder.read_vec(redundant_len)?.unverified(/*up to consumer to validate this data*/);
+
+        Ok(EchConfig(data))
+    }
+}
+
+impl BinEncodable for EchConfig {
+    /// In wire format, the value
+    ///   of the parameter is an ECHConfigs vector [ECH], including the
+    ///   redundant length prefix (a 2 octet field containing the length of the SvcParamValue
+    ///   as an integer between 0 and 65535 in network byte order).
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        let len = u16::try_from(self.0.len())
+            .map_err(|_| ProtoError::from("ECH value length exceeds max size of u16::MAX"))?;
+
+        // redundant length...
+        encoder.emit_u16(len)?;
+        encoder.emit_vec(&self.0)?;
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for EchConfig {
+    /// In presentation format, the value is a
+    ///   single ECHConfigs encoded in Base64 [base64].  Base64 is used here to
+    ///   simplify integration with TLS server software.  To enable simpler
+    ///   parsing, this SvcParam MUST NOT contain escape sequences.
+    ///
+    /// *note* while the on the wire the EchConfig has a redundant length,
+    ///   the RFC is not explicit about including it in the base64
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", data_encoding::BASE64.encode(&self.0))
+    }
+}
+
+/// ```text
+///    6.4.  "ipv4hint" and "ipv6hint"
+///
+///   The "ipv4hint" and "ipv6hint" keys convey IP addresses that clients
+///   MAY use to reach the service.  If A and AAAA records for TargetName
+///   are locally available, the client SHOULD ignore these hints.
+///   Otherwise, clients SHOULD perform A and/or AAAA queries for
+///   TargetName as in Section 3, and clients SHOULD use the IP address in
+///   those responses for future connections.  Clients MAY opt to terminate
+///   any connections using the addresses in hints and instead switch to
+///   the addresses in response to the TargetName query.  Failure to use A
+///   and/or AAAA response addresses could negatively impact load balancing
+///   or other geo-aware features and thereby degrade client performance.
+///
+///   The presentation "value" SHALL be a comma-separated list
+///   (Appendix A.1) of one or more IP addresses of the appropriate family
+///   in standard textual format [RFC5952].  To enable simpler parsing,
+///   this SvcParamValue MUST NOT contain escape sequences.
+///
+///   The wire format for each parameter is a sequence of IP addresses in
+///   network byte order.  Like an A or AAAA RRSet, the list of addresses
+///   represents an unordered collection, and clients SHOULD pick addresses
+///   to use in a random order.  An empty list of addresses is invalid.
+///
+///   When selecting between IPv4 and IPv6 addresses to use, clients may
+///   use an approach such as Happy Eyeballs [HappyEyeballsV2].  When only
+///   "ipv4hint" is present, IPv6-only clients may synthesize IPv6
+///   addresses as specified in [RFC7050] or ignore the "ipv4hint" key and
+///   wait for AAAA resolution (Section 3).  Recursive resolvers MUST NOT
+///   perform DNS64 ([RFC6147]) on parameters within a SVCB record.  For
+///   best performance, server operators SHOULD include an "ipv6hint"
+///   parameter whenever they include an "ipv4hint" parameter.
+///
+///   These parameters are intended to minimize additional connection
+///   latency when a recursive resolver is not compliant with the
+///   requirements in Section 4, and SHOULD NOT be included if most clients
+///   are using compliant recursive resolvers.  When TargetName is the
+///   origin hostname or the owner name (which can be written as "."),
+///   server operators SHOULD NOT include these hints, because they are
+///   unlikely to convey any performance benefit.
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[repr(transparent)]
+pub struct IpHint<T>(Vec<T>);
+
+impl<'r, T> BinDecodable<'r> for IpHint<T>
+where
+    T: BinDecodable<'r>,
+{
+    ///   The wire format for each parameter is a sequence of IP addresses in
+    ///   network byte order.  Like an A or AAAA RRSet, the list of addresses
+    ///   represents an unordered collection, and clients SHOULD pick addresses
+    ///   to use in a random order.  An empty list of addresses is invalid.
+    fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Self> {
+        let mut ips = Vec::new();
+
+        while decoder.peek().is_some() {
+            ips.push(T::read(decoder)?)
+        }
+
+        Ok(IpHint(ips))
+    }
+}
+
+impl<T> BinEncodable for IpHint<T>
+where
+    T: BinEncodable,
+{
+    ///   The wire format for each parameter is a sequence of IP addresses in
+    ///   network byte order.  Like an A or AAAA RRSet, the list of addresses
+    ///   represents an unordered collection, and clients SHOULD pick addresses
+    ///   to use in a random order.  An empty list of addresses is invalid.
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        for ip in self.0.iter() {
+            ip.emit(encoder)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<T> fmt::Display for IpHint<T>
+where
+    T: fmt::Display,
+{
+    ///   The presentation "value" SHALL be a comma-separated list
+    ///   (Appendix A.1) of one or more IP addresses of the appropriate family
+    ///   in standard textual format [RFC5952].  To enable simpler parsing,
+    ///   this SvcParamValue MUST NOT contain escape sequences.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        for ip in self.0.iter() {
+            write!(f, "{},", ip)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -271,24 +888,12 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
     while remainder_len >= 4 {
         // a 2 octet field containing the SvcParamKey as an integer in
         //      network byte order.  (See Section 14.3.2 for the defined values.)
-        let key: SvcParamKey = decoder.read_u16()?.unverified(/*any u16 is valid*/).into();
+        let key = SvcParamKey::read(decoder)?;
 
         // a 2 octet field containing the length of the SvcParamValue as an
         //      integer between 0 and 65535 in network byte order (but constrained
         //      by the RDATA and DNS message sizes).
-        let len: u16 = decoder
-            .read_u16()?
-            .verify_unwrap(|len| *len as usize <= remainder_len)
-            .map_err(|u| {
-                ProtoError::from(format!(
-                    "length of SvcParamValue ({}) exceeds remainder in RDATA ({})",
-                    u, remainder_len
-                ))
-            })?;
-
-        // an octet string of this length whose contents are in a format
-        //      determined by the SvcParamKey.
-        let value = decoder.read_vec(len as usize)?.unverified(/*char data for users*/);
+        let value = SvcParamValue::read(key, decoder)?;
 
         if let Some(last_key) = svc_params.last().map(|(key, _)| key) {
             if last_key >= &key {
@@ -296,7 +901,7 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
             }
         }
 
-        svc_params.push((key, value.into()));
+        svc_params.push((key, value));
         remainder_len = rdata_length.map(|len| len as usize - (decoder.index() - start_index)).unverified(/*valid len*/);
     }
 
@@ -320,13 +925,8 @@ pub fn emit(encoder: &mut BinEncoder<'_>, svcb: &SVCB) -> ProtoResult<()> {
             }
         }
 
-        if param.as_slice().len() > u16::MAX as usize {
-            return Err(ProtoError::from("SvcParams exceeds u16 max size"));
-        }
-
-        encoder.emit_u16((*key).into())?;
-        encoder.emit_u16(param.as_slice().len() as u16)?;
-        encoder.emit_vec(param.as_slice())?;
+        key.emit(encoder)?;
+        param.emit(encoder)?;
 
         last_key = Some(*key);
     }
@@ -353,7 +953,6 @@ impl fmt::Display for SVCB {
         )?;
 
         for (key, param) in self.svc_params.iter() {
-            let param = String::from_utf8_lossy(param.as_slice());
             write!(f, " {key}=\"{param}\"", key = key, param = param)?
         }
 
@@ -421,14 +1020,23 @@ mod tests {
         test_encode_decode(SVCB::new(
             0,
             Name::from_utf8(".").unwrap(),
-            vec![(SvcParamKey::Alpn, "h2".as_bytes().to_vec().into())],
+            vec![(
+                SvcParamKey::Alpn,
+                SvcParamValue::Alpn(Alpn(vec!["h2".to_string()])),
+            )],
         ));
         test_encode_decode(SVCB::new(
             0,
             Name::from_utf8("example.com.").unwrap(),
             vec![
-                (SvcParamKey::Mandatory, "alpn".as_bytes().to_vec().into()),
-                (SvcParamKey::Alpn, "h2".as_bytes().to_vec().into()),
+                (
+                    SvcParamKey::Mandatory,
+                    SvcParamValue::Mandatory(Mandatory(vec![SvcParamKey::Alpn])),
+                ),
+                (
+                    SvcParamKey::Alpn,
+                    SvcParamValue::Alpn(Alpn(vec!["h2".to_string()])),
+                ),
             ],
         ));
     }
@@ -440,8 +1048,14 @@ mod tests {
             0,
             Name::from_utf8(".").unwrap(),
             vec![
-                (SvcParamKey::Alpn, "h2".as_bytes().to_vec().into()),
-                (SvcParamKey::Mandatory, "alpn".as_bytes().to_vec().into()),
+                (
+                    SvcParamKey::Alpn,
+                    SvcParamValue::Alpn(Alpn(vec!["h2".to_string()])),
+                ),
+                (
+                    SvcParamKey::Mandatory,
+                    SvcParamValue::Mandatory(Mandatory(vec![SvcParamKey::Alpn])),
+                ),
             ],
         ));
     }

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -1145,7 +1145,8 @@ mod tests {
         assert_eq!(u16::from(SvcParamKey::Unknown(65279)), 65279);
     }
 
-    #[track_caller]
+    // TODO: add this back after upgrading rustc version to 1.46
+    // #[track_caller]
     fn test_encode_decode(rdata: SVCB) {
         let mut bytes = Vec::new();
         let mut encoder: BinEncoder<'_> = BinEncoder::new(&mut bytes);

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -1,18 +1,9 @@
-/*
- * Copyright (C) 2015-2019 Benjamin Fry <benjaminfry@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2015-2021 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
 
 //! record type definitions
 
@@ -64,6 +55,8 @@ pub enum RecordType {
     /// RFC 1035[1] host information
     HINFO,
     //  HIP,        // 55 RFC 5205 Host Identity Protocol
+    /// RFC draft-ietf-dnsop-svcb-https-03 DNS SVCB and HTTPS RRs
+    HTTPS,
     //  IPSECKEY,   // 45 RFC 4025 IPsec Key
     /// RFC 1996 Incremental Zone Transfer
     IXFR,
@@ -90,6 +83,8 @@ pub enum RecordType {
     SRV,
     /// RFC 4255 SSH Public Key Fingerprint
     SSHFP,
+    /// RFC draft-ietf-dnsop-svcb-https-03 DNS SVCB and HTTPS RRs
+    SVCB,
     //  TA,         // 32768 N/A DNSSEC Trust Authorities
     //  TKEY,       // 249 RFC 2930 Secret key record
     /// RFC 6698 TLSA certificate association
@@ -172,6 +167,7 @@ impl FromStr for RecordType {
             "CAA" => Ok(RecordType::CAA),
             "CNAME" => Ok(RecordType::CNAME),
             "HINFO" => Ok(RecordType::HINFO),
+            "HTTPS" => Ok(RecordType::HTTPS),
             "NULL" => Ok(RecordType::NULL),
             "MX" => Ok(RecordType::MX),
             "NAPTR" => Ok(RecordType::NAPTR),
@@ -181,6 +177,7 @@ impl FromStr for RecordType {
             "SOA" => Ok(RecordType::SOA),
             "SRV" => Ok(RecordType::SRV),
             "SSHFP" => Ok(RecordType::SSHFP),
+            "SVCB" => Ok(RecordType::SVCB),
             "TLSA" => Ok(RecordType::TLSA),
             "TXT" => Ok(RecordType::TXT),
             "ANY" | "*" => Ok(RecordType::ANY),
@@ -213,7 +210,8 @@ impl From<u16> for RecordType {
             252 => RecordType::AXFR,
             257 => RecordType::CAA,
             5 => RecordType::CNAME,
-            0 => RecordType::ZERO,
+            13 => RecordType::HINFO,
+            65 => RecordType::HTTPS,
             15 => RecordType::MX,
             35 => RecordType::NAPTR,
             2 => RecordType::NS,
@@ -224,8 +222,10 @@ impl From<u16> for RecordType {
             6 => RecordType::SOA,
             33 => RecordType::SRV,
             44 => RecordType::SSHFP,
+            64 => RecordType::SVCB,
             52 => RecordType::TLSA,
             16 => RecordType::TXT,
+            0 => RecordType::ZERO,
             #[cfg(feature = "dnssec")]
             48/*DNSKEY*/ |
             43/*DS*/ |
@@ -283,7 +283,8 @@ impl From<RecordType> for &'static str {
             RecordType::CAA => "CAA",
             RecordType::CNAME => "CNAME",
             RecordType::HINFO => "HINFO",
-            RecordType::ZERO => "",
+            RecordType::HTTPS => "HTTPS",
+            RecordType::ZERO => "ZERO",
             RecordType::IXFR => "IXFR",
             RecordType::MX => "MX",
             RecordType::NAPTR => "NAPTR",
@@ -295,6 +296,7 @@ impl From<RecordType> for &'static str {
             RecordType::SOA => "SOA",
             RecordType::SRV => "SRV",
             RecordType::SSHFP => "SSHFP",
+            RecordType::SVCB => "SVCB",
             RecordType::TLSA => "TLSA",
             RecordType::TXT => "TXT",
             #[cfg(feature = "dnssec")]
@@ -325,6 +327,7 @@ impl From<RecordType> for u16 {
             RecordType::CAA => 257,
             RecordType::CNAME => 5,
             RecordType::HINFO => 13,
+            RecordType::HTTPS => 65,
             RecordType::ZERO => 0,
             RecordType::IXFR => 251,
             RecordType::MX => 15,
@@ -337,6 +340,7 @@ impl From<RecordType> for u16 {
             RecordType::SOA => 6,
             RecordType::SRV => 33,
             RecordType::SSHFP => 44,
+            RecordType::SVCB => 64,
             RecordType::TLSA => 52,
             RecordType::TXT => 16,
             #[cfg(feature = "dnssec")]

--- a/crates/proto/src/serialize/binary/mod.rs
+++ b/crates/proto/src/serialize/binary/mod.rs
@@ -20,6 +20,8 @@ mod decoder;
 mod encoder;
 mod restrict;
 
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 pub use self::decoder::{BinDecoder, DecodeError};
 pub use self::encoder::BinEncoder;
 pub use self::encoder::EncodeMode;
@@ -107,5 +109,29 @@ impl<'r> BinDecodable<'r> for u32 {
 impl BinEncodable for Vec<u8> {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         encoder.emit_vec(self)
+    }
+}
+
+impl BinEncodable for Ipv4Addr {
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        crate::rr::rdata::a::emit(encoder, *self)
+    }
+}
+
+impl<'r> BinDecodable<'r> for Ipv4Addr {
+    fn read(decoder: &mut BinDecoder<'_>) -> ProtoResult<Self> {
+        crate::rr::rdata::a::read(decoder)
+    }
+}
+
+impl BinEncodable for Ipv6Addr {
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        crate::rr::rdata::aaaa::emit(encoder, self)
+    }
+}
+
+impl<'r> BinDecodable<'r> for Ipv6Addr {
+    fn read(decoder: &mut BinDecoder<'_>) -> ProtoResult<Self> {
+        crate::rr::rdata::aaaa::read(decoder)
     }
 }


### PR DESCRIPTION
@briansmith @djc @sayrer @moonshiner

Ok, had some time today, through these record types in.

Some notes, currently this does not validate the `SvcbParamValue` against the `SvcbParamKey` type.
Currently this is not supported in the Zone file for the server, but that shouldn't be too hard, so I think I'll leave this in draft until I can do that.

This can be tested with:

```
$> cargo install --git https://github.com/bluejekyll/trust-dns.git --branch https_and_svcb --bin resolve -- trust-dns-util
$> resolve -t HTTPS crypto.cloudflare.com
crypto.cloudflare.com. 273 IN HTTPS 1 . alpn=h2, ipv4hint=162.159.135.79,162.159.136.79, echconfig="/gkAQwATY2xvdWRmbGFyZS1lc25pLmNvbQAgSiSc2sO3T91QP7ZBkmxa4DBEHReUB0M5UXn3iFQpvW8AIAAEAAEAAQAAAAA=" ipv6hint=2606:4700:7::a29f:874f,2606:4700:7::a29f:884f,
```

fixes: #1323