### PR TITLE
add systemd unit and apparmor profile example

### DIFF
--- a/bin/named.service.example
+++ b/bin/named.service.example
@@ -1,0 +1,21 @@
+[Unit]
+Description=Trust-DNS Named Service
+Documentation=https://github.com/bluejekyll/trust-dns
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/named
+Restart=on-failure
+RestartSec=5
+PrivateTmp=yes
+NoNewPrivileges=yes
+ProtectSystem=yes
+ProtectHome=yes
+ProtectDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+MemoryDenyWriteExecute=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/bin/named.service.example
+++ b/bin/named.service.example
@@ -3,19 +3,29 @@ Description=Trust-DNS Named Service
 Documentation=https://github.com/bluejekyll/trust-dns
 
 [Service]
+User=www-data
+Group=www-data
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 Type=simple
 ExecStart=/usr/local/bin/named
 Restart=on-failure
 RestartSec=5
 PrivateTmp=yes
-NoNewPrivileges=yes
-ProtectSystem=yes
-ProtectHome=yes
-ProtectDevices=yes
-ProtectKernelTunables=yes
-ProtectKernelModules=yes
-ProtectControlGroups=yes
-MemoryDenyWriteExecute=yes
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+ProtectDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+KeyringMode=private
+ProtectClock=true
+RestrictRealtime=true
+ProtectHostname=true
 
 [Install]
 WantedBy=multi-user.target

--- a/bin/usr.local.bin.named
+++ b/bin/usr.local.bin.named
@@ -1,0 +1,12 @@
+# vim:syntax=apparmor
+# AppArmor policy for named
+
+#include <tunables/global>
+
+/usr/local/bin/named {
+  #include <abstractions/base>
+
+  network,
+  /etc/named.toml r,
+  /var/named/**/*.zone rw,
+}

--- a/bin/usr.local.bin.named
+++ b/bin/usr.local.bin.named
@@ -7,6 +7,7 @@
   #include <abstractions/base>
 
   network,
+  capability net_bind_service,
   /etc/named.toml r,
   /var/named/**/*.zone rw,
 }


### PR DESCRIPTION
Hi,

I wrote some systemd unit and apparmor profile example based on the example configuration file variables. the goal, even if trust-dns is not production ready yet, is too give people how may try to do it anyway a solid security baseline.

Tell me what you think about it !

Thank you