### PR TITLE
restart using slproweb for OpenSSL on Windows in CI

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -45,8 +45,7 @@ script = [
 '''
 mkdir ${env:CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}\\target
 mkdir ${env:CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}\\target\OpenSSL
-Invoke-WebRequest -URI "https://trinity.fr.eu.org/Win64OpenSSL-${env:OPENSSL_VERSION}.exe" -OutFile "${env:CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}\target\OpenSSL.exe"
-#Invoke-WebRequest -URI "http://slproweb.com/download/Win64OpenSSL-${env:OPENSSL_VERSION}.exe" -OutFile "${env:CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}\target\OpenSSL.exe"
+Invoke-WebRequest -URI "http://slproweb.com/download/Win64OpenSSL-${env:OPENSSL_VERSION}.exe" -OutFile "${env:CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}\target\OpenSSL.exe"
 Start-Process -FilePath "${env:CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}\target\OpenSSL.exe" -ArgumentList "/SILENT /VERYSILENT /SP- /DIR=${env:OPENSSL_DIR}"
 Invoke-WebRequest "https://curl.haxx.se/ca/cacert.pem" -O "${env:OPENSSL_DIR}\cacert.pem"
 '''


### PR DESCRIPTION
using my own server was a quick fix that should not have landed on main. It was added in https://github.com/bluejekyll/trust-dns/pull/1478/commits/7a05ba18513da6d1b272d3911f84504ca37eebb2 because slproweb.com was down for some time, preventing most jobs from running