### PR TITLE
[0.20] Fix Windows build without system-config feature

### DIFF
--- a/crates/resolver/src/error.rs
+++ b/crates/resolver/src/error.rs
@@ -282,6 +282,7 @@ impl From<&'static str> for ResolveError {
 }
 
 #[cfg(target_os = "windows")]
+#[cfg(feature = "system-config")]
 impl From<ipconfig::error::Error> for ResolveError {
     fn from(e: ipconfig::error::Error) -> ResolveError {
         ResolveErrorKind::Msg(format!("failed to read from registry: {}", e)).into()


### PR DESCRIPTION
Backport of https://github.com/bluejekyll/trust-dns/pull/1431

I tested this by doing `no-default-features` builds in CI before and after:
 - https://github.com/stephank/trust-dns/runs/2512105509
 - https://github.com/stephank/trust-dns/runs/2512336530