### PR TITLE
on `REFUSED` response, fall back to other nameservers

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -378,7 +378,7 @@ pub struct NameServerConfig {
     pub tls_dns_name: Option<String>,
     /// Default to not trust negative responses from upstream nameservers
     ///
-    /// When a SERVFAIL, NXDOMAIN and NoError/Empty response is received, the query will be
+    /// When a SERVFAIL, NXDOMAIN, REFUSED, or NoError/Empty response is received, the query will be
     /// retried against other configured name servers.
     #[cfg_attr(feature = "serde-config", serde(default))]
     pub trust_nx_responses: bool,

--- a/crates/resolver/src/error.rs
+++ b/crates/resolver/src/error.rs
@@ -145,6 +145,23 @@ impl ResolveError {
 
                 Err(ResolveError::from(error_kind))
             }
+            ResponseCode::Refused => {
+                let note = "Nameserver responded with REFUSED";
+                debug!("{}", note);
+
+                let mut response = response;
+                let soa = response.soa();
+                let query = response.take_queries().drain(..).next().unwrap_or_default();
+                let error_kind = ResolveErrorKind::NoRecordsFound {
+                    query: Box::new(query),
+                    soa: soa.map(Box::new),
+                    negative_ttl: None,
+                    response_code: ResponseCode::Refused,
+                    trusted: false,
+                };
+
+                Err(ResolveError::from(error_kind))
+            }
             // Some NXDOMAIN responses contain CNAME referals, that will not be an error
             ResponseCode::NXDomain if !response.contains_answer() => {
                 let note = "Nameserver responded with NXDomain";


### PR DESCRIPTION
In using trust-dns-resolver as the DNS resolver for Fuchsia, we noticed that there are some authoritative DNS name servers that respond with a `REFUSED` response when they don't know the domain (e.g., it wasn't on an allowlist of hosts it'd respond to queries about).

We have a mitigation for this to our current version of trust-dns-resolver (0.19.2): https://fuchsia-review.googlesource.com/c/fuchsia/+/545423/17/third_party/rust_crates/vendor/trust-dns-resolver/src/name_server/name_server.rs

I'd like to contribute a similar fix here, if you think it makes sense. The intention of this patch is essentially to add `REFUSED` to the list of "retryable" errors—errors that should not lead to a terminal query failure. I looked into the precedent for this and found [this issue](https://github.com/bluejekyll/trust-dns/issues/606) where `SERVFAIL` being a terminal error [led to failed queries](https://github.com/bluejekyll/trust-dns/issues/606#issuecomment-437379564) where the resolver should have continued on to other name servers. I also saw [this TODO](https://github.com/bluejekyll/trust-dns/blob/c9523a86958345d54ff0eeb809194470cd16cae6/crates/resolver/src/name_server/name_server.rs#L144) which suggests it might be appropriate to consider continuing a query after a `REFUSED` response.

I have a couple of questions:
- Do you have any thoughts about this approach?
- If you think it makes sense to move forward with this PR, where can I add tests for this? Perhaps in [name_server_pool_tests](https://github.com/bluejekyll/trust-dns/blob/c658222274090901c810742a1026701c1c094416/tests/integration-tests/tests/name_server_pool_tests.rs)?


