### PR TITLE
1445 part2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['1.46.0', beta, nightly]
+        version: ['1.50.0', beta, nightly]
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ presume that the trust-dns repos have already been synced to the local system:
 
 ### Minimum Rust Version
 
-- The current minimum rustc version for this project is `1.46`
+- The current minimum rustc version for this project is `1.50`
 - OpenSSL development libraries (optional in client and resolver, min version 1.0.2)
 
 ### Mac OS X: using homebrew

--- a/bin/README.md
+++ b/bin/README.md
@@ -44,7 +44,7 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/async-std-resolver/README.md
+++ b/crates/async-std-resolver/README.md
@@ -51,7 +51,7 @@ async fn main() {
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -74,7 +74,7 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/https/README.md
+++ b/crates/https/README.md
@@ -6,7 +6,7 @@ This library allows for HTTPS connections to be established to remote DNS server
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/native-tls/README.md
+++ b/crates/native-tls/README.md
@@ -6,7 +6,7 @@ This library allows for TLS connections to be established to remote DNS servers.
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/openssl/README.md
+++ b/crates/openssl/README.md
@@ -6,7 +6,7 @@ This library allows for TLS connections to be established to remote DNS servers.
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/proto/README.md
+++ b/crates/proto/README.md
@@ -4,7 +4,7 @@ Trust-DNS Proto is the foundational DNS protocol library and implementation for 
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/proto/src/https/https_client_stream.rs
+++ b/crates/proto/src/https/https_client_stream.rs
@@ -110,10 +110,10 @@ impl HttpsClientStream {
             .map_err(|e| ProtoError::from(format!("bad headers received: {}", e)))?;
 
         // TODO: what is a good max here?
-        // max(512) says make sure it is at least 512 bytes, and min 4096 says it is at most 4k
-        //  just a little protection from malicious actors.
+        // clamp(512, 4096) says make sure it is at least 512 bytes, and min 4096 says it is at most 4k
+        // just a little protection from malicious actors.
         let mut response_bytes =
-            BytesMut::with_capacity(content_length.unwrap_or(512).max(512).min(4096));
+            BytesMut::with_capacity(content_length.unwrap_or(512).clamp(512, 4096));
 
         while let Some(partial_bytes) = response_stream.body_mut().data().await {
             let partial_bytes =

--- a/crates/proto/src/https/https_server.rs
+++ b/crates/proto/src/https/https_server.rs
@@ -63,7 +63,7 @@ pub(crate) async fn message_from_post<R>(
 where
     R: Stream<Item = Result<Bytes, h2::Error>> + 'static + Send + Debug + Unpin,
 {
-    let mut bytes = BytesMut::with_capacity(length.unwrap_or(0).max(512).min(4096));
+    let mut bytes = BytesMut::with_capacity(length.unwrap_or(0).clamp(512, 4096));
 
     loop {
         match request_stream.next().await {

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -164,7 +164,7 @@ impl DnsResponse {
             .iter()
             .filter_map(|record| record.rdata().as_soa().map(|soa| (record.ttl(), soa)))
             .next()
-            .map(|(ttl, soa)| (ttl as u32).min(soa.minimum()).max(0))
+            .map(|(ttl, soa)| (ttl as u32).min(soa.minimum()))
     }
 
     /// Does the response contain any records matching the query name and type?

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -98,7 +98,7 @@ Success for query name: www.example.com. type: A class: IN
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -235,8 +235,7 @@ impl DnsLru {
             let ttl_duration = Duration::from_secs(u64::from(ttl))
                 // Clamp the TTL so that it's between the cache's configured
                 // minimum and maximum TTLs for negative responses.
-                .max(self.negative_min_ttl)
-                .min(self.negative_max_ttl);
+                .clamp(self.negative_min_ttl, self.negative_max_ttl);
             let valid_until = now + ttl_duration;
 
             {

--- a/crates/rustls/README.md
+++ b/crates/rustls/README.md
@@ -8,7 +8,7 @@ This library allows for TLS connections to be established to remote DNS servers.
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -24,7 +24,7 @@ This library contains basic implementations for DNS zone hosting. It is capable 
 
 ## Minimum Rust Version
 
-The current minimum rustc version for this project is `1.46`
+The current minimum rustc version for this project is `1.50`
 
 ## Versioning
 


### PR DESCRIPTION
Building on top of #1473, I found one more place where min().max() construct could be replaced.

The simplest solution is not to use clamp(), but to remove the .max(0) as it is unnecessary on a u32.
