### PR TITLE
client: add send_msg to client

### DIFF
--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -156,15 +156,6 @@ impl<T> ClientHandle for T where T: DnsHandle<Error = ProtoError> {}
 
 /// A trait for implementing high level functions of DNS.
 pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
-    /// Sends an arbitrary `Message` to the client
-    fn send_msg<M: Into<Message>>(
-        &mut self,
-        msg: M,
-    ) -> ClientResponse<<Self as DnsHandle>::Response> {
-        let msg = msg.into();
-        debug!("sending message: {:?}", msg);
-        ClientResponse(self.send(msg))
-    }
     /// A *classic* DNS query
     ///
     /// *Note* As of now, this will not recurse on PTR or CNAME record responses, that is up to
@@ -583,7 +574,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
 
 /// A future result of a Client Request
 #[must_use = "futures do nothing unless polled"]
-pub struct ClientResponse<R>(R)
+pub struct ClientResponse<R>(pub(crate) R)
 where
     R: Future<Output = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static;
 

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -17,6 +17,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use tokio::runtime::{self, Runtime};
+use trust_dns_proto::op::Edns;
 
 #[cfg(feature = "dnssec")]
 use crate::client::AsyncDnssecClient;
@@ -107,6 +108,29 @@ pub trait Client {
         let (mut client, runtime) = self.spawn_client()?;
 
         runtime.block_on(client.query(name.clone(), query_class, query_type))
+    }
+
+    /// A DNS query with edns, i.e. does not perform any DNSSec operations
+    ///
+    /// *Note* As of now, this will not recurse on PTR record responses, that is up to
+    ///        the caller.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - the label to lookup
+    /// * `query_class` - most likely this should always be DNSClass::IN
+    /// * `query_type` - record type to lookup
+    /// * `edns` - an Edns section to insert in the message
+    fn query_edns(
+        &self,
+        name: &Name,
+        query_class: DNSClass,
+        query_type: RecordType,
+        edns: Edns,
+    ) -> ClientResult<DnsResponse> {
+        let (mut client, runtime) = self.spawn_client()?;
+
+        runtime.block_on(client.query_edns(name.clone(), query_class, query_type, edns))
     }
 
     /// Sends a NOTIFY message to the remote system

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -13,9 +13,9 @@ use futures_util::future::Future;
 use log::debug;
 use rand;
 
+use crate::error::*;
 use crate::op::{Message, MessageType, OpCode, Query};
 use crate::xfer::{DnsRequest, DnsRequestOptions, DnsResponse, SerialMessage};
-use crate::{error::*, op::Edns};
 
 // TODO: this should be configurable
 // > An EDNS buffer size of 1232 bytes will avoid fragmentation on nearly all current networks.
@@ -81,33 +81,6 @@ pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
     fn lookup(&mut self, query: Query, options: DnsRequestOptions) -> Self::Response {
         debug!("querying: {} {:?}", query.name(), query.query_type());
         self.send(DnsRequest::new(build_message(query, options), options))
-    }
-
-    /// A DNS query with edns, i.e. does not perform any DNSSec operations
-    ///
-    /// *Note* As of now, this will not recurse on PTR record responses, that is up to
-    ///        the caller.
-    ///
-    /// # Arguments
-    ///
-    /// * `query` - the query to lookup
-    /// * `edns` - an Edns section to insert in the message
-    /// * `options` - options to use when constructing the message
-    fn lookup_edns(
-        &mut self,
-        query: Query,
-        edns: Edns,
-        options: DnsRequestOptions,
-    ) -> Self::Response {
-        debug!(
-            "querying: {} {:?} {:?}",
-            query.name(),
-            query.query_type(),
-            edns
-        );
-        let mut message = build_message(query, options);
-        message.set_edns(edns);
-        self.send(DnsRequest::new(message, options))
     }
 }
 

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -25,6 +25,7 @@ use trust_dns_client::{error::ClientErrorKind, op::Edns, rr::rdata::opt::EdnsCod
 use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 #[cfg(feature = "dnssec")]
 use trust_dns_proto::xfer::{DnsExchangeBackground, DnsMultiplexer, DnsStreamHandle};
+use trust_dns_proto::DnsHandle;
 #[cfg(all(feature = "dnssec", feature = "sqlite"))]
 use trust_dns_proto::TokioTime;
 
@@ -212,7 +213,7 @@ fn test_query_edns(client: &mut AsyncClient) -> impl Future<Output = ()> {
     .set_version(0);
 
     client
-        .send_msg(msg)
+        .send(msg)
         .map_ok(move |response| {
             println!("response records: {:?}", response);
             assert!(response

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -164,7 +164,7 @@ where
     .set_max_payload(1232)
     .set_version(0);
 
-    let response = client.send_msg(msg).expect("Query failed");
+    let response = client.send(msg).expect("Query failed");
 
     println!("response records: {:?}", response);
     assert!(response


### PR DESCRIPTION
closes #350 

Adds a `send_msg` to `Client` and `ClientHandle` so that the method is available to `SyncClient` & `AsyncClient`
