### PR TITLE
Add Dockerfile and GitHub workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,30 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    environment: docker_image_building
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/trust-dns:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,9 @@
 name: Publish Docker image
 
 on:
-  push:
-    branches: [ main ]
+  release:
+    types:
+        - published
 
 jobs:
   push_to_registry:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.50.0-buster as build-env
+
+RUN git clone https://github.com/bluejekyll/trust-dns
+RUN apt-get update
+RUN apt-get install -y musl-tools libssl-dev
+WORKDIR /trust-dns
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo build --release -p trust-dns --target=x86_64-unknown-linux-musl
+
+FROM gcr.io/distroless/cc
+COPY --from=build-env /trust-dns/target/x86_64-unknown-linux-musl/release/named /
+
+ENTRYPOINT [ "/named" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:1.50.0-buster as build-env
 
 RUN git clone https://github.com/bluejekyll/trust-dns
 RUN apt-get update
-RUN apt-get install -y musl-tools libssl-dev
+RUN apt-get install -y musl-tools openssl libssl-dev
 WORKDIR /trust-dns
 RUN rustup target add x86_64-unknown-linux-musl
 RUN cargo build --release -p trust-dns --target=x86_64-unknown-linux-musl

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM rust:1.50.0-buster as build-env
 
 RUN git clone https://github.com/bluejekyll/trust-dns
 WORKDIR /trust-dns
-RUN rustup target add x86_64-unknown-linux-musl
-RUN cargo build --release -p trust-dns --target=x86_64-unknown-linux-musl
+RUN cargo build --release -p trust-dns
 
-FROM gcr.io/distroless/cc
-COPY --from=build-env /trust-dns/target/x86_64-unknown-linux-musl/release/named /
+FROM gcr.io/distroless/cc-debian10
+COPY --from=build-env /trust-dns/target/release/named /
 
 ENTRYPOINT [ "/named" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM rust:1.50.0-buster as build-env
 
 RUN git clone https://github.com/bluejekyll/trust-dns
-RUN apt-get update
-RUN apt-get install -y musl-tools openssl libssl-dev
 WORKDIR /trust-dns
 RUN rustup target add x86_64-unknown-linux-musl
 RUN cargo build --release -p trust-dns --target=x86_64-unknown-linux-musl


### PR DESCRIPTION
This workflow uses GitHub Container Registry to publish Docker image. 
Therefore you have to add personal access token CA_PAT to make this PR work.  More information about personal access token, https://github.com/docker/login-action#github-container-registry.
If you want to use another registry like DockerHub, please tell me.