### PR TITLE
add onion special domain handling

### DIFF
--- a/crates/client/src/rr/zone.rs
+++ b/crates/client/src/rr/zone.rs
@@ -230,6 +230,7 @@ impl UsageTrie {
             .is_none());
 
         assert!(trie.insert(INVALID.clone().into(), &INVALID).is_none());
+        assert!(trie.insert(ONION.clone().into(), &ONION).is_none());
 
         assert!(trie.insert(EXAMPLE.clone().into(), &EXAMPLE).is_none());
         assert!(trie
@@ -452,6 +453,21 @@ mod tests {
 
         let usage = USAGE.get(&name);
         assert_eq!(usage.name(), INVALID.name());
+    }
+
+    #[test]
+    fn test_onion() {
+        let name = Name::from_ascii("onion.").unwrap();
+
+        let usage = USAGE.get(&name);
+        assert_eq!(usage.name(), ONION.name());
+
+        let name =
+            Name::from_ascii("2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion.")
+                .unwrap(); // torproject.org onion
+
+        let usage = USAGE.get(&name);
+        assert_eq!(usage.name(), ONION.name());
     }
 
     #[test]

--- a/crates/proto/src/rr/domain/usage.rs
+++ b/crates/proto/src/rr/domain/usage.rs
@@ -112,6 +112,30 @@ lazy_static! {
     pub static ref INVALID: ZoneUsage = ZoneUsage::invalid(Name::from_ascii("invalid.").unwrap());
 }
 
+lazy_static! {
+    /// invalid.
+    ///
+    /// [The ".onion" Special-Use Domain Name](https://tools.ietf.org/html/rfc7686), RFC 7686 October, 2015
+    ///
+    /// ```text
+    /// 1.  Introduction
+    ///
+    ///   The Tor network has the ability to host network
+    ///   services using the ".onion" Special-Use Top-Level Domain Name.  Such
+    ///   names can be used as other domain names would be (e.g., in URLs
+    ///   [RFC3986]), but instead of using the DNS infrastructure, .onion names
+    ///   functionally correspond to the identity of a given service, thereby
+    ///   combining location and authentication.
+    /// ```
+
+    /// onion. name usage
+    pub static ref ONION: ZoneUsage = ZoneUsage {
+        user: UserUsage::Normal, // the domain is special, but this is what seems to match the most
+        app: AppUsage::Normal, // the domain is special, but this is what seems to match the most
+        .. ZoneUsage::invalid(Name::from_ascii("onion.").unwrap())
+    };
+}
+
 /// Users:
 ///
 ///   Are human users expected to recognize these names as special and

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -299,19 +299,17 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
 
     fn build_names(&self, name: Name) -> Vec<Name> {
         // if it's fully qualified, we can short circuit the lookup logic
-        if name.is_fqdn() {
-            vec![name]
-        } else if ONION.zone_of(&name)
-            && name
-                .trim_to(2)
-                .iter()
-                .next()
-                .map(|name| name.len() == 56)
-                .unwrap_or(false)
+        if name.is_fqdn()
+            || ONION.zone_of(&name)
+                && name
+                    .trim_to(2)
+                    .iter()
+                    .next()
+                    .map(|name| name.len() == 56) // size of onion v3 address
+                    .unwrap_or(false)
         {
-            // special handling of .onion looking names. Try to not break onion.example.com. and
-            // *.onion.example.com, but reject Tor Onion V3 names. Onion V2 are deprectated and
-            // soon to be removed
+            // if already fully qualified, or if onion address, don't assume it might be a
+            // sub-domain
             vec![name]
         } else {
             // Otherwise we have to build the search list

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use futures_util::{self, future};
 use proto::error::ProtoResult;
 use proto::op::Query;
+use proto::rr::domain::usage::ONION;
 use proto::rr::domain::TryParseIp;
 use proto::rr::{IntoName, Name, Record, RecordType};
 use proto::xfer::{DnsRequestOptions, RetryDnsHandle};
@@ -299,6 +300,18 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
     fn build_names(&self, name: Name) -> Vec<Name> {
         // if it's fully qualified, we can short circuit the lookup logic
         if name.is_fqdn() {
+            vec![name]
+        } else if ONION.zone_of(&name)
+            && name
+                .trim_to(2)
+                .iter()
+                .next()
+                .map(|name| name.len() == 56)
+                .unwrap_or(false)
+        {
+            // special handling of .onion looking names. Try to not break onion.example.com. and
+            // *.onion.example.com, but reject Tor Onion V3 names. Onion V2 are deprectated and
+            // soon to be removed
             vec![name]
         } else {
             // Otherwise we have to build the search list
@@ -1282,5 +1295,39 @@ mod tests {
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
         let handle = TokioHandle;
         search_ipv6_name_parse_fails_test::<Runtime, TokioRuntime>(io_loop, handle);
+    }
+
+    #[test]
+    fn test_build_names_onion() {
+        let handle = TokioHandle;
+        let mut config = ResolverConfig::default();
+        config.add_search(Name::from_ascii("example.com.").unwrap());
+        let resolver =
+            AsyncResolver::<GenericConnection, GenericConnectionProvider<TokioRuntime>>::new(
+                config,
+                ResolverOpts::default(),
+                handle,
+            )
+            .expect("failed to create resolver");
+        let tor_address = [
+            Name::from_ascii("2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion")
+                .unwrap(),
+            Name::from_ascii("www.2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion")
+                .unwrap(), // subdomain are allowed too
+        ];
+        let not_tor_address = [
+            Name::from_ascii("onion").unwrap(),
+            Name::from_ascii("www.onion").unwrap(),
+            Name::from_ascii("2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.www.onion")
+                .unwrap(), // www before key
+            Name::from_ascii("2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion.to")
+                .unwrap(), // Tor2web
+        ];
+        for name in &tor_address {
+            assert_eq!(resolver.build_names(name.clone()).len(), 1);
+        }
+        for name in &not_tor_address {
+            assert_eq!(resolver.build_names(name.clone()).len(), 2);
+        }
     }
 }

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -21,7 +21,7 @@ use proto::error::ProtoError;
 use proto::op::{Query, ResponseCode};
 use proto::rr::domain::usage::{
     ResolverUsage, DEFAULT, INVALID, IN_ADDR_ARPA_127, IP6_ARPA_1, LOCAL,
-    LOCALHOST as LOCALHOST_usage,
+    LOCALHOST as LOCALHOST_usage, ONION,
 };
 use proto::rr::rdata::SOA;
 use proto::rr::{DNSClass, Name, RData, Record, RecordType};
@@ -128,6 +128,7 @@ where
                 n if IP6_ARPA_1.zone_of(n) => &*LOCALHOST_usage,
                 n if INVALID.zone_of(n) => &*INVALID,
                 n if LOCAL.zone_of(n) => &*LOCAL,
+                n if ONION.zone_of(n) => &*ONION,
                 _ => &*DEFAULT,
             };
 


### PR DESCRIPTION
fix #1382
For search, as it's possible to have a domain like `something.onion.example.com`, but very unlikely to have `<valid_key>.onion.example.com`, this try to evaluate whether the `something.onion` might be a valid Tor onion domain name based on the length of the name. This match only V3 onion domains (56 chars long), as V2 (16 chars long) [are deprecated](https://blog.torproject.org/v2-deprecation-timeline) and will soon be no longer supported