### PR TITLE
Allow cloning ForwardConfig

### DIFF
--- a/crates/server/src/store/forwarder/config.rs
+++ b/crates/server/src/store/forwarder/config.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use crate::resolver::config::{NameServerConfigGroup, ResolverOpts};
 
 /// Configuration for file based zones
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 pub struct ForwardConfig {
     /// upstream name_server configurations
     pub name_servers: NameServerConfigGroup,


### PR DESCRIPTION
Hiya, I'm trying to use the Trust-DNS server library and it seems to me that allowing `ForwardConfig` to be cloned would be an usability improvement.