### PR TITLE
1445 Replace all min & max constructs with clamp

### DIFF
--- a/crates/proto/src/https/https_client_stream.rs
+++ b/crates/proto/src/https/https_client_stream.rs
@@ -106,10 +106,10 @@ impl HttpsClientStream {
             .map_err(|e| ProtoError::from(format!("bad headers received: {}", e)))?;
 
         // TODO: what is a good max here?
-        // max(512) says make sure it is at least 512 bytes, and min 4096 says it is at most 4k
-        //  just a little protection from malicious actors.
+        // clamp(512, 4096) says make sure it is at least 512 bytes, and min 4096 says it is at most 4k
+        // just a little protection from malicious actors.
         let mut response_bytes =
-            BytesMut::with_capacity(content_length.unwrap_or(512).max(512).min(4096));
+            BytesMut::with_capacity(content_length.unwrap_or(512).clamp(512, 4096));
 
         while let Some(partial_bytes) = response_stream.body_mut().data().await {
             let partial_bytes =

--- a/crates/proto/src/https/https_server.rs
+++ b/crates/proto/src/https/https_server.rs
@@ -63,7 +63,7 @@ pub(crate) async fn message_from_post<R>(
 where
     R: Stream<Item = Result<Bytes, h2::Error>> + 'static + Send + Debug + Unpin,
 {
-    let mut bytes = BytesMut::with_capacity(length.unwrap_or(0).max(512).min(4096));
+    let mut bytes = BytesMut::with_capacity(length.unwrap_or(0).clamp(512, 4096));
 
     loop {
         match request_stream.next().await {

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -239,8 +239,7 @@ impl DnsLru {
             let ttl_duration = Duration::from_secs(u64::from(ttl))
                 // Clamp the TTL so that it's between the cache's configured
                 // minimum and maximum TTLs for negative responses.
-                .max(self.negative_min_ttl)
-                .min(self.negative_max_ttl);
+                .clamp(self.negative_min_ttl, self.negative_max_ttl);
             let valid_until = now + ttl_duration;
 
             {


### PR DESCRIPTION
replace .max().min() constructs with .clamp()

----

fixes: #1445