### PR TITLE
allow receiving multiple response to a single zone transfert request

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -86,7 +86,7 @@ wasm-bindgen-crate = { version = "0.2.58", optional = true, package = "wasm-bind
 [dev-dependencies]
 env_logger = "0.8"
 futures-executor = { version = "0.3.5", default-features = false, features = ["std"] }
-tokio = { version = "1.0", features = ["rt", "time"] }
+tokio = { version = "1.0", features = ["rt", "time", "macros"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -233,7 +233,7 @@ impl Stream for NeverReturnsClientStream {
 
 impl fmt::Debug for NeverReturnsClientStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TestClientStream catalog")
+        write!(f, "NeverReturnsClientStream")
     }
 }
 


### PR DESCRIPTION
fix #1277 
This does not allow to transmit a zone of unlimited size, but only up to 1000 messages (arbitrary number), which seems enough for most use-cases. There is no easy way to apply back-pressure on the stream sending the zone, so even if the code used `Stream`s more, there would still be the need for a limit.
This would probably need some test