### PR TITLE
Cleanup default features, remove dnssec from client and server default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 
 ### Removed
 
-- (proto) removed `RecordType::DNSSEC` and moved all variants of `DNSSECRecordType` into `RecordType`
+- (proto) removed `RecordType::DNSSEC` and moved all variants of `DNSSECRecordType` into `RecordType` #1506
 - (proto) removed `BufStreamHandle` and `StreamHandle` #1433
 - (response) disabled `mdns` to work on a new solution #1433
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 
 ### Removed
 
+- (proto) removed `RecordType::DNSSEC` and moved all variants of `DNSSECRecordType` into `RecordType`
 - (proto) removed `BufStreamHandle` and `StreamHandle` #1433
 - (response) disabled `mdns` to work on a new solution #1433
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notes should be prepended with the location of the change, e.g. `(proto)` or
 
 ### Changed
 
+- (client) the feature `dnssec` is no longer enabled by default, use `dnssec-ring` or `dnssec-openssl` #1506
+- (server) dnssec functions of `Authority` moved into `DnsSecAuthority` #1506
 - (all) Most public enum types are now marked `#[non_exaustive]` #1426
 - (resolver) DnsRequestOptions and ResolverOpts now `#[non_exaustive]` #1426
 - (proto) all I/O Streams now use `BufDnsStreamHandle` rather than generic `DnsStreamHandle` #1433

--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -21,12 +21,12 @@ use tokio::runtime::Runtime;
 
 use trust_dns_client::client::*;
 use trust_dns_client::op::*;
-use trust_dns_client::rr::dnssec::Signer;
 use trust_dns_client::rr::*;
 use trust_dns_client::tcp::*;
 use trust_dns_client::udp::*;
 use trust_dns_proto::error::*;
 use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
+use trust_dns_proto::op::NoopMessageFinalizer;
 use trust_dns_proto::xfer::*;
 
 fn find_test_port() -> u16 {
@@ -184,7 +184,7 @@ fn trust_dns_tcp_bench(b: &mut Bencher) {
         .next()
         .unwrap();
     let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TcpStream>>::new(addr);
-    let mp = DnsMultiplexer::new(stream, sender, None::<Arc<Signer>>);
+    let mp = DnsMultiplexer::new(stream, sender, None::<Arc<NoopMessageFinalizer>>);
     bench(b, mp);
 
     // cleaning up the named process
@@ -259,7 +259,7 @@ fn bind_tcp_bench(b: &mut Bencher) {
         .next()
         .unwrap();
     let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TcpStream>>::new(addr);
-    let mp = DnsMultiplexer::new(stream, sender, None::<Arc<Signer>>);
+    let mp = DnsMultiplexer::new(stream, sender, None::<Arc<NoopMessageFinalizer>>);
     bench(b, mp);
 
     // cleaning up the named process

--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -40,6 +40,7 @@ extern crate clap;
 #[macro_use]
 extern crate log;
 
+#[cfg(feature = "dnssec")]
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
 use std::path::{Path, PathBuf};

--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -16,10 +16,11 @@ use tokio::runtime::Runtime;
 
 use trust_dns_client::client::*;
 use trust_dns_client::proto::xfer::DnsResponse;
-use trust_dns_client::rr::dnssec::*;
-use trust_dns_client::rr::rdata::DNSSECRData;
 use trust_dns_client::rr::*;
+#[cfg(feature = "dnssec")]
+use trust_dns_client::rr::{dnssec::*, rdata::DNSSECRData};
 
+#[cfg(feature = "dnssec")]
 use self::mut_message_client::MutMessageHandle;
 
 fn collect_and_print<R: BufRead>(read: &mut R, output: &mut String) {
@@ -238,6 +239,7 @@ pub fn query_a<C: ClientHandle>(io_loop: &mut Runtime, client: &mut C) {
 // This only validates that a query to the server works, it shouldn't be used for more than this.
 //  i.e. more complex checks live with the clients and authorities to validate deeper functionality
 #[allow(dead_code)]
+#[cfg(feature = "dnssec")]
 pub fn query_all_dnssec(
     io_loop: &mut Runtime,
     client: AsyncClient,
@@ -246,9 +248,11 @@ pub fn query_all_dnssec(
 ) {
     let name = Name::from_str("example.com.").unwrap();
     let mut client = MutMessageHandle::new(client);
-    client.dnssec_ok = true;
+    client.lookup_options.set_is_dnssec(true);
     if with_rfc6975 {
-        client.support_algorithms = Some(SupportedAlgorithms::from_vec(&[algorithm]));
+        client
+            .lookup_options
+            .set_supported_algorithms(SupportedAlgorithms::from_vec(&[algorithm]));
     }
 
     let response = query_message(io_loop, &mut client, name.clone(), RecordType::DNSKEY);
@@ -286,6 +290,7 @@ pub fn query_all_dnssec(
 }
 
 #[allow(dead_code)]
+#[cfg(feature = "dnssec")]
 pub fn query_all_dnssec_with_rfc6975(
     io_loop: &mut Runtime,
     client: AsyncClient,
@@ -295,6 +300,7 @@ pub fn query_all_dnssec_with_rfc6975(
 }
 
 #[allow(dead_code)]
+#[cfg(feature = "dnssec")]
 pub fn query_all_dnssec_wo_rfc6975(
     io_loop: &mut Runtime,
     client: AsyncClient,

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -41,8 +41,6 @@ codecov = { repository = "bluejekyll/trust-dns", branch = "main", service = "git
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["dnssec"]
-
 backtrace = ["trust-dns-proto/backtrace"]
 # TODO: the rustls and openssl crates are not deps... should we change that to make them easier to use?
 #  or change this to also be external?
@@ -84,7 +82,7 @@ rustls = { version = "0.19", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0.20"
 tokio = { version = "1.0", features = ["rt"] }
-trust-dns-proto = { version = "0.21.0-alpha.1", path = "../proto", features = ["dnssec"]}
+trust-dns-proto = { version = "0.21.0-alpha.1", path = "../proto"}
 webpki = { version = "0.21", optional = true }
 
 [dev-dependencies]

--- a/crates/client/src/error/parse_error.rs
+++ b/crates/client/src/error/parse_error.rs
@@ -11,9 +11,12 @@
 use std::{fmt, io};
 
 use thiserror::Error;
-use trust_dns_proto::error::{ProtoError, ProtoErrorKind};
 
 use super::LexerError;
+use crate::proto::{
+    error::{ProtoError, ProtoErrorKind},
+    rr::RecordType,
+};
 #[cfg(feature = "backtrace")]
 use crate::proto::{trace, ExtBacktrace};
 use crate::serialize::txt::Token;
@@ -78,6 +81,10 @@ pub enum ErrorKind {
     #[error("unknown RecordType: {0}")]
     UnknownRecordType(u16),
 
+    /// Unknown RecordType
+    #[error("unsupported RecordType: {0}")]
+    UnsupportedRecordType(RecordType),
+
     /// A request timed out
     #[error("request timed out")]
     Timeout,
@@ -100,6 +107,7 @@ impl Clone for ErrorKind {
             Lexer(e) => Lexer(e.clone()),
             ParseInt(e) => ParseInt(e.clone()),
             Proto(e) => Proto(e.clone()),
+            UnsupportedRecordType(ty) => UnsupportedRecordType(*ty),
             UnknownRecordType(ty) => UnknownRecordType(*ty),
             Timeout => Timeout,
         }

--- a/crates/client/src/rr/dnssec/mod.rs
+++ b/crates/client/src/rr/dnssec/mod.rs
@@ -20,8 +20,6 @@
 mod key_format;
 mod keypair;
 mod signer;
-#[cfg(feature = "dnssec")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
 pub mod tsig;
 
 use crate::proto::rr::dnssec;

--- a/crates/client/src/rr/dnssec/signer.rs
+++ b/crates/client/src/rr/dnssec/signer.rs
@@ -17,7 +17,7 @@ use {
     crate::error::DnsSecResult,
     crate::proto::rr::dnssec::{tbs, TBS},
     crate::rr::dnssec::{Algorithm, KeyPair, Private},
-    crate::rr::rdata::{DNSSECRData, DNSSECRecordType, DNSKEY, KEY, SIG},
+    crate::rr::rdata::{DNSSECRData, DNSKEY, KEY, SIG},
     crate::rr::{DNSClass, Name, RData, RecordType},
     crate::serialize::binary::BinEncoder,
 };
@@ -537,7 +537,7 @@ impl MessageFinalizer for SigSigner {
 
         let expiration_time: u32 = current_time + (5 * 60); // +5 minutes in seconds
 
-        sig0.set_rr_type(RecordType::DNSSEC(DNSSECRecordType::SIG));
+        sig0.set_rr_type(RecordType::SIG);
         let pre_sig0 = SIG::new(
             // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
             RecordType::ZERO,

--- a/crates/client/src/rr/dnssec/tsig.rs
+++ b/crates/client/src/rr/dnssec/tsig.rs
@@ -213,6 +213,8 @@ impl MessageFinalizer for TSigner {
 }
 
 #[cfg(test)]
+#[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
+
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
@@ -229,7 +231,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
     fn test_sign_and_verify_message_tsig() {
         let time_begin = 1609459200u64;
         let fudge = 300u64;
@@ -260,7 +261,6 @@ mod tests {
     }
 
     // make rejection tests shorter by centralizing common setup code
-    #[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
     fn get_message_and_signer() -> (Message, TSigner) {
         let time_begin = 1609459200u64;
         let fudge = 300u64;
@@ -290,7 +290,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
     fn test_sign_and_verify_message_tsig_reject_keyname() {
         let (mut question, signer) = get_message_and_signer();
 
@@ -305,7 +304,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
     fn test_sign_and_verify_message_tsig_reject_invalid_mac() {
         let (mut question, signer) = get_message_and_signer();
 
@@ -320,7 +318,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
     #[cfg(feature = "hmac_truncation")] // not currently supported for security reasons
     fn test_sign_and_verify_message_tsig_truncation() {
         let (mut question, signer) = get_message_and_signer();

--- a/crates/client/src/rr/mod.rs
+++ b/crates/client/src/rr/mod.rs
@@ -16,6 +16,8 @@
 
 //! Resource record related components, e.g. `Name` aka label, `Record`, `RData`, ...
 
+#[cfg(feature = "dnssec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
 pub mod dnssec;
 mod lower_name;
 mod rr_key;
@@ -41,6 +43,8 @@ pub use self::rr_key::RrKey;
 
 /// All record data structures and related serialization methods
 pub mod rdata {
+    #[cfg(feature = "dnssec")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
     pub use crate::proto::rr::dnssec::rdata::*;
     pub use crate::proto::rr::rdata::*;
 }

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -17,7 +17,6 @@
 //! record data enum variants
 
 use crate::error::*;
-use crate::rr::rdata::DNSSECRecordType;
 use crate::rr::{Name, RData, RecordType};
 use crate::serialize::txt::rdata_parsers::*;
 
@@ -61,44 +60,30 @@ impl RDataParser for RData {
             RecordType::SVCB => svcb::parse(tokens).map(RData::SVCB)?,
             RecordType::TLSA => RData::TLSA(tlsa::parse(tokens)?),
             RecordType::TXT => RData::TXT(txt::parse(tokens)?),
-            RecordType::DNSSEC(DNSSECRecordType::SIG) => {
-                return Err(ParseError::from("parsing SIG doesn't make sense"))
-            }
-            RecordType::DNSSEC(DNSSECRecordType::DNSKEY) => {
+            RecordType::SIG => return Err(ParseError::from("parsing SIG doesn't make sense")),
+            RecordType::DNSKEY => {
                 return Err(ParseError::from("DNSKEY should be dynamically generated"))
             }
-            RecordType::DNSSEC(DNSSECRecordType::KEY) => {
-                return Err(ParseError::from("KEY should be dynamically generated"))
-            }
-            RecordType::DNSSEC(DNSSECRecordType::DS) => {
-                return Err(ParseError::from("DS should be dynamically generated"))
-            }
-            RecordType::DNSSEC(DNSSECRecordType::NSEC) => {
+            RecordType::KEY => return Err(ParseError::from("KEY should be dynamically generated")),
+            RecordType::DS => return Err(ParseError::from("DS should be dynamically generated")),
+            RecordType::NSEC => {
                 return Err(ParseError::from("NSEC should be dynamically generated"))
             }
-            RecordType::DNSSEC(DNSSECRecordType::NSEC3) => {
+            RecordType::NSEC3 => {
                 return Err(ParseError::from("NSEC3 should be dynamically generated"))
             }
-            RecordType::DNSSEC(DNSSECRecordType::NSEC3PARAM) => {
+            RecordType::NSEC3PARAM => {
                 return Err(ParseError::from(
                     "NSEC3PARAM should be dynamically generated",
                 ))
             }
-            RecordType::DNSSEC(DNSSECRecordType::RRSIG) => {
+            RecordType::RRSIG => {
                 return Err(ParseError::from("RRSIG should be dynamically generated"))
             }
-            RecordType::DNSSEC(DNSSECRecordType::Unknown(code)) => {
-                return Err(ParseError::from(ParseErrorKind::UnknownRecordType(code)))
-            }
-            RecordType::Unknown(code) => {
-                // TODO: add a way to associate generic record types to the zone
-                return Err(ParseError::from(ParseErrorKind::UnknownRecordType(code)));
-            }
             RecordType::ZERO => RData::ZERO,
-            r @ trust_dns_proto::rr::RecordType::DNSSEC(..) | r => {
-                return Err(ParseError::from(ParseErrorKind::UnknownRecordType(
-                    u16::from(r),
-                )))
+            r => {
+                // TODO: add a way to associate generic record types to the zone
+                return Err(ParseError::from(ParseErrorKind::UnsupportedRecordType(r)));
             }
         };
 

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -80,8 +80,9 @@ impl RDataParser for RData {
             RecordType::RRSIG => {
                 return Err(ParseError::from("RRSIG should be dynamically generated"))
             }
+            RecordType::TSIG => return Err(ParseError::from("TSIG is only used during AXFR")),
             RecordType::ZERO => RData::ZERO,
-            r => {
+            r @ RecordType::Unknown(..) | r => {
                 // TODO: add a way to associate generic record types to the zone
                 return Err(ParseError::from(ParseErrorKind::UnsupportedRecordType(r)));
             }

--- a/crates/proto/benches/lib.rs
+++ b/crates/proto/benches/lib.rs
@@ -139,6 +139,6 @@ fn bench_parse_real_message(b: &mut Bencher) {
     ];
     b.iter(|| {
         let mut decoder = BinDecoder::new(&bytes[..]);
-        Message::read(&mut decoder);
+        assert!(Message::read(&mut decoder).is_ok());
     })
 }

--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -30,12 +30,8 @@ pub mod nsec3param;
 pub mod sig;
 pub mod tsig;
 
-use std::str::FromStr;
-
 use enum_as_inner::EnumAsInner;
 use log::trace;
-#[cfg(feature = "serde-config")]
-use serde::{Deserialize, Serialize};
 
 use crate::error::*;
 use crate::rr::rdata::null;
@@ -53,108 +49,8 @@ pub use self::sig::SIG;
 pub use self::tsig::TSIG;
 
 /// The type of the resource record, for DNSSEC-specific records.
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-#[non_exhaustive]
-pub enum DNSSECRecordType {
-    //  CDS,        //	59	RFC 7344	Child DS
-    //  CDNSKEY,    //	60	RFC 7344	Child DNSKEY
-    //  DLV,        //	32769	RFC 4431	DNSSEC Lookaside Validation record
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034) DNS Key record: RSASHA256 and RSASHA512, RFC5702
-    DNSKEY,
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034) Delegation signer: RSASHA256 and RSASHA512, RFC5702
-    DS,
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535) and [RFC 2930](https://tools.ietf.org/html/rfc2930) Key record
-    KEY,
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034) Next-Secure record
-    NSEC,
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155) NSEC record version 3
-    NSEC3,
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155) NSEC3 parameters
-    NSEC3PARAM,
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034) DNSSEC signature: RSASHA256 and RSASHA512, RFC5702
-    RRSIG,
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535) (and [RFC 2931](https://tools.ietf.org/html/rfc2931)) Signature, to support [RFC 2137](https://tools.ietf.org/html/rfc2137) Update.
-    ///
-    /// This isn't really a DNSSEC record type, but it is here because, at least
-    /// for now, we enable/disable SIG(0) in exactly the same circumstances that
-    /// we enable/disable DNSSEC. This may change in the future.
-    SIG,
-    /// [RFC 8945](https://tools.ietf.org/html/rfc8945) Transaction Signature
-    TSIG,
-    /// Unknown or not yet supported DNSSec record type
-    Unknown(u16),
-}
-
-impl FromStr for DNSSECRecordType {
-    type Err = ProtoError;
-
-    fn from_str(str: &str) -> ProtoResult<Self> {
-        match str {
-            "DNSKEY" => Ok(DNSSECRecordType::DNSKEY),
-            "DS" => Ok(DNSSECRecordType::DS),
-            "KEY" => Ok(DNSSECRecordType::KEY),
-            "NSEC" => Ok(DNSSECRecordType::NSEC),
-            "NSEC3" => Ok(DNSSECRecordType::NSEC3),
-            "NSEC3PARAM" => Ok(DNSSECRecordType::NSEC3PARAM),
-            "RRSIG" => Ok(DNSSECRecordType::RRSIG),
-            "SIG" => Ok(DNSSECRecordType::SIG),
-            "TSIG" => Ok(DNSSECRecordType::TSIG),
-            _ => Err(ProtoErrorKind::UnknownRecordTypeStr(str.to_string()).into()),
-        }
-    }
-}
-
-impl From<u16> for DNSSECRecordType {
-    fn from(value: u16) -> Self {
-        match value {
-            48 => DNSSECRecordType::DNSKEY,
-            43 => DNSSECRecordType::DS,
-            25 => DNSSECRecordType::KEY,
-            47 => DNSSECRecordType::NSEC,
-            50 => DNSSECRecordType::NSEC3,
-            51 => DNSSECRecordType::NSEC3PARAM,
-            46 => DNSSECRecordType::RRSIG,
-            24 => DNSSECRecordType::SIG,
-            250 => DNSSECRecordType::TSIG,
-            _ => DNSSECRecordType::Unknown(value),
-        }
-    }
-}
-
-impl From<DNSSECRecordType> for &'static str {
-    fn from(rt: DNSSECRecordType) -> &'static str {
-        match rt {
-            DNSSECRecordType::DNSKEY => "DNSKEY",
-            DNSSECRecordType::DS => "DS",
-            DNSSECRecordType::KEY => "KEY",
-            DNSSECRecordType::NSEC => "NSEC",
-            DNSSECRecordType::NSEC3 => "NSEC3",
-            DNSSECRecordType::NSEC3PARAM => "NSEC3PARAM",
-            DNSSECRecordType::RRSIG => "RRSIG",
-            DNSSECRecordType::SIG => "SIG",
-            DNSSECRecordType::TSIG => "TSIG",
-            DNSSECRecordType::Unknown(..) => "DnsSecUnknown",
-        }
-    }
-}
-
-impl From<DNSSECRecordType> for u16 {
-    fn from(rt: DNSSECRecordType) -> Self {
-        match rt {
-            DNSSECRecordType::KEY => 25,
-            DNSSECRecordType::DNSKEY => 48,
-            DNSSECRecordType::DS => 43,
-            DNSSECRecordType::NSEC => 47,
-            DNSSECRecordType::NSEC3 => 50,
-            DNSSECRecordType::NSEC3PARAM => 51,
-            DNSSECRecordType::RRSIG => 46,
-            DNSSECRecordType::SIG => 24,
-            DNSSECRecordType::TSIG => 250,
-            DNSSECRecordType::Unknown(value) => value,
-        }
-    }
-}
+#[deprecated(note = "All RecordType definitions have been moved into RecordType")]
+pub type DNSSECRecordType = RecordType;
 
 /// Record data enum variants for DNSSEC-specific records.
 #[derive(Debug, EnumAsInner, PartialEq, Clone, Eq)]
@@ -611,49 +507,48 @@ pub enum DNSSECRData {
 impl DNSSECRData {
     pub(crate) fn read(
         decoder: &mut BinDecoder<'_>,
-        record_type: DNSSECRecordType,
+        record_type: RecordType,
         rdata_length: Restrict<u16>,
     ) -> ProtoResult<Self> {
         match record_type {
-            DNSSECRecordType::DNSKEY => {
+            RecordType::DNSKEY => {
                 trace!("reading DNSKEY");
                 dnskey::read(decoder, rdata_length).map(DNSSECRData::DNSKEY)
             }
-            DNSSECRecordType::DS => {
+            RecordType::DS => {
                 trace!("reading DS");
                 ds::read(decoder, rdata_length).map(DNSSECRData::DS)
             }
-            DNSSECRecordType::KEY => {
+            RecordType::KEY => {
                 trace!("reading KEY");
                 key::read(decoder, rdata_length).map(DNSSECRData::KEY)
             }
-            DNSSECRecordType::NSEC => {
+            RecordType::NSEC => {
                 trace!("reading NSEC");
                 nsec::read(decoder, rdata_length).map(DNSSECRData::NSEC)
             }
-            DNSSECRecordType::NSEC3 => {
+            RecordType::NSEC3 => {
                 trace!("reading NSEC3");
                 nsec3::read(decoder, rdata_length).map(DNSSECRData::NSEC3)
             }
-            DNSSECRecordType::NSEC3PARAM => {
+            RecordType::NSEC3PARAM => {
                 trace!("reading NSEC3PARAM");
                 nsec3param::read(decoder).map(DNSSECRData::NSEC3PARAM)
             }
-            DNSSECRecordType::RRSIG => {
+            RecordType::RRSIG => {
                 trace!("reading RRSIG");
                 sig::read(decoder, rdata_length).map(DNSSECRData::SIG)
             }
-            DNSSECRecordType::SIG => {
+            RecordType::SIG => {
                 trace!("reading SIG");
                 sig::read(decoder, rdata_length).map(DNSSECRData::SIG)
             }
-            DNSSECRecordType::TSIG => {
+            RecordType::TSIG => {
                 trace!("reading TSIG");
                 tsig::read(decoder, rdata_length).map(DNSSECRData::TSIG)
             }
-            DNSSECRecordType::Unknown(code) => {
-                trace!("reading unknown dnssec: {}", code);
-                null::read(decoder, rdata_length).map(|rdata| DNSSECRData::Unknown { code, rdata })
+            r => {
+                panic!("not a dnssec RecordType: {}", r);
             }
         }
     }
@@ -688,17 +583,17 @@ impl DNSSECRData {
         }
     }
 
-    pub(crate) fn to_record_type(&self) -> DNSSECRecordType {
+    pub(crate) fn to_record_type(&self) -> RecordType {
         match *self {
-            DNSSECRData::DS(..) => DNSSECRecordType::DS,
-            DNSSECRData::KEY(..) => DNSSECRecordType::KEY,
-            DNSSECRData::DNSKEY(..) => DNSSECRecordType::DNSKEY,
-            DNSSECRData::NSEC(..) => DNSSECRecordType::NSEC,
-            DNSSECRData::NSEC3(..) => DNSSECRecordType::NSEC3,
-            DNSSECRData::NSEC3PARAM(..) => DNSSECRecordType::NSEC3PARAM,
-            DNSSECRData::SIG(..) => DNSSECRecordType::SIG,
-            DNSSECRData::TSIG(..) => DNSSECRecordType::TSIG,
-            DNSSECRData::Unknown { code, .. } => DNSSECRecordType::Unknown(code),
+            DNSSECRData::DS(..) => RecordType::DS,
+            DNSSECRData::KEY(..) => RecordType::KEY,
+            DNSSECRData::DNSKEY(..) => RecordType::DNSKEY,
+            DNSSECRData::NSEC(..) => RecordType::NSEC,
+            DNSSECRData::NSEC3(..) => RecordType::NSEC3,
+            DNSSECRData::NSEC3PARAM(..) => RecordType::NSEC3PARAM,
+            DNSSECRData::SIG(..) => RecordType::SIG,
+            DNSSECRData::TSIG(..) => RecordType::TSIG,
+            DNSSECRData::Unknown { code, .. } => RecordType::Unknown(code),
         }
     }
 }
@@ -720,12 +615,6 @@ impl fmt::Display for DNSSECRData {
             DNSSECRData::TSIG(ref tsig) => w(f, tsig),
             DNSSECRData::Unknown { rdata, .. } => w(f, rdata),
         }
-    }
-}
-
-impl From<DNSSECRecordType> for RecordType {
-    fn from(record_type: DNSSECRecordType) -> RecordType {
-        RecordType::DNSSEC(record_type)
     }
 }
 

--- a/crates/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec.rs
@@ -214,7 +214,6 @@ mod tests {
 
     #[test]
     fn test() {
-        use crate::rr::dnssec::rdata::DNSSECRecordType;
         use crate::rr::RecordType;
         use std::str::FromStr;
 

--- a/crates/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec.rs
@@ -19,7 +19,6 @@ use std::fmt;
 
 use super::nsec3;
 use crate::error::*;
-use crate::rr::dnssec::rdata::DNSSECRecordType;
 use crate::rr::{Name, RecordType};
 use crate::serialize::binary::*;
 
@@ -84,7 +83,7 @@ impl NSEC {
     ///
     /// An NSEC RData for use in a Resource Record
     pub fn new_cover_self(next_domain_name: Name, mut type_bit_maps: Vec<RecordType>) -> NSEC {
-        type_bit_maps.push(RecordType::DNSSEC(DNSSECRecordType::NSEC));
+        type_bit_maps.push(RecordType::NSEC);
 
         Self::new(next_domain_name, type_bit_maps)
     }
@@ -224,8 +223,8 @@ mod tests {
             vec![
                 RecordType::A,
                 RecordType::AAAA,
-                RecordType::DNSSEC(DNSSECRecordType::DS),
-                RecordType::DNSSEC(DNSSECRecordType::RRSIG),
+                RecordType::DS,
+                RecordType::RRSIG,
             ],
         );
 

--- a/crates/proto/src/rr/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3.rs
@@ -563,7 +563,7 @@ mod tests {
 
     #[test]
     fn test() {
-        use crate::rr::dnssec::rdata::DNSSECRecordType;
+        use crate::rr::dnssec::rdata::RecordType;
 
         let rdata = NSEC3::new(
             Nsec3HashAlgorithm::SHA1,
@@ -574,8 +574,8 @@ mod tests {
             vec![
                 RecordType::A,
                 RecordType::AAAA,
-                RecordType::DNSSEC(DNSSECRecordType::DS),
-                RecordType::DNSSEC(DNSSECRecordType::RRSIG),
+                RecordType::DS,
+                RecordType::RRSIG,
             ],
         );
 
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_dups() {
-        use crate::rr::dnssec::rdata::DNSSECRecordType;
+        use crate::rr::dnssec::rdata::RecordType;
 
         let rdata_with_dups = NSEC3::new(
             Nsec3HashAlgorithm::SHA1,
@@ -605,9 +605,9 @@ mod tests {
             vec![
                 RecordType::A,
                 RecordType::AAAA,
-                RecordType::DNSSEC(DNSSECRecordType::DS),
+                RecordType::DS,
                 RecordType::AAAA,
-                RecordType::DNSSEC(DNSSECRecordType::RRSIG),
+                RecordType::RRSIG,
             ],
         );
 
@@ -620,8 +620,8 @@ mod tests {
             vec![
                 RecordType::A,
                 RecordType::AAAA,
-                RecordType::DNSSEC(DNSSECRecordType::DS),
-                RecordType::DNSSEC(DNSSECRecordType::RRSIG),
+                RecordType::DS,
+                RecordType::RRSIG,
             ],
         );
 

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -14,7 +14,7 @@ use crate::rr::rdata::sshfp;
 use crate::error::*;
 use crate::op::{Header, Message, Query};
 use crate::rr::dns_class::DNSClass;
-use crate::rr::dnssec::rdata::{DNSSECRData, DNSSECRecordType};
+use crate::rr::dnssec::rdata::DNSSECRData;
 use crate::rr::record_data::RData;
 use crate::rr::record_type::RecordType;
 use crate::rr::{Name, Record};
@@ -720,10 +720,8 @@ pub fn signed_bitmessage_to_buf(
 
     // parse a tsig record
     let sig = Record::read(&mut decoder)?;
-    let tsig = if let (
-        RecordType::DNSSEC(DNSSECRecordType::TSIG),
-        RData::DNSSEC(DNSSECRData::TSIG(tsig_data)),
-    ) = (sig.rr_type(), sig.rdata())
+    let tsig = if let (RecordType::TSIG, RData::DNSSEC(DNSSECRData::TSIG(tsig_data))) =
+        (sig.rr_type(), sig.rdata())
     {
         tsig_data
     } else {
@@ -766,7 +764,7 @@ pub fn make_tsig_record(name: Name, rdata: TSIG) -> Record {
     //   NAME:  The name of the key used, in domain name syntax
     tsig.set_name(name)
         //   TYPE:  This MUST be TSIG (250: Transaction SIGnature).
-        .set_record_type(DNSSECRecordType::TSIG.into())
+        .set_record_type(RecordType::TSIG.into())
         //   CLASS:  This MUST be ANY.
         .set_dns_class(DNSClass::ANY)
         //   TTL:  This MUST be 0.

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -764,7 +764,7 @@ pub fn make_tsig_record(name: Name, rdata: TSIG) -> Record {
     //   NAME:  The name of the key used, in domain name syntax
     tsig.set_name(name)
         //   TYPE:  This MUST be TSIG (250: Transaction SIGnature).
-        .set_record_type(RecordType::TSIG.into())
+        .set_record_type(RecordType::TSIG)
         //   CLASS:  This MUST be ANY.
         .set_dns_class(DNSClass::ANY)
         //   TTL:  This MUST be 0.

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -860,7 +860,7 @@ mod test {
     #[allow(clippy::blocks_in_if_conditions)]
     fn test_get_filter() {
         use crate::rr::dnssec::rdata::SIG;
-        use crate::rr::dnssec::rdata::{DNSSECRData, DNSSECRecordType};
+        use crate::rr::dnssec::rdata::{DNSSECRData, RecordType};
         use crate::rr::dnssec::{Algorithm, SupportedAlgorithms};
 
         let name = Name::root();
@@ -912,28 +912,28 @@ mod test {
         let rrsig_rsa = Record::new()
             .set_name(name.clone())
             .set_ttl(3600)
-            .set_rr_type(RecordType::DNSSEC(DNSSECRecordType::RRSIG))
+            .set_rr_type(RecordType::RRSIG)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::DNSSEC(DNSSECRData::SIG(rsasha256)))
             .clone();
         let rrsig_ecp256 = Record::new()
             .set_name(name.clone())
             .set_ttl(3600)
-            .set_rr_type(RecordType::DNSSEC(DNSSECRecordType::RRSIG))
+            .set_rr_type(RecordType::RRSIG)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::DNSSEC(DNSSECRData::SIG(ecp256)))
             .clone();
         let rrsig_ecp384 = Record::new()
             .set_name(name.clone())
             .set_ttl(3600)
-            .set_rr_type(RecordType::DNSSEC(DNSSECRecordType::RRSIG))
+            .set_rr_type(RecordType::RRSIG)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::DNSSEC(DNSSECRData::SIG(ecp384)))
             .clone();
         let rrsig_ed25519 = Record::new()
             .set_name(name.clone())
             .set_ttl(3600)
-            .set_rr_type(RecordType::DNSSEC(DNSSECRecordType::RRSIG))
+            .set_rr_type(RecordType::RRSIG)
             .set_dns_class(DNSClass::IN)
             .set_rdata(RData::DNSSEC(DNSSECRData::SIG(ed25519)))
             .clone();

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -859,8 +859,8 @@ mod test {
     #[cfg(feature = "dnssec")] // This tests RFC 6975, a DNSSEC-specific feature.
     #[allow(clippy::blocks_in_if_conditions)]
     fn test_get_filter() {
+        use crate::rr::dnssec::rdata::DNSSECRData;
         use crate::rr::dnssec::rdata::SIG;
-        use crate::rr::dnssec::rdata::{DNSSECRData, RecordType};
         use crate::rr::dnssec::{Algorithm, SupportedAlgorithms};
 
         let name = Name::root();

--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -9,9 +9,10 @@ use std::iter::Chain;
 use std::slice::Iter;
 use std::sync::Arc;
 
-use crate::authority::LookupObject;
+use cfg_if::cfg_if;
+
+use crate::authority::{LookupObject, LookupOptions};
 use crate::client::rr::LowerName;
-use crate::proto::rr::dnssec::SupportedAlgorithms;
 use crate::proto::rr::{Record, RecordSet, RecordType, RrsetRecords};
 
 /// The result of a lookup on an Authority
@@ -185,8 +186,7 @@ impl From<LookupRecords> for AuthLookup {
 /// * `'q` - the lifetime of the query/request
 #[derive(Debug)]
 pub struct AnyRecords {
-    is_secure: bool,
-    supported_algorithms: SupportedAlgorithms,
+    lookup_options: LookupOptions,
     rrsets: Vec<Arc<RecordSet>>,
     rrset: Option<Arc<RecordSet>>,
     records: Option<Arc<RecordSet>>,
@@ -197,16 +197,14 @@ pub struct AnyRecords {
 impl AnyRecords {
     /// construct a new lookup of any set of records
     pub fn new(
-        is_secure: bool,
-        supported_algorithms: SupportedAlgorithms,
+        lookup_options: LookupOptions,
         // TODO: potentially very expensive
         rrsets: Vec<Arc<RecordSet>>,
         query_type: RecordType,
         query_name: LowerName,
     ) -> Self {
         AnyRecords {
-            is_secure,
-            supported_algorithms,
+            lookup_options,
             rrsets,
             rrset: None,
             records: None,
@@ -226,8 +224,7 @@ impl<'r> IntoIterator for &'r AnyRecords {
 
     fn into_iter(self) -> Self::IntoIter {
         AnyRecordsIter {
-            is_secure: self.is_secure,
-            supported_algorithms: self.supported_algorithms,
+            lookup_options: self.lookup_options,
             // TODO: potentially very expensive
             rrsets: self.rrsets.iter(),
             rrset: None,
@@ -239,9 +236,9 @@ impl<'r> IntoIterator for &'r AnyRecords {
 }
 
 /// An iteration over a lookup for any Records
+#[allow(unused)]
 pub struct AnyRecordsIter<'r> {
-    is_secure: bool,
-    supported_algorithms: SupportedAlgorithms,
+    lookup_options: LookupOptions,
     rrsets: Iter<'r, Arc<RecordSet>>,
     rrset: Option<&'r RecordSet>,
     records: Option<RrsetRecords<'r>>,
@@ -281,11 +278,17 @@ impl<'r> Iterator for AnyRecordsIter<'r> {
             self.rrset?;
 
             // getting here, we must have exhausted our records from the rrset
-            self.records = Some(
-                self.rrset
-                    .expect("rrset should not be None at this point")
-                    .records(self.is_secure, self.supported_algorithms),
-            );
+            cfg_if! {
+                if #[cfg(feature = "dnssec")] {
+                    self.records = Some(
+                        self.rrset
+                            .expect("rrset should not be None at this point")
+                            .records(self.lookup_options.is_dnssec(), self.lookup_options.supported_algorithms()),
+                    );
+                } else {
+                    self.records = Some(self.rrset.expect("rrset should not be None at this point").records_without_rrsigs());
+                }
+            }
         }
     }
 }
@@ -297,15 +300,13 @@ pub enum LookupRecords {
     Empty,
     /// The associate records
     Records {
-        /// was the search a secure search
-        is_secure: bool,
-        /// what are the requests supported algorithms
-        supported_algorithms: SupportedAlgorithms,
+        /// LookupOptions for the request, e.g. dnssec and supported algorithms
+        lookup_options: LookupOptions,
         /// the records found based on the query
         records: Arc<RecordSet>,
     },
     /// Vec of disjoint record sets
-    ManyRecords(bool, SupportedAlgorithms, Vec<Arc<RecordSet>>),
+    ManyRecords(LookupOptions, Vec<Arc<RecordSet>>),
     // TODO: need a better option for very large zone xfrs...
     /// A generic lookup response where anything is desired
     AnyRecords(AnyRecords),
@@ -313,27 +314,18 @@ pub enum LookupRecords {
 
 impl LookupRecords {
     /// Construct a new LookupRecords
-    pub fn new(
-        is_secure: bool,
-        supported_algorithms: SupportedAlgorithms,
-        records: Arc<RecordSet>,
-    ) -> Self {
+    pub fn new(lookup_options: LookupOptions, records: Arc<RecordSet>) -> Self {
         LookupRecords::Records {
-            is_secure,
-            supported_algorithms,
+            lookup_options,
             records,
         }
     }
 
     /// Construct a new LookupRecords over a set of ResordSets
-    pub fn many(
-        is_secure: bool,
-        supported_algorithms: SupportedAlgorithms,
-        mut records: Vec<Arc<RecordSet>>,
-    ) -> Self {
+    pub fn many(lookup_options: LookupOptions, mut records: Vec<Arc<RecordSet>>) -> Self {
         // we're reversing the records because they are output in reverse order, via pop()
         records.reverse();
-        LookupRecords::ManyRecords(is_secure, supported_algorithms, records)
+        LookupRecords::ManyRecords(lookup_options, records)
     }
 
     /// This is an NxDomain or NameExists, and has no associated records
@@ -363,17 +355,37 @@ impl<'a> IntoIterator for &'a LookupRecords {
         match self {
             LookupRecords::Empty => LookupRecordsIter::Empty,
             LookupRecords::Records {
-                is_secure,
-                supported_algorithms,
+                lookup_options,
                 records,
-            } => LookupRecordsIter::RecordsIter(records.records(*is_secure, *supported_algorithms)),
-            LookupRecords::ManyRecords(is_secure, supported_algorithms, r) => {
-                LookupRecordsIter::ManyRecordsIter(
-                    r.iter()
-                        .map(|r| r.records(*is_secure, *supported_algorithms))
-                        .collect(),
-                    None,
-                )
+            } => {
+                cfg_if! {
+                    if #[cfg(feature = "dnssec")] {
+                        LookupRecordsIter::RecordsIter(records.records(
+                            lookup_options.is_dnssec(),
+                            lookup_options.supported_algorithms(),
+                        ))
+                    } else {
+                        LookupRecordsIter::RecordsIter(records.records_without_rrsigs())
+                    }
+                }
+            }
+            LookupRecords::ManyRecords(lookup_options, r) => {
+                cfg_if! {
+                    if #[cfg(feature = "dnssec")] {
+                        LookupRecordsIter::ManyRecordsIter(
+                            r.iter().map(|r| r.records(
+                                lookup_options.is_dnssec(),
+                                lookup_options.supported_algorithms(),
+                            )).collect(),
+                            None,
+                        )
+                    } else {
+                        LookupRecordsIter::ManyRecordsIter(
+                            r.iter().map(|r| r.records_without_rrsigs()).collect(),
+                            None,
+                        )
+                    }
+                }
             }
             LookupRecords::AnyRecords(r) => LookupRecordsIter::AnyRecordsIter(r.iter()),
         }

--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -351,6 +351,7 @@ impl<'a> IntoIterator for &'a LookupRecords {
     type Item = &'a Record;
     type IntoIter = LookupRecordsIter<'a>;
 
+    #[allow(unused_variables)]
     fn into_iter(self) -> Self::IntoIter {
         match self {
             LookupRecords::Empty => LookupRecordsIter::Empty,

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -10,11 +10,12 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::client::op::LowerQuery;
-use crate::client::rr::{LowerName, Name, RecordType};
+use crate::client::rr::{LowerName, RecordType};
 #[cfg(feature = "dnssec")]
 use crate::client::{
     proto::rr::dnssec::rdata::key::KEY,
     rr::dnssec::{DnsSecResult, SigSigner, SupportedAlgorithms},
+    rr::Name,
 };
 
 use crate::authority::{LookupError, MessageRequest, UpdateResult, ZoneType};
@@ -54,6 +55,7 @@ impl LookupOptions {
     }
 
     /// Specify that this lookup should return DNSSEC related records as well, e.g. RRSIG
+    #[allow(clippy::needless_update)]
     pub fn set_is_dnssec(self, val: bool) -> Self {
         Self {
             is_dnssec: val,

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -10,11 +10,12 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::client::op::LowerQuery;
-use crate::client::proto::rr::dnssec::rdata::key::KEY;
-#[cfg(feature = "dnssec")]
-use crate::client::rr::dnssec::SupportedAlgorithms;
-use crate::client::rr::dnssec::{DnsSecError, DnsSecResult, SigSigner};
 use crate::client::rr::{LowerName, Name, RecordType};
+#[cfg(feature = "dnssec")]
+use crate::client::{
+    proto::rr::dnssec::rdata::key::KEY,
+    rr::dnssec::{DnsSecResult, SigSigner, SupportedAlgorithms},
+};
 
 use crate::authority::{LookupError, MessageRequest, UpdateResult, ZoneType};
 
@@ -177,25 +178,18 @@ pub trait Authority: Send {
     ) -> Pin<Box<dyn Future<Output = Result<Self::Lookup, LookupError>> + Send>> {
         self.lookup(self.origin(), RecordType::SOA, lookup_options)
     }
+}
 
+/// Extension to Authority to allow for DNSSEC features
+#[cfg(feature = "dnssec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
+pub trait DnssecAuthority: Authority {
     /// Add a (Sig0) key that is authorized to perform updates against this authority
-    fn add_update_auth_key(&mut self, _name: Name, _key: KEY) -> DnsSecResult<()> {
-        Err(DnsSecError::from(
-            "dynamic update not supported by this Authority type",
-        ))
-    }
+    fn add_update_auth_key(&mut self, name: Name, key: KEY) -> DnsSecResult<()>;
 
     /// Add Signer
-    fn add_zone_signing_key(&mut self, _signer: SigSigner) -> DnsSecResult<()> {
-        Err(DnsSecError::from(
-            "zone signing not supported by this Authority type",
-        ))
-    }
+    fn add_zone_signing_key(&mut self, signer: SigSigner) -> DnsSecResult<()>;
 
     /// Sign the zone for DNSSEC
-    fn secure_zone(&mut self) -> DnsSecResult<()> {
-        Err(DnsSecError::from(
-            "zone signing not supported by this Authority type",
-        ))
-    }
+    fn secure_zone(&mut self) -> DnsSecResult<()>;
 }

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -25,10 +25,8 @@ use crate::authority::{
 };
 use crate::client::op::{Edns, Header, LowerQuery, MessageType, OpCode, ResponseCode};
 #[cfg(feature = "dnssec")]
-use crate::client::rr::{
-    dnssec::{Algorithm, SupportedAlgorithms},
-    rdata::opt::{EdnsCode, EdnsOption},
-};
+use crate::client::rr::dnssec::{Algorithm, SupportedAlgorithms};
+use crate::client::rr::rdata::opt::{EdnsCode, EdnsOption};
 use crate::client::rr::{LowerName, RecordType};
 use crate::server::{Request, RequestHandler, ResponseHandler};
 
@@ -38,6 +36,7 @@ pub struct Catalog {
     authorities: HashMap<LowerName, Box<dyn AuthorityObject>>,
 }
 
+#[allow(unused_mut)]
 fn send_response<R: ResponseHandler>(
     response_edns: Option<Edns>,
     mut response: MessageResponse<'_, '_>,

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -25,8 +25,10 @@ use crate::authority::{
 };
 use crate::client::op::{Edns, Header, LowerQuery, MessageType, OpCode, ResponseCode};
 #[cfg(feature = "dnssec")]
-use crate::client::rr::dnssec::{Algorithm, SupportedAlgorithms};
-use crate::client::rr::rdata::opt::{EdnsCode, EdnsOption};
+use crate::client::rr::{
+    dnssec::{Algorithm, SupportedAlgorithms},
+    rdata::opt::{EdnsCode, EdnsOption},
+};
 use crate::client::rr::{LowerName, RecordType};
 use crate::server::{Request, RequestHandler, ResponseHandler};
 
@@ -36,7 +38,7 @@ pub struct Catalog {
     authorities: HashMap<LowerName, Box<dyn AuthorityObject>>,
 }
 
-#[allow(unused_mut)]
+#[allow(unused_mut, unused_variables)]
 fn send_response<R: ResponseHandler>(
     response_edns: Option<Edns>,
     mut response: MessageResponse<'_, '_>,
@@ -424,6 +426,7 @@ async fn lookup<R: ResponseHandler + Unpin>(
     }
 }
 
+#[allow(unused_variables)]
 fn lookup_options_for_edns(edns: Option<&Edns>) -> LookupOptions {
     let edns = match edns {
         Some(edns) => edns,

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -32,3 +32,7 @@ pub use self::error::{LookupError, LookupResult};
 pub use self::message_request::{MessageRequest, Queries, UpdateRequest};
 pub use self::message_response::{MessageResponse, MessageResponseBuilder};
 pub use self::zone_type::ZoneType;
+
+#[cfg(feature = "dnssec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
+pub use self::authority::DnssecAuthority;

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -25,7 +25,7 @@ mod zone_type;
 pub use self::auth_lookup::{
     AnyRecords, AuthLookup, AuthLookupIter, LookupRecords, LookupRecordsIter,
 };
-pub use self::authority::Authority;
+pub use self::authority::{Authority, LookupOptions};
 pub use self::authority_object::{AuthorityObject, BoxedLookupFuture, EmptyLookup, LookupObject};
 pub use self::catalog::Catalog;
 pub use self::error::{LookupError, LookupResult};

--- a/crates/server/src/config/dnssec.rs
+++ b/crates/server/src/config/dnssec.rs
@@ -16,12 +16,12 @@ use rustls::{Certificate, PrivateKey};
 use serde::Deserialize;
 
 use crate::client::error::ParseResult;
-use crate::client::rr::dnssec::Algorithm;
-#[cfg(any(feature = "dns-over-tls", feature = "dnssec"))]
-use crate::client::rr::dnssec::{KeyFormat, KeyPair, Private, SigSigner};
-#[cfg(feature = "dnssec")]
-use crate::client::rr::domain::IntoName;
 use crate::client::rr::domain::Name;
+#[cfg(feature = "dnssec")]
+use crate::client::rr::{
+    dnssec::{Algorithm, KeyFormat, KeyPair, Private, SigSigner},
+    domain::IntoName,
+};
 
 /// Key pair configuration for DNSSec keys for signing a zone
 #[derive(Deserialize, PartialEq, Debug)]
@@ -51,6 +51,8 @@ impl KeyConfig {
     /// * `signer_name` - the name to use when signing records, e.g. ns.example.com
     /// * `is_zone_signing_key` - specify that this key should be used for signing a zone
     /// * `is_zone_update_auth` - specifies that this key can be used for dynamic updates in the zone
+    #[cfg(feature = "dnssec")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
     pub fn new(
         key_path: String,
         password: Option<String>,
@@ -107,6 +109,8 @@ impl KeyConfig {
     }
 
     /// algorithm for for the key, see `Algorithm` for supported algorithms.
+    #[cfg(feature = "dnssec")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
     pub fn algorithm(&self) -> ParseResult<Algorithm> {
         match self.algorithm.as_str() {
             "RSASHA1" => Ok(Algorithm::RSASHA1),

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
 
+use cfg_if::cfg_if;
 use log;
 use serde::{self, Deserialize};
 use toml;
@@ -139,7 +140,13 @@ impl Config {
 
     /// the tls certificate to use for accepting tls connections
     pub fn get_tls_cert(&self) -> Option<&dnssec::TlsCertConfig> {
-        self.tls_cert.as_ref()
+        cfg_if! {
+            if #[cfg(feature = "dnssec")] {
+                self.tls_cert.as_ref()
+            } else {
+                None
+            }
+        }
     }
 }
 
@@ -239,10 +246,18 @@ impl ZoneConfig {
 
     /// declare that this zone should be signed, see keys for configuration of the keys for signing
     pub fn is_dnssec_enabled(&self) -> bool {
-        self.enable_dnssec.unwrap_or(false)
+        cfg_if! {
+            if #[cfg(feature = "dnssec")] {
+                self.enable_dnssec.unwrap_or(false)
+            } else {
+                false
+            }
+        }
     }
 
     /// the configuration for the keys used for auth and/or dnssec zone signing.
+    #[cfg(feature = "dnssec")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
     pub fn get_keys(&self) -> &[dnssec::KeyConfig] {
         &self.keys
     }

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -17,10 +17,12 @@ use std::pin::Pin;
 
 use log::{debug, info};
 
-use crate::authority::{Authority, LookupError, MessageRequest, UpdateResult, ZoneType};
+use crate::authority::{
+    Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType,
+};
 use crate::client::op::LowerQuery;
 use crate::client::proto::rr::dnssec::rdata::key::KEY;
-use crate::client::rr::dnssec::{DnsSecResult, SigSigner, SupportedAlgorithms};
+use crate::client::rr::dnssec::{DnsSecResult, SigSigner};
 use crate::client::rr::{LowerName, Name, RecordSet, RecordType, RrKey};
 use crate::client::serialize::txt::{Lexer, Parser, Token};
 use crate::store::file::FileConfig;
@@ -268,10 +270,9 @@ impl Authority for FileAuthority {
         &self,
         name: &LowerName,
         rtype: RecordType,
-        is_secure: bool,
-        supported_algorithms: SupportedAlgorithms,
+        lookup_options: LookupOptions,
     ) -> Pin<Box<dyn Future<Output = Result<Self::Lookup, LookupError>> + Send>> {
-        Box::pin(self.0.lookup(name, rtype, is_secure, supported_algorithms))
+        Box::pin(self.0.lookup(name, rtype, lookup_options))
     }
 
     /// Using the specified query, perform a lookup against this zone.
@@ -288,19 +289,17 @@ impl Authority for FileAuthority {
     fn search(
         &self,
         query: &LowerQuery,
-        is_secure: bool,
-        supported_algorithms: SupportedAlgorithms,
+        lookup_options: LookupOptions,
     ) -> Pin<Box<dyn Future<Output = Result<Self::Lookup, LookupError>> + Send>> {
-        Box::pin(self.0.search(query, is_secure, supported_algorithms))
+        Box::pin(self.0.search(query, lookup_options))
     }
 
     /// Get the NS, NameServer, record for the zone
     fn ns(
         &self,
-        is_secure: bool,
-        supported_algorithms: SupportedAlgorithms,
+        lookup_options: LookupOptions,
     ) -> Pin<Box<dyn Future<Output = Result<Self::Lookup, LookupError>> + Send>> {
-        self.0.ns(is_secure, supported_algorithms)
+        self.0.ns(lookup_options)
     }
 
     /// Return the NSEC records based on the given name
@@ -313,11 +312,9 @@ impl Authority for FileAuthority {
     fn get_nsec_records(
         &self,
         name: &LowerName,
-        is_secure: bool,
-        supported_algorithms: SupportedAlgorithms,
+        lookup_options: LookupOptions,
     ) -> Pin<Box<dyn Future<Output = Result<Self::Lookup, LookupError>> + Send>> {
-        self.0
-            .get_nsec_records(name, is_secure, supported_algorithms)
+        self.0.get_nsec_records(name, lookup_options)
     }
 
     /// Returns the SOA of the authority.
@@ -331,10 +328,9 @@ impl Authority for FileAuthority {
     /// Returns the SOA record for the zone
     fn soa_secure(
         &self,
-        is_secure: bool,
-        supported_algorithms: SupportedAlgorithms,
+        lookup_options: LookupOptions,
     ) -> Pin<Box<dyn Future<Output = Result<Self::Lookup, LookupError>> + Send>> {
-        self.0.soa_secure(is_secure, supported_algorithms)
+        self.0.soa_secure(lookup_options)
     }
 
     /// Add a (Sig0) key that is authorized to perform updates against this authority
@@ -382,8 +378,7 @@ mod tests {
             &authority,
             &LowerName::from_str("www.example.com.").unwrap(),
             RecordType::A,
-            false,
-            SupportedAlgorithms::new(),
+            LookupOptions::default(),
         ))
         .expect("lookup failed");
 
@@ -401,8 +396,7 @@ mod tests {
             &authority,
             &LowerName::from_str("include.alias.example.com.").unwrap(),
             RecordType::A,
-            false,
-            SupportedAlgorithms::new(),
+            LookupOptions::default(),
         ))
         .expect("INCLUDE lookup failed");
 

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -15,26 +15,28 @@ use std::sync::Arc;
 
 use log::{error, info, warn};
 
-use crate::client::op::LowerQuery;
-use crate::client::rr::dnssec::{DnsSecResult, SigSigner};
-use crate::client::rr::{LowerName, RrKey};
-use crate::proto::op::ResponseCode;
-use crate::proto::rr::dnssec::rdata::key::KEY;
-use crate::proto::rr::{DNSClass, Name, RData, Record, RecordSet, RecordType};
-
 use crate::authority::{
     Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType,
 };
-#[cfg(feature = "dnssec")]
-use crate::authority::{DnssecAuthority, UpdateRequest};
+use crate::client::op::LowerQuery;
+use crate::client::rr::{LowerName, RrKey};
 use crate::error::{PersistenceErrorKind, PersistenceResult};
+use crate::proto::op::ResponseCode;
+use crate::proto::rr::{DNSClass, Name, RData, Record, RecordSet, RecordType};
 use crate::store::in_memory::InMemoryAuthority;
 use crate::store::sqlite::{Journal, SqliteConfig};
+#[cfg(feature = "dnssec")]
+use crate::{
+    authority::{DnssecAuthority, UpdateRequest},
+    client::rr::dnssec::{DnsSecResult, SigSigner},
+    proto::rr::dnssec::rdata::key::KEY,
+};
 
 /// SqliteAuthority is responsible for storing the resource records for a particular zone.
 ///
 /// Authorities default to DNSClass IN. The ZoneType specifies if this should be treated as the
 /// start of authority for the zone, is a Secondary, or a cached zone.
+#[allow(dead_code)]
 pub struct SqliteAuthority {
     in_memory: InMemoryAuthority,
     journal: Option<Journal>,

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -445,7 +445,7 @@ impl SqliteAuthority {
         use futures_executor::block_on;
         use log::debug;
 
-        use crate::client::rr::rdata::{DNSSECRData, DNSSECRecordType};
+        use crate::client::rr::rdata::{DNSSECRData, RecordType};
         use crate::proto::rr::dnssec::Verifier;
 
         // 3.3.3 - Pseudocode for Permission Checking
@@ -484,7 +484,7 @@ impl SqliteAuthority {
                     // TODO: updates should be async as well.
                     let keys = block_on(self.lookup(
                         &name,
-                        RecordType::DNSSEC(DNSSECRecordType::KEY),
+                        RecordType::KEY,
                         false,
                         SupportedAlgorithms::new(),
                     ));

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -445,7 +445,7 @@ impl SqliteAuthority {
         use futures_executor::block_on;
         use log::debug;
 
-        use crate::client::rr::rdata::{DNSSECRData, RecordType};
+        use crate::client::rr::rdata::DNSSECRData;
         use crate::proto::rr::dnssec::Verifier;
 
         // 3.3.3 - Pseudocode for Permission Checking

--- a/crates/server/tests/authority_battery/basic.rs
+++ b/crates/server/tests/authority_battery/basic.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 use futures_executor::block_on;
 
 use trust_dns_client::op::{Message, Query, ResponseCode};
-use trust_dns_client::rr::dnssec::SupportedAlgorithms;
 use trust_dns_client::rr::{Name, RData, Record, RecordType};
 use trust_dns_server::authority::{
     AuthLookup, Authority, LookupError, LookupOptions, MessageRequest,

--- a/crates/server/tests/authority_battery/basic.rs
+++ b/crates/server/tests/authority_battery/basic.rs
@@ -9,13 +9,14 @@ use futures_executor::block_on;
 use trust_dns_client::op::{Message, Query, ResponseCode};
 use trust_dns_client::rr::dnssec::SupportedAlgorithms;
 use trust_dns_client::rr::{Name, RData, Record, RecordType};
-use trust_dns_server::authority::{AuthLookup, Authority, LookupError, MessageRequest};
+use trust_dns_server::authority::{
+    AuthLookup, Authority, LookupError, LookupOptions, MessageRequest,
+};
 
 pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
 
-    let lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     match lookup
         .into_iter()
@@ -52,7 +53,7 @@ pub fn test_soa<A: Authority<Lookup = AuthLookup>>(authority: A) {
 }
 
 pub fn test_ns<A: Authority<Lookup = AuthLookup>>(authority: A) {
-    let lookup = block_on(authority.ns(false, SupportedAlgorithms::new())).unwrap();
+    let lookup = block_on(authority.ns(LookupOptions::default())).unwrap();
 
     match lookup
         .into_iter()
@@ -68,8 +69,7 @@ pub fn test_ns<A: Authority<Lookup = AuthLookup>>(authority: A) {
 pub fn test_ns_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let query = Query::query(Name::from_str("example.com.").unwrap(), RecordType::NS);
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let additionals = dbg!(lookup
         .take_additionals()
@@ -98,8 +98,7 @@ pub fn test_ns_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
 pub fn test_mx<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let query = Query::query(Name::from_str("example.com.").unwrap(), RecordType::MX);
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let additionals = dbg!(lookup
         .take_additionals()
@@ -152,8 +151,7 @@ pub fn test_mx_to_null<A: Authority<Lookup = AuthLookup>>(authority: A) {
         RecordType::MX,
     );
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     // In this case there should be no additional records
     assert!(lookup.take_additionals().is_none());
@@ -175,8 +173,7 @@ pub fn test_cname<A: Authority<Lookup = AuthLookup>>(authority: A) {
         RecordType::CNAME,
     );
 
-    let lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let cname = lookup
         .into_iter()
@@ -192,8 +189,7 @@ pub fn test_cname<A: Authority<Lookup = AuthLookup>>(authority: A) {
 pub fn test_cname_alias<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let query = Query::query(Name::from_str("alias.example.com.").unwrap(), RecordType::A);
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let additionals = lookup
         .take_additionals()
@@ -227,8 +223,7 @@ pub fn test_cname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         RecordType::A,
     );
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let additionals = lookup
         .take_additionals()
@@ -270,8 +265,7 @@ pub fn test_cname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
 pub fn test_aname<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let query = Query::query(Name::from_str("example.com.").unwrap(), RecordType::ANAME);
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let additionals = lookup
         .take_additionals()
@@ -311,8 +305,7 @@ pub fn test_aname<A: Authority<Lookup = AuthLookup>>(authority: A) {
 pub fn test_aname_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let query = Query::query(Name::from_str("example.com.").unwrap(), RecordType::A);
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let additionals = lookup.take_additionals().expect("no additionals for aname");
 
@@ -348,8 +341,7 @@ pub fn test_aname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         RecordType::A,
     );
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let additionals = lookup.take_additionals().expect("no additionals");
 
@@ -408,8 +400,7 @@ pub fn test_dots_in_name<A: Authority<Lookup = AuthLookup>>(authority: A) {
         Name::from_str("this.has.dots.example.com.").unwrap(),
         RecordType::A,
     );
-    let lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     assert_eq!(
         *lookup
@@ -427,15 +418,13 @@ pub fn test_dots_in_name<A: Authority<Lookup = AuthLookup>>(authority: A) {
         Name::from_str("has.dots.example.com.").unwrap(),
         RecordType::A,
     );
-    let lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap_err();
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap_err();
 
     assert!(lookup.is_name_exists(), "lookup: {}", lookup);
 
     // the rest should all be NameExists
     let query = Query::query(Name::from_str("dots.example.com.").unwrap(), RecordType::A);
-    let lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap_err();
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap_err();
 
     assert!(lookup.is_name_exists());
 
@@ -444,8 +433,7 @@ pub fn test_dots_in_name<A: Authority<Lookup = AuthLookup>>(authority: A) {
         Name::from_str("not.this.has.dots.example.com.").unwrap(),
         RecordType::A,
     );
-    let lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap_err();
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap_err();
 
     assert!(lookup.is_nx_domain());
 }
@@ -456,8 +444,7 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A) {
         Name::from_str("*.wildcard.example.com.").unwrap(),
         RecordType::CNAME,
     );
-    let lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     assert_eq!(
         *lookup
@@ -475,7 +462,7 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A) {
         Name::from_str("www.wildcard.example.com.").unwrap(),
         RecordType::CNAME,
     );
-    let lookup = block_on(authority.search(&query.into(), false, SupportedAlgorithms::new()))
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default()))
         .expect("lookup of www.wildcard.example.com. failed");
 
     assert_eq!(
@@ -503,7 +490,7 @@ pub fn test_wildcard_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         Name::from_str("www.wildcard.example.com.").unwrap(),
         RecordType::A,
     );
-    let mut lookup = block_on(authority.search(&query.into(), false, SupportedAlgorithms::new()))
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default()))
         .expect("lookup of www.wildcard.example.com. failed");
 
     // the name should match the lookup, not the A records
@@ -536,8 +523,7 @@ pub fn test_srv<A: Authority<Lookup = AuthLookup>>(authority: A) {
         RecordType::SRV,
     );
 
-    let mut lookup =
-        block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+    let mut lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
     let additionals = dbg!(lookup
         .take_additionals()
@@ -584,7 +570,7 @@ pub fn test_srv<A: Authority<Lookup = AuthLookup>>(authority: A) {
 pub fn test_invalid_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let query = Query::query(Name::from_str("www.google.com.").unwrap(), RecordType::A);
 
-    let lookup = block_on(authority.search(&query.into(), false, SupportedAlgorithms::new()));
+    let lookup = block_on(authority.search(&query.into(), LookupOptions::default()));
 
     let err = lookup.expect_err("Lookup for www.google.com succeeded");
     match err {

--- a/crates/server/tests/authority_battery/dnssec.rs
+++ b/crates/server/tests/authority_battery/dnssec.rs
@@ -10,13 +10,16 @@ use trust_dns_client::rr::dnssec::{Algorithm, SupportedAlgorithms, Verifier};
 use trust_dns_client::rr::{DNSClass, Name, Record, RecordType};
 use trust_dns_proto::rr::dnssec::rdata::DNSKEY;
 use trust_dns_proto::xfer;
-use trust_dns_server::authority::{AuthLookup, Authority};
+use trust_dns_server::authority::{AuthLookup, Authority, LookupOptions};
 
 pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
     let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
 
-    let lookup =
-        block_on(authority.search(&query.into(), true, SupportedAlgorithms::new())).unwrap();
+    let lookup = block_on(authority.search(
+        &query.into(),
+        LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
+    ))
+    .unwrap();
 
     let (a_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -33,7 +36,9 @@ pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
 
 #[allow(clippy::unreadable_literal)]
 pub fn test_soa<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
-    let lookup = block_on(authority.soa_secure(true, SupportedAlgorithms::new())).unwrap();
+    let lookup =
+        block_on(authority.soa_secure(LookupOptions::for_dnssec(true, SupportedAlgorithms::new())))
+            .unwrap();
 
     let (soa_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -61,7 +66,9 @@ pub fn test_soa<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]
 }
 
 pub fn test_ns<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
-    let lookup = block_on(authority.ns(true, SupportedAlgorithms::new())).unwrap();
+    let lookup =
+        block_on(authority.ns(LookupOptions::for_dnssec(true, SupportedAlgorithms::new())))
+            .unwrap();
 
     let (ns_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -87,8 +94,11 @@ pub fn test_aname_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: 
         RecordType::A,
     );
 
-    let lookup =
-        block_on(authority.search(&query.into(), true, SupportedAlgorithms::new())).unwrap();
+    let lookup = block_on(authority.search(
+        &query.into(),
+        LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
+    ))
+    .unwrap();
 
     let (a_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -109,8 +119,11 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
         Name::from_str("www.wildcard.example.com.").unwrap(),
         RecordType::CNAME,
     );
-    let lookup = block_on(authority.search(&query.into(), true, SupportedAlgorithms::new()))
-        .expect("lookup of www.wildcard.example.com. failed");
+    let lookup = block_on(authority.search(
+        &query.into(),
+        LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
+    ))
+    .expect("lookup of www.wildcard.example.com. failed");
 
     let (cname_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -134,8 +147,7 @@ pub fn test_nsec_nodata<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &
     let name = Name::from_str("www.example.com.").unwrap();
     let lookup = block_on(authority.get_nsec_records(
         &name.clone().into(),
-        true,
-        SupportedAlgorithms::all(),
+        LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
     ))
     .unwrap();
 
@@ -165,8 +177,7 @@ pub fn test_nsec_nxdomain_start<A: Authority<Lookup = AuthLookup>>(authority: A,
     let name = Name::from_str("aaa.example.com.").unwrap();
     let lookup = block_on(authority.get_nsec_records(
         &name.clone().into(),
-        true,
-        SupportedAlgorithms::all(),
+        LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
     ))
     .unwrap();
 
@@ -198,8 +209,7 @@ pub fn test_nsec_nxdomain_middle<A: Authority<Lookup = AuthLookup>>(authority: A
     let name = Name::from_str("ccc.example.com.").unwrap();
     let lookup = block_on(authority.get_nsec_records(
         &name.clone().into(),
-        true,
-        SupportedAlgorithms::all(),
+        LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
     ))
     .unwrap();
 
@@ -233,8 +243,7 @@ pub fn test_nsec_nxdomain_wraps_end<A: Authority<Lookup = AuthLookup>>(
     let name = Name::from_str("zzz.example.com.").unwrap();
     let lookup = block_on(authority.get_nsec_records(
         &name.clone().into(),
-        true,
-        SupportedAlgorithms::all(),
+        LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
     ))
     .unwrap();
 
@@ -272,8 +281,7 @@ pub fn test_rfc_6975_supported_algorithms<A: Authority<Lookup = AuthLookup>>(
 
         let lookup = block_on(authority.search(
             &query.into(),
-            true,
-            SupportedAlgorithms::from(key.algorithm()),
+            LookupOptions::for_dnssec(true, SupportedAlgorithms::from(key.algorithm())),
         ))
         .unwrap();
 

--- a/crates/server/tests/authority_battery/dnssec.rs
+++ b/crates/server/tests/authority_battery/dnssec.rs
@@ -10,7 +10,7 @@ use trust_dns_client::rr::dnssec::{Algorithm, SupportedAlgorithms, Verifier};
 use trust_dns_client::rr::{DNSClass, Name, Record, RecordType};
 use trust_dns_proto::rr::dnssec::rdata::DNSKEY;
 use trust_dns_proto::xfer;
-use trust_dns_server::authority::{AuthLookup, Authority, LookupOptions};
+use trust_dns_server::authority::{AuthLookup, Authority, DnssecAuthority, LookupOptions};
 
 pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
     let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
@@ -328,7 +328,7 @@ pub fn verify(records: &[Record], rrsig_records: &[Record], keys: &[DNSKEY]) {
             .is_ok())));
 }
 
-pub fn add_signers<A: Authority<Lookup = AuthLookup>>(authority: &mut A) -> Vec<DNSKEY> {
+pub fn add_signers<A: DnssecAuthority>(authority: &mut A) -> Vec<DNSKEY> {
     use trust_dns_server::config::dnssec::*;
     let signer_name = Name::from(authority.origin().to_owned());
 

--- a/crates/server/tests/authority_battery/dnssec.rs
+++ b/crates/server/tests/authority_battery/dnssec.rs
@@ -8,7 +8,7 @@ use futures_executor::block_on;
 use trust_dns_client::op::Query;
 use trust_dns_client::rr::dnssec::{Algorithm, SupportedAlgorithms, Verifier};
 use trust_dns_client::rr::{DNSClass, Name, Record, RecordType};
-use trust_dns_proto::rr::dnssec::rdata::{DNSSECRecordType, DNSKEY};
+use trust_dns_proto::rr::dnssec::rdata::{RecordType, DNSKEY};
 use trust_dns_proto::xfer;
 use trust_dns_server::authority::{AuthLookup, Authority};
 
@@ -25,7 +25,7 @@ pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
 
     let (rrsig_records, _other_records): (Vec<_>, Vec<_>) = other_records
         .into_iter()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::RRSIG));
+        .partition(|r| r.record_type() == RecordType::RRSIG);
 
     assert!(!rrsig_records.is_empty());
     verify(&a_records, &rrsig_records, keys);
@@ -54,7 +54,7 @@ pub fn test_soa<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]
 
     let (rrsig_records, _other_records): (Vec<_>, Vec<_>) = other_records
         .into_iter()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::RRSIG));
+        .partition(|r| r.record_type() == RecordType::RRSIG);
 
     assert!(!rrsig_records.is_empty());
     verify(&soa_records, &rrsig_records, keys);
@@ -75,7 +75,7 @@ pub fn test_ns<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY])
 
     let (rrsig_records, _other_records): (Vec<_>, Vec<_>) = other_records
         .into_iter()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::RRSIG));
+        .partition(|r| r.record_type() == RecordType::RRSIG);
 
     assert!(!rrsig_records.is_empty());
     verify(&ns_records, &rrsig_records, keys);
@@ -97,7 +97,7 @@ pub fn test_aname_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: 
 
     let (rrsig_records, _other_records): (Vec<_>, Vec<_>) = other_records
         .into_iter()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::RRSIG));
+        .partition(|r| r.record_type() == RecordType::RRSIG);
 
     assert!(!rrsig_records.is_empty());
     verify(&a_records, &rrsig_records, keys);
@@ -123,7 +123,7 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
 
     let (rrsig_records, _other_records): (Vec<_>, Vec<_>) = other_records
         .into_iter()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::RRSIG));
+        .partition(|r| r.record_type() == RecordType::RRSIG);
 
     assert!(!rrsig_records.is_empty());
     verify(&cname_records, &rrsig_records, keys);
@@ -142,7 +142,7 @@ pub fn test_nsec_nodata<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &
     let (nsec_records, _other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
         .cloned()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::NSEC));
+        .partition(|r| r.record_type() == RecordType::NSEC);
 
     println!("nsec_records: {:?}", nsec_records);
 
@@ -173,7 +173,7 @@ pub fn test_nsec_nxdomain_start<A: Authority<Lookup = AuthLookup>>(authority: A,
     let (nsec_records, _other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
         .cloned()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::NSEC));
+        .partition(|r| r.record_type() == RecordType::NSEC);
 
     println!("nsec_records: {:?}", nsec_records);
 
@@ -206,7 +206,7 @@ pub fn test_nsec_nxdomain_middle<A: Authority<Lookup = AuthLookup>>(authority: A
     let (nsec_records, _other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
         .cloned()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::NSEC));
+        .partition(|r| r.record_type() == RecordType::NSEC);
 
     println!("nsec_records: {:?}", nsec_records);
 
@@ -241,7 +241,7 @@ pub fn test_nsec_nxdomain_wraps_end<A: Authority<Lookup = AuthLookup>>(
     let (nsec_records, _other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
         .cloned()
-        .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::NSEC));
+        .partition(|r| r.record_type() == RecordType::NSEC);
 
     println!("nsec_records: {:?}", nsec_records);
 
@@ -284,7 +284,7 @@ pub fn test_rfc_6975_supported_algorithms<A: Authority<Lookup = AuthLookup>>(
 
         let (rrsig_records, _other_records): (Vec<_>, Vec<_>) = other_records
             .into_iter()
-            .partition(|r| r.record_type() == RecordType::DNSSEC(DNSSECRecordType::RRSIG));
+            .partition(|r| r.record_type() == RecordType::RRSIG);
 
         assert!(!rrsig_records.is_empty());
         verify(&a_records, &rrsig_records, &[key.clone()]);

--- a/crates/server/tests/authority_battery/dnssec.rs
+++ b/crates/server/tests/authority_battery/dnssec.rs
@@ -8,7 +8,7 @@ use futures_executor::block_on;
 use trust_dns_client::op::Query;
 use trust_dns_client::rr::dnssec::{Algorithm, SupportedAlgorithms, Verifier};
 use trust_dns_client::rr::{DNSClass, Name, Record, RecordType};
-use trust_dns_proto::rr::dnssec::rdata::{RecordType, DNSKEY};
+use trust_dns_proto::rr::dnssec::rdata::DNSKEY;
 use trust_dns_proto::xfer;
 use trust_dns_server::authority::{AuthLookup, Authority};
 

--- a/crates/server/tests/authority_battery/dynamic_update.rs
+++ b/crates/server/tests/authority_battery/dynamic_update.rs
@@ -12,7 +12,8 @@ use trust_dns_client::proto::rr::{DNSClass, Name, RData, Record, RecordSet, Reco
 use trust_dns_client::rr::dnssec::{Algorithm, SigSigner, SupportedAlgorithms, Verifier};
 use trust_dns_client::serialize::binary::{BinDecodable, BinEncodable, BinSerializable};
 use trust_dns_server::authority::{
-    AuthLookup, Authority, LookupError, LookupOptions, MessageRequest, UpdateResult,
+    AuthLookup, Authority, DnssecAuthority, LookupError, LookupOptions, MessageRequest,
+    UpdateResult,
 };
 
 fn update_authority<A: Authority<Lookup = AuthLookup>>(
@@ -654,7 +655,7 @@ pub fn test_delete_all<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys
     }
 }
 
-pub fn add_auth<A: Authority<Lookup = AuthLookup>>(authority: &mut A) -> Vec<SigSigner> {
+pub fn add_auth<A: DnssecAuthority>(authority: &mut A) -> Vec<SigSigner> {
     use trust_dns_client::rr::rdata::key::KeyUsage;
     use trust_dns_server::config::dnssec::*;
 

--- a/crates/server/tests/authority_battery/dynamic_update.rs
+++ b/crates/server/tests/authority_battery/dynamic_update.rs
@@ -12,7 +12,7 @@ use trust_dns_client::proto::rr::{DNSClass, Name, RData, Record, RecordSet, Reco
 use trust_dns_client::rr::dnssec::{Algorithm, SigSigner, SupportedAlgorithms, Verifier};
 use trust_dns_client::serialize::binary::{BinDecodable, BinEncodable, BinSerializable};
 use trust_dns_server::authority::{
-    AuthLookup, Authority, LookupError, MessageRequest, UpdateResult,
+    AuthLookup, Authority, LookupError, LookupOptions, MessageRequest, UpdateResult,
 };
 
 fn update_authority<A: Authority<Lookup = AuthLookup>>(
@@ -44,8 +44,7 @@ pub fn test_create<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
         assert!(update_authority(message, key, &mut authority).expect("create failed"));
 
         let query = Query::query(name, RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         match lookup
             .into_iter()
@@ -92,8 +91,7 @@ pub fn test_create_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
         assert!(update_authority(message, key, &mut authority).expect("create failed"));
 
         let query = Query::query(name, RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert!(lookup.iter().any(|rr| *rr == record));
         assert!(lookup.iter().any(|rr| *rr == record2));
@@ -142,8 +140,7 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
 
         // verify record contents
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 1);
         assert!(lookup.iter().any(|rr| *rr == record));
@@ -161,8 +158,7 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
         assert!(update_authority(message, key, &mut authority).expect("append failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
 
@@ -179,8 +175,7 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
         assert!(!update_authority(message, key, &mut authority).expect("append failed"));
 
         let query = Query::query(name, RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
 
@@ -229,8 +224,7 @@ pub fn test_append_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
         assert!(update_authority(message, key, &mut authority).expect("append failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 3);
 
@@ -249,8 +243,7 @@ pub fn test_append_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
         assert!(!update_authority(message, key, &mut authority).expect("append failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 3);
 
@@ -297,8 +290,7 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
         assert!(update_authority(message, key, &mut authority).expect("compare_and_swap failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 1);
         assert!(lookup.iter().any(|rr| *rr == new));
@@ -321,8 +313,7 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
         );
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 1);
         assert!(lookup.iter().any(|rr| *rr == new));
@@ -378,8 +369,7 @@ pub fn test_compare_and_swap_multi<A: Authority<Lookup = AuthLookup>>(
         assert!(update_authority(message, key, &mut authority).expect("compare_and_swap failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
         assert!(lookup.iter().any(|rr| *rr == new1));
@@ -404,8 +394,7 @@ pub fn test_compare_and_swap_multi<A: Authority<Lookup = AuthLookup>>(
         );
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
         assert!(lookup.iter().any(|rr| *rr == new1));
@@ -463,8 +452,7 @@ pub fn test_delete_by_rdata<A: Authority<Lookup = AuthLookup>>(
         assert!(update_authority(message, key, &mut authority).expect("delete_by_rdata failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 1);
         assert!(lookup.iter().any(|rr| *rr == record1));
@@ -536,8 +524,7 @@ pub fn test_delete_by_rdata_multi<A: Authority<Lookup = AuthLookup>>(
         assert!(update_authority(message, key, &mut authority).expect("delete_by_rdata failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup =
-            block_on(authority.search(&query.into(), false, SupportedAlgorithms::new())).unwrap();
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default())).unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
         assert!(!lookup.iter().any(|rr| *rr == record1));
@@ -594,7 +581,7 @@ pub fn test_delete_rrset<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
         assert!(update_authority(message, key, &mut authority).expect("delete_rrset failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup = block_on(authority.search(&query.into(), false, SupportedAlgorithms::new()));
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default()));
 
         assert_eq!(
             *lookup.unwrap_err().as_response_code().unwrap(),
@@ -652,14 +639,14 @@ pub fn test_delete_all<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys
         assert!(update_authority(message, key, &mut authority).expect("delete_all failed"));
 
         let query = Query::query(name.clone(), RecordType::A);
-        let lookup = block_on(authority.search(&query.into(), false, SupportedAlgorithms::new()));
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default()));
         assert_eq!(
             *lookup.unwrap_err().as_response_code().unwrap(),
             ResponseCode::NXDomain
         );
 
         let query = Query::query(name.clone(), RecordType::AAAA);
-        let lookup = block_on(authority.search(&query.into(), false, SupportedAlgorithms::new()));
+        let lookup = block_on(authority.search(&query.into(), LookupOptions::default()));
         assert_eq!(
             *lookup.unwrap_err().as_response_code().unwrap(),
             ResponseCode::NXDomain

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -24,7 +24,6 @@ fn test_lookup() {
         .block_on(forwarder.lookup(
             &Name::from_str("www.example.com.").unwrap().into(),
             RecordType::A,
-            false,
             Default::default(),
         ))
         .unwrap();

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -4,10 +4,9 @@ use std::str::FromStr;
 use futures_executor::block_on;
 
 use trust_dns_client::proto::rr::rdata::tlsa::*;
-use trust_dns_client::rr::dnssec::*;
 use trust_dns_client::rr::*;
 use trust_dns_client::serialize::txt::*;
-use trust_dns_server::authority::{Authority, ZoneType};
+use trust_dns_server::authority::{Authority, LookupOptions, ZoneType};
 use trust_dns_server::store::in_memory::InMemoryAuthority;
 
 // TODO: split this test up to test each thing separately
@@ -100,8 +99,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let lowercase_record = block_on(authority.lookup(
         &Name::from_str("tech.").unwrap().into(),
         RecordType::SOA,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -132,8 +130,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let mut ns_records: Vec<Record> = block_on(authority.lookup(
         &Name::from_str("isi.edu").unwrap().into(),
         RecordType::NS,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -166,8 +163,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let mut mx_records: Vec<Record> = block_on(authority.lookup(
         &Name::from_str("isi.edu").unwrap().into(),
         RecordType::MX,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -199,8 +195,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let a_record: Record = block_on(authority.lookup(
         &Name::from_str("a.isi.edu").unwrap().into(),
         RecordType::A,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -221,8 +216,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let aaaa_record: Record = block_on(authority.lookup(
         &Name::from_str("aaaa.isi.edu").unwrap().into(),
         RecordType::AAAA,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -243,8 +237,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let short_record: Record = block_on(authority.lookup(
         &Name::from_str("short.isi.edu").unwrap().into(),
         RecordType::A,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -266,8 +259,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let mut txt_records: Vec<Record> = block_on(authority.lookup(
         &Name::from_str("a.isi.edu").unwrap().into(),
         RecordType::TXT,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -311,8 +303,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let ptr_record: Record = block_on(authority.lookup(
         &Name::from_str("103.0.3.26.in-addr.arpa").unwrap().into(),
         RecordType::PTR,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -329,8 +320,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let srv_record: Record = block_on(authority.lookup(
         &Name::from_str("_ldap._tcp.service.isi.edu").unwrap().into(),
         RecordType::SRV,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -350,8 +340,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let idna_record: Record = block_on(authority.lookup(
         &Name::from_str("rust-❤️-🦀.isi.edu").unwrap().into(),
         RecordType::A,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -372,8 +361,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let caa_record: Record = block_on(authority.lookup(
         &Name::parse("nocerts.isi.edu.", None).unwrap().into(),
         RecordType::CAA,
-        false,
-        SupportedAlgorithms::new(),
+        LookupOptions::default(),
     ))
     .unwrap()
     .iter()
@@ -395,8 +383,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
                 .unwrap()
                 .into(),
             RecordType::TLSA,
-            false,
-            SupportedAlgorithms::new(),
+            LookupOptions::default(),
         ),
     )
     .unwrap()

--- a/tests/integration-tests/src/authority.rs
+++ b/tests/integration-tests/src/authority.rs
@@ -193,7 +193,7 @@ pub fn create_secure_example() -> InMemoryAuthority {
     use chrono::Duration;
     use openssl::rsa::Rsa;
     use trust_dns_client::rr::dnssec::*;
-    use trust_dns_server::authority::Authority;
+    use trust_dns_server::authority::{Authority, DnssecAuthority};
 
     let mut authority = create_example();
     let rsa = Rsa::generate(2048).unwrap();

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -288,7 +288,7 @@ async fn create_sig0_ready_client() -> (
 ) {
     use openssl::rsa::Rsa;
     use trust_dns_client::rr::dnssec::{Algorithm, KeyPair};
-    use trust_dns_client::rr::rdata::{DNSSECRData, DNSSECRecordType};
+    use trust_dns_client::rr::rdata::{DNSSECRData, RecordType};
     use trust_dns_server::store::sqlite::SqliteAuthority;
 
     let authority = create_example();
@@ -306,7 +306,7 @@ async fn create_sig0_ready_client() -> (
     // insert the KEY for the trusted.example.com
     let mut auth_key = Record::with(
         trusted_name,
-        RecordType::DNSSEC(DNSSECRecordType::KEY),
+        RecordType::KEY,
         Duration::minutes(5).num_seconds() as u32,
     );
     auth_key.set_rdata(RData::DNSSEC(DNSSECRData::KEY(sig0_key)));

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -288,7 +288,7 @@ async fn create_sig0_ready_client() -> (
 ) {
     use openssl::rsa::Rsa;
     use trust_dns_client::rr::dnssec::{Algorithm, KeyPair};
-    use trust_dns_client::rr::rdata::{DNSSECRData, RecordType};
+    use trust_dns_client::rr::rdata::DNSSECRData;
     use trust_dns_server::store::sqlite::SqliteAuthority;
 
     let authority = create_example();

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -437,7 +437,7 @@ fn test_nsec_query_type() {
 fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient<TestClientConnection>, Name) {
     use openssl::rsa::Rsa;
     use trust_dns_client::rr::dnssec::{Algorithm, KeyPair, Signer as SigSigner};
-    use trust_dns_proto::rr::dnssec::rdata::{DNSSECRData, RecordType, KEY};
+    use trust_dns_proto::rr::dnssec::rdata::{DNSSECRData, KEY};
     use trust_dns_server::store::sqlite::SqliteAuthority;
 
     let authority = create_example();

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -310,7 +310,7 @@ fn test_timeout_query_tcp() {
 //     c.secure_query(
 //         &Name::parse("rollernet.us.", None).unwrap(),
 //         DNSClass::IN,
-//         RecordType::DNSSEC(DNSSECRecordType::DS),
+//         RecordType::DS),
 //     ).unwrap();
 // }
 
@@ -324,7 +324,7 @@ fn test_timeout_query_tcp() {
 //     c.secure_query(
 //         &Name::parse("rollernet.us.", None).unwrap(),
 //         DNSClass::IN,
-//         RecordType::DNSSEC(DNSSECRecordType::DS),
+//         RecordType::DS),
 //     ).unwrap();
 // }
 
@@ -338,7 +338,7 @@ fn test_timeout_query_tcp() {
 //     c.secure_query(
 //         &Name::parse("RollErnet.Us.", None).unwrap(),
 //         DNSClass::IN,
-//         RecordType::DNSSEC(DNSSECRecordType::DS),
+//         RecordType::DS),
 //     ).unwrap();
 // }
 
@@ -437,7 +437,7 @@ fn test_nsec_query_type() {
 fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient<TestClientConnection>, Name) {
     use openssl::rsa::Rsa;
     use trust_dns_client::rr::dnssec::{Algorithm, KeyPair, Signer as SigSigner};
-    use trust_dns_proto::rr::dnssec::rdata::{DNSSECRData, DNSSECRecordType, KEY};
+    use trust_dns_proto::rr::dnssec::rdata::{DNSSECRData, RecordType, KEY};
     use trust_dns_server::store::sqlite::SqliteAuthority;
 
     let authority = create_example();
@@ -460,7 +460,7 @@ fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient<TestClientConne
     // insert the KEY for the trusted.example.com
     let mut auth_key = Record::with(
         Name::from_str("trusted.example.com").unwrap(),
-        RecordType::DNSSEC(DNSSECRecordType::KEY),
+        RecordType::KEY,
         Duration::minutes(5).num_seconds() as u32,
     );
     auth_key.set_rdata(RData::DNSSEC(DNSSECRData::KEY(KEY::new(

--- a/tests/integration-tests/tests/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/dnssec_client_handle_tests.rs
@@ -156,7 +156,7 @@ where
 //         .block_on(client.query(
 //             name.clone(),
 //             DNSClass::IN,
-//             RecordType::DNSSEC(DNSSECRecordType::DS),
+//             RecordType::DS),
 //         ))
 //         .expect("query failed");
 
@@ -176,7 +176,7 @@ where
 //         .block_on(client.query(
 //             name.clone(),
 //             DNSClass::IN,
-//             RecordType::DNSSEC(DNSSECRecordType::DS),
+//             RecordType::DS),
 //         ))
 //         .expect("query failed");
 

--- a/tests/integration-tests/tests/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/sqlite_authority_tests.rs
@@ -821,9 +821,7 @@ fn test_zone_signing() {
     .unwrap();
 
     assert!(
-        results
-            .iter()
-            .any(|r| r.rr_type() == RecordType::DNSSEC(DNSSECRecordType::DNSKEY)),
+        results.iter().any(|r| r.rr_type() == RecordType::DNSKEY),
         "must contain a DNSKEY"
     );
 
@@ -836,10 +834,10 @@ fn test_zone_signing() {
     .unwrap();
 
     for record in &results {
-        if record.rr_type() == RecordType::DNSSEC(DNSSECRecordType::RRSIG) {
+        if record.rr_type() == RecordType::RRSIG {
             continue;
         }
-        if record.rr_type() == RecordType::DNSSEC(DNSSECRecordType::DNSKEY) {
+        if record.rr_type() == RecordType::DNSKEY {
             continue;
         }
 
@@ -853,14 +851,15 @@ fn test_zone_signing() {
 
         // validate all records have associated RRSIGs after signing
         assert!(
-            inner_results.iter().any(|r| r.rr_type()
-                == RecordType::DNSSEC(DNSSECRecordType::RRSIG)
-                && r.name() == record.name()
-                && if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *r.rdata() {
-                    rrsig.type_covered() == record.rr_type()
-                } else {
-                    false
-                }),
+            inner_results
+                .iter()
+                .any(|r| r.rr_type() == RecordType::RRSIG
+                    && r.name() == record.name()
+                    && if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *r.rdata() {
+                        rrsig.type_covered() == record.rr_type()
+                    } else {
+                        false
+                    }),
             "record type not covered: {:?}",
             record
         );

--- a/util/src/get_root_ksks.rs
+++ b/util/src/get_root_ksks.rs
@@ -30,7 +30,6 @@ use clap::{
 
 use trust_dns_client::rr::dnssec::Algorithm;
 use trust_dns_proto::rr::dnssec::rdata::DNSSECRData;
-use trust_dns_proto::rr::dnssec::rdata::DNSSECRecordType;
 use trust_dns_proto::rr::record_data::RData;
 use trust_dns_proto::rr::record_type::RecordType;
 use trust_dns_resolver::Resolver;
@@ -47,7 +46,7 @@ pub fn main() {
     println!("querying for root key-signing-keys, ie dnskeys");
     let resolver = Resolver::default().expect("could not create resolver");
     let lookup = resolver
-        .lookup(".", RecordType::DNSSEC(DNSSECRecordType::DNSKEY))
+        .lookup(".", RecordType::DNSKEY)
         .expect("query failed");
 
     for r in lookup.iter() {


### PR DESCRIPTION
This is a series of 5 commits to build up the the final commit to remove the default `dnssec` feature from the `client` crate.