### PR TITLE
reduce size of ResolveErrorKind

### DIFF
--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -267,13 +267,13 @@ impl<'a> From<ArgMatches<'a>> for Args {
             flag_zonedir: matches.value_of(ZONEDIR_ARG).map(ToString::to_string),
             flag_port: matches
                 .value_of(PORT_ARG)
-                .map(|s| u16::from_str_radix(s, 10).expect("bad port argument")),
+                .map(|s| s.parse().expect("bad port argument")),
             flag_tls_port: matches
                 .value_of(TLS_PORT_ARG)
-                .map(|s| u16::from_str_radix(s, 10).expect("bad tls-port argument")),
+                .map(|s| s.parse().expect("bad tls-port argument")),
             flag_https_port: matches
                 .value_of(HTTPS_PORT_ARG)
-                .map(|s| u16::from_str_radix(s, 10).expect("bad https-port argument")),
+                .map(|s| s.parse().expect("bad https-port argument")),
         }
     }
 }

--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -130,22 +130,35 @@ where
 
         if let Some(udp) = udp_regex.captures(&output) {
             test_udp_port = Some(
-                u16::from_str_radix(udp.get(1).expect("udp missing port").as_str(), 10)
+                udp.get(1)
+                    .expect("udp missing port")
+                    .as_str()
+                    .parse()
                     .expect("could not parse udp port"),
             );
         } else if let Some(tcp) = tcp_regex.captures(&output) {
             test_tcp_port = Some(
-                u16::from_str_radix(tcp.get(1).expect("tcp missing port").as_str(), 10)
+                tcp.get(1)
+                    .expect("tcp missing port")
+                    .as_str()
+                    .parse()
                     .expect("could not parse tcp port"),
             );
         } else if let Some(tls) = tls_regex.captures(&output) {
             test_tls_port = Some(
-                u16::from_str_radix(tls.get(1).expect("tls missing port").as_str(), 10)
+                tls.get(1)
+                    .expect("tls missing port")
+                    .as_str()
+                    .parse()
                     .expect("could not parse tls port"),
             );
         } else if let Some(https) = https_regex.captures(&output) {
             test_https_port = Some(
-                u16::from_str_radix(https.get(1).expect("https missing port").as_str(), 10)
+                https
+                    .get(1)
+                    .expect("https missing port")
+                    .as_str()
+                    .parse()
                     .expect("could not parse https port"),
             );
         } else if output.contains("awaiting connections...") {

--- a/crates/client/src/serialize/txt/rdata_parsers/caa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/caa.rs
@@ -58,7 +58,7 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResu
 
     // parse the flags
     let issuer_critical = {
-        let flags = u8::from_str_radix(flags_str, 10)?;
+        let flags = flags_str.parse::<u8>()?;
         if flags & 0b0111_1111 != 0 {
             warn!("unexpected flag values in caa (0 or 128): {}", flags);
         }

--- a/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
@@ -13,7 +13,7 @@ use crate::rr::rdata::tlsa::CertUsage;
 use crate::rr::rdata::{sshfp, TLSA};
 
 fn to_u8(data: &str) -> ParseResult<u8> {
-    u8::from_str_radix(data, 10).map_err(ParseError::from)
+    data.parse::<u8>().map_err(ParseError::from)
 }
 
 /// Parse the RData from a set of Tokens

--- a/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
@@ -13,7 +13,7 @@ use crate::rr::rdata::tlsa::CertUsage;
 use crate::rr::rdata::{sshfp, TLSA};
 
 fn to_u8(data: &str) -> ParseResult<u8> {
-    data.parse::<u8>().map_err(ParseError::from)
+    data.parse().map_err(ParseError::from)
 }
 
 /// Parse the RData from a set of Tokens

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -207,8 +207,8 @@ where
                 Err(Self::handle_nxdomain(
                     is_dnssec,
                     false, /*tbd*/
-                    query,
-                    soa,
+                    *query,
+                    soa.map(|v| *v),
                     negative_ttl,
                     response_code,
                     trusted,
@@ -275,8 +275,8 @@ where
         if valid_nsec || !is_dnssec {
             // only trust if there were validated NSEC records
             ResolveErrorKind::NoRecordsFound {
-                query,
-                soa,
+                query: Box::new(query),
+                soa: soa.map(Box::new),
                 negative_ttl,
                 response_code,
                 trusted: true,
@@ -285,8 +285,8 @@ where
         } else {
             // not cacheable, no ttl...
             ResolveErrorKind::NoRecordsFound {
-                query,
-                soa,
+                query: Box::new(query),
+                soa: soa.map(Box::new),
                 negative_ttl: None,
                 response_code,
                 trusted,
@@ -517,7 +517,7 @@ mod tests {
         .unwrap_err()
         .kind()
         {
-            assert_eq!(*query, Query::new());
+            assert_eq!(**query, Query::new());
             assert_eq!(*negative_ttl, None);
         } else {
             panic!("wrong error received")

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -373,7 +373,7 @@ mod tests {
 
         // neg response should have TTL of 1 seconds.
         let err = ResolveErrorKind::NoRecordsFound {
-            query: name.clone(),
+            query: Box::new(name.clone()),
             soa: None,
             negative_ttl: Some(1),
             response_code: ResponseCode::NoError,
@@ -391,7 +391,7 @@ mod tests {
 
         // neg response should have TTL of 3 seconds.
         let err = ResolveErrorKind::NoRecordsFound {
-            query: name.clone(),
+            query: Box::new(name.clone()),
             soa: None,
             negative_ttl: Some(3),
             response_code: ResponseCode::NoError,
@@ -463,7 +463,7 @@ mod tests {
 
         // neg response should have TTL of 62 seconds.
         let err = ResolveErrorKind::NoRecordsFound {
-            query: name.clone(),
+            query: Box::new(name.clone()),
             soa: None,
             negative_ttl: Some(62),
             response_code: ResponseCode::NoError,
@@ -481,7 +481,7 @@ mod tests {
 
         // neg response should have TTL of 59 seconds.
         let err = ResolveErrorKind::NoRecordsFound {
-            query: name.clone(),
+            query: Box::new(name.clone()),
             soa: None,
             negative_ttl: Some(59),
             response_code: ResponseCode::NoError,

--- a/crates/resolver/src/error.rs
+++ b/crates/resolver/src/error.rs
@@ -40,9 +40,9 @@ pub enum ResolveErrorKind {
     #[error("no record found for {query}")]
     NoRecordsFound {
         /// The query for which no records were found.
-        query: Query,
+        query: Box<Query>,
         /// If an SOA is present, then this is an authoritative response.
-        soa: Option<SOA>,
+        soa: Option<Box<SOA>>,
         /// negative ttl, as determined from DnsResponse::negative_ttl
         ///  this will only be present if the SOA was also present.
         negative_ttl: Option<u32>,
@@ -111,8 +111,8 @@ impl ResolveError {
         trusted: bool,
     ) -> ResolveError {
         ResolveErrorKind::NoRecordsFound {
-            query,
-            soa,
+            query: Box::new(query),
+            soa: soa.map(Box::new),
             negative_ttl,
             response_code,
             trusted,
@@ -136,8 +136,8 @@ impl ResolveError {
                 let soa = response.soa();
                 let query = response.take_queries().drain(..).next().unwrap_or_default();
                 let error_kind = ResolveErrorKind::NoRecordsFound {
-                    query,
-                    soa,
+                    query: Box::new(query),
+                    soa: soa.map(Box::new),
                     negative_ttl: None,
                     response_code: ResponseCode::ServFail,
                     trusted: false,
@@ -159,8 +159,8 @@ impl ResolveError {
 
                 let query = response.take_queries().drain(..).next().unwrap_or_default();
                 let error_kind = ResolveErrorKind::NoRecordsFound {
-                    query,
-                    soa,
+                    query: Box::new(query),
+                    soa: soa.map(Box::new),
                     negative_ttl,
                     response_code: ResponseCode::NXDomain,
                     trusted: trust_nx,
@@ -182,8 +182,8 @@ impl ResolveError {
 
                 let query = response.take_queries().drain(..).next().unwrap_or_default();
                 let error_kind = ResolveErrorKind::NoRecordsFound {
-                    query,
-                    soa,
+                    query: Box::new(query),
+                    soa: soa.map(Box::new),
                     negative_ttl,
                     response_code: ResponseCode::NoError,
                     trusted: false,

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -645,7 +645,7 @@ pub mod tests {
         .unwrap_err()
         .kind()
         {
-            assert_eq!(*query, Query::query(Name::root(), RecordType::A));
+            assert_eq!(**query, Query::query(Name::root(), RecordType::A));
             assert_eq!(*negative_ttl, None);
         } else {
             panic!("wrong error recieved");


### PR DESCRIPTION
fix #1383 part2
Reduce size of `ResolveError` by boxing some parts of its inner enum
#1409 already boxed `ProtoErrorKind` in `ProtoError`