### PR TITLE
Fix Windows build without system-config feature

### DIFF
--- a/crates/resolver/src/error.rs
+++ b/crates/resolver/src/error.rs
@@ -282,7 +282,8 @@ impl From<&'static str> for ResolveError {
 }
 
 #[cfg(target_os = "windows")]
-#[cfg_attr(docsrs, doc(cfg(target_os = "windows")))]
+#[cfg(feature = "system-config")]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "system-config", windows))))]
 impl From<ipconfig::error::Error> for ResolveError {
     fn from(e: ipconfig::error::Error) -> ResolveError {
         ResolveErrorKind::Msg(format!("failed to read from registry: {}", e)).into()


### PR DESCRIPTION
I don't really have a Windows system to test this with, but we have a [CI failure](https://github.com/portier/portier-broker/pull/211/checks?check_run_id=2243878215) on Windows because we build trust-dns-resolver with `default-features = false`:

```
   Compiling trust-dns-resolver v0.20.1
error[E0433]: failed to resolve: use of undeclared crate or module `ipconfig`
   --> C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\trust-dns-resolver-0.20.1\src\error.rs:285:11
    |
285 | impl From<ipconfig::error::Error> for ResolveError {
    |           ^^^^^^^^ use of undeclared crate or module `ipconfig`

error[E0433]: failed to resolve: use of undeclared crate or module `ipconfig`
   --> C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\trust-dns-resolver-0.20.1\src\error.rs:286:16
    |
286 |     fn from(e: ipconfig::error::Error) -> ResolveError {
    |                ^^^^^^^^ use of undeclared crate or module `ipconfig`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0433`.
error: could not compile `trust-dns-resolver`
```