### PR TITLE
Make `trust_dns_proto::rr::Record` serializable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,6 +1919,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -98,7 +98,7 @@ tokio = { version = "1.0", features = ["io-util"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-openssl = { version = "0.6.0", optional = true }
 tokio-rustls = { version = "0.22", optional = true, features = ["early-data"] }
-url = "2.1.0"
+url = { version = "2.1.0", features = ["serde"] }
 wasm-bindgen-crate = { version = "0.2.58", optional = true, package = "wasm-bindgen" }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.21", optional = true }

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -13,10 +13,14 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::serialize::binary::*;
 
 /// The DNS Record class
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 #[allow(dead_code)]
 pub enum DNSClass {

--- a/crates/proto/src/rr/dnssec/algorithm.rs
+++ b/crates/proto/src/rr/dnssec/algorithm.rs
@@ -8,6 +8,9 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::serialize::binary::*;
 
@@ -92,6 +95,7 @@ use crate::serialize::binary::*;
 ///    This document cannot be updated, only made obsolete and replaced by a
 ///    successor document.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[non_exhaustive]
 pub enum Algorithm {

--- a/crates/proto/src/rr/dnssec/digest_type.rs
+++ b/crates/proto/src/rr/dnssec/digest_type.rs
@@ -19,6 +19,9 @@ use openssl::hash;
 #[cfg(feature = "ring")]
 use ring::digest;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::dnssec::Algorithm;
 
@@ -36,6 +39,7 @@ use super::Digest;
 /// 5 ED25519 [RFC draft-ietf-curdle-dnskey-eddsa-03]
 /// 5-255 Unassigned -
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[non_exhaustive]
 pub enum DigestType {

--- a/crates/proto/src/rr/dnssec/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/nsec3.rs
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 #[cfg(any(feature = "openssl", feature = "ring"))]
 use super::{Digest, DigestType};
 use crate::error::*;
@@ -96,6 +99,7 @@ use crate::serialize::binary::{BinEncodable, BinEncoder};
 ///    Assignment of additional NSEC3 hash algorithms in this registry
 ///    requires IETF Standards Action [RFC2434].
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Nsec3HashAlgorithm {
     /// Hash for the Nsec3 records

--- a/crates/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -18,6 +18,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::dnssec::{Algorithm, Digest, DigestType};
 use crate::rr::record_data::RData;
@@ -72,6 +75,7 @@ use crate::serialize::binary::{
 ///    backward compatibility with early versions of the KEY record.
 ///
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct DNSKEY {
     zone_key: bool,

--- a/crates/proto/src/rr/dnssec/rdata/ds.rs
+++ b/crates/proto/src/rr/dnssec/rdata/ds.rs
@@ -18,6 +18,9 @@
 
 use std::fmt::{self, Display, Formatter};
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::dnssec::{Algorithm, DigestType};
 use crate::serialize::binary::*;
@@ -68,6 +71,7 @@ use crate::rr::Name;
 ///    hexadecimal digits.  Whitespace is allowed within the hexadecimal
 ///    text.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct DS {
     key_tag: u16,

--- a/crates/proto/src/rr/dnssec/rdata/key.rs
+++ b/crates/proto/src/rr/dnssec/rdata/key.rs
@@ -17,6 +17,9 @@
 //! public key record data for signing zone records
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::dnssec::Algorithm;
 use crate::rr::record_data::RData;
@@ -160,6 +163,7 @@ use crate::serialize::binary::*;
 ///               the zone regardless of the value of the signatory field.
 /// ```
 #[allow(deprecated)]
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct KEY {
     key_trust: KeyTrust,
@@ -171,6 +175,7 @@ pub struct KEY {
 }
 
 /// Specifies in what contexts this key may be trusted for use
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum KeyTrust {
     /// Use of the key is prohibited for authentication
@@ -244,6 +249,7 @@ fn test_key_trust() {
 /// Declares what this key is for
 #[allow(deprecated)]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 pub enum KeyUsage {
     /// key associated with a "user" or "account" at an end entity, usually a host
     Host,
@@ -404,6 +410,7 @@ fn test_key_usage() {
 ///    SHOULD be set to 0 in KEY records, and MUST be ignored.
 ///
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[deprecated = "Deprecated by RFC3007"]
 #[allow(deprecated)]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
@@ -577,6 +584,7 @@ fn test_update_scope() {
 /// ```text
 /// All Protocol Octet values except DNSSEC (3) are eliminated
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[allow(deprecated)]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Protocol {

--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -18,6 +18,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 // TODO: these should each be it's own struct, it would make parsing and decoding a little cleaner
 //  and also a little more ergonomic when accessing.
 // each of these module's has the parser for that rdata embedded, to keep the file sizes down...
@@ -53,6 +56,7 @@ pub use self::tsig::TSIG;
 pub type DNSSECRecordType = RecordType;
 
 /// Record data enum variants for DNSSEC-specific records.
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, EnumAsInner, PartialEq, Clone, Eq)]
 #[non_exhaustive]
 pub enum DNSSECRData {

--- a/crates/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec.rs
@@ -17,6 +17,9 @@
 //! negative cache proof for non-existence
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use super::nsec3;
 use crate::error::*;
 use crate::rr::{Name, RecordType};
@@ -46,6 +49,7 @@ use crate::serialize::binary::*;
 ///    expansion.  [RFC4035] describes the impact of wildcards on
 ///    authenticated denial of existence.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NSEC {
     next_domain_name: Name,

--- a/crates/proto/src/rr/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3.rs
@@ -18,6 +18,9 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::dnssec::Nsec3HashAlgorithm;
 use crate::rr::RecordType;
@@ -108,6 +111,7 @@ use crate::serialize::binary::*;
 ///  does not include the name of the containing zone.  The length of this
 ///  field is determined by the preceding Hash Length field.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NSEC3 {
     hash_algorithm: Nsec3HashAlgorithm,

--- a/crates/proto/src/rr/dnssec/rdata/nsec3param.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3param.rs
@@ -18,6 +18,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::dnssec::Nsec3HashAlgorithm;
 use crate::serialize::binary::*;
@@ -78,6 +81,7 @@ use crate::serialize::binary::*;
 ///  length of this field is determined by the preceding Salt Length
 ///  field.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NSEC3PARAM {
     hash_algorithm: Nsec3HashAlgorithm,

--- a/crates/proto/src/rr/dnssec/rdata/sig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/sig.rs
@@ -17,6 +17,9 @@
 //! signature record for signing queries, updates, and responses
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::dnssec::Algorithm;
 use crate::rr::{Name, RecordType};
@@ -180,6 +183,7 @@ use crate::serialize::binary::*;
 ///    networks, this time bracket should not normally extend further than 5
 ///    minutes into the past and 5 minutes into the future.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SIG {
     type_covered: RecordType,

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -9,6 +9,9 @@
 use std::convert::TryInto;
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::rr::rdata::sshfp;
 
 use crate::error::*;
@@ -132,6 +135,7 @@ use crate::serialize::binary::*;
 ///      seconds (see Section 5.2.3).  This document assigns no meaning to
 ///      its contents in requests.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TSIG {
     algorithm: TsigAlgorithm,
@@ -171,6 +175,7 @@ pub struct TSIG {
 ///      | hmac-sha512-256          | MAY            | MAY             |
 ///      +--------------------------+----------------+-----------------+
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum TsigAlgorithm {
     /// HMAC-MD5.SIG-ALG.REG.INT (not supported for cryptographic operations)

--- a/crates/proto/src/rr/dnssec/supported_algorithm.rs
+++ b/crates/proto/src/rr/dnssec/supported_algorithm.rs
@@ -20,6 +20,9 @@ use std::convert::From;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use log::warn;
 
 use crate::error::*;
@@ -27,6 +30,7 @@ use crate::rr::dnssec::Algorithm;
 use crate::serialize::binary::{BinEncodable, BinEncoder};
 
 /// Used to specify the set of SupportedAlgorithms between a client and server
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct SupportedAlgorithms {
     // right now the number of Algorithms supported are fewer than 16..

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -23,6 +23,9 @@
 use std::fmt;
 use std::str;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
@@ -127,6 +130,7 @@ use url::Url;
 /// domain will change between the time a certificate was issued and
 /// validation by a relying party.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CAA {
     #[doc(hidden)]
@@ -214,6 +218,7 @@ impl CAA {
 }
 
 /// Specifies in what contexts this key may be trusted for use
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Property {
     /// The issue property
@@ -294,6 +299,7 @@ impl From<String> for Property {
 /// `Issue` and `IssueWild` => `Issuer`,
 /// `Iodef` => `Url`,
 /// `Unknown` => `Unknown`,
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Value {
     /// Issuer authorized to issue certs for this zone, and any associated parameters
@@ -623,6 +629,7 @@ pub fn read_iodef(url: &[u8]) -> ProtoResult<Url> {
 ///
 /// See [RFC 6844, DNS Certification Authority Authorization, January 2013](https://tools.ietf.org/html/rfc6844#section-5.2)
 /// for more explanation.
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct KeyValue {
     key: String,

--- a/crates/proto/src/rr/rdata/hinfo.rs
+++ b/crates/proto/src/rr/rdata/hinfo.rs
@@ -9,6 +9,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::serialize::binary::*;
 
@@ -38,6 +41,7 @@ use crate::serialize::binary::*;
 /// ```
 ///
 /// [rfc1035]: https://tools.ietf.org/html/rfc1035
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct HINFO {
     cpu: Box<[u8]>,

--- a/crates/proto/src/rr/rdata/mx.rs
+++ b/crates/proto/src/rr/rdata/mx.rs
@@ -18,6 +18,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
@@ -39,6 +42,7 @@ use crate::serialize::binary::*;
 /// [RFC-974].
 ///
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct MX {
     preference: u16,

--- a/crates/proto/src/rr/rdata/naptr.rs
+++ b/crates/proto/src/rr/rdata/naptr.rs
@@ -9,6 +9,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
@@ -42,6 +45,7 @@ use crate::serialize::binary::*;
 ///   <character-string> and <domain-name> as used here are defined in RFC
 ///   1035 [7].
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NAPTR {
     order: u16,

--- a/crates/proto/src/rr/rdata/null.rs
+++ b/crates/proto/src/rr/rdata/null.rs
@@ -17,6 +17,9 @@
 //! null record type, generally not used except as an internal tool for representing null data
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::serialize::binary::*;
 
@@ -37,6 +40,7 @@ use crate::serialize::binary::*;
 /// allowed in Zone Files.  NULLs are used as placeholders in some
 /// experimental extensions of the DNS.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Default, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NULL {
     anything: Option<Vec<u8>>,

--- a/crates/proto/src/rr/rdata/openpgpkey.rs
+++ b/crates/proto/src/rr/rdata/openpgpkey.rs
@@ -8,6 +8,9 @@
 //! OPENPGPKEY records for OpenPGP public keys
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::serialize::binary::*;
 
@@ -18,6 +21,7 @@ use crate::serialize::binary::*;
 /// value consisting of a Transferable Public Key formatted as specified
 /// in [RFC4880].
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct OPENPGPKEY {
     public_key: Vec<u8>,

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -18,6 +18,9 @@
 
 use std::collections::HashMap;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use log::warn;
 
 use crate::error::*;
@@ -162,6 +165,7 @@ use crate::rr::dnssec::SupportedAlgorithms;
 ///       Set to zero by senders and ignored by receivers, unless modified
 ///       in a subsequent specification.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct OPT {
     options: HashMap<EdnsCode, EdnsOption>,
@@ -312,6 +316,7 @@ enum OptReadState {
 }
 
 /// The code of the EDNS data option
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Hash, Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EdnsCode {
@@ -408,6 +413,7 @@ impl From<EdnsCode> for u16 {
 /// `note: Not all EdnsOptions are supported at this time.`
 ///
 /// <http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-13>
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Hash)]
 #[non_exhaustive]
 pub enum EdnsOption {

--- a/crates/proto/src/rr/rdata/soa.rs
+++ b/crates/proto/src/rr/rdata/soa.rs
@@ -18,6 +18,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
@@ -66,6 +69,7 @@ use crate::serialize::binary::*;
 /// reason for this provison is to allow future dynamic update facilities to
 /// change the SOA RR with known semantics.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SOA {
     mname: Name,

--- a/crates/proto/src/rr/rdata/srv.rs
+++ b/crates/proto/src/rr/rdata/srv.rs
@@ -17,6 +17,9 @@
 //! service records for identify port mapping for specific services on a host
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
@@ -81,6 +84,7 @@ use crate::serialize::binary::*;
 /// Class.
 ///
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SRV {
     priority: u16,

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -8,6 +8,9 @@
 //! SSHFP records for SSH public key fingerprints
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use data_encoding::{Encoding, Specification};
 use lazy_static::lazy_static;
 
@@ -52,6 +55,7 @@ lazy_static! {
 ///    The message-digest algorithm is presumed to produce an opaque octet
 ///    string output, which is placed as-is in the RDATA fingerprint field.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SSHFP {
     algorithm: Algorithm,
@@ -113,6 +117,7 @@ impl SSHFP {
 /// The algorithm values have been updated in
 /// [RFC 6594](https://tools.ietf.org/html/rfc6594) and
 /// [RFC 7479](https://tools.ietf.org/html/rfc7479).
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Algorithm {
     /// Reserved value
@@ -181,6 +186,7 @@ impl From<Algorithm> for u8 {
 ///
 /// The fingerprint type values have been updated in
 /// [RFC 6594](https://tools.ietf.org/html/rfc6594).
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum FingerprintType {
     /// Reserved value

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -15,6 +15,9 @@ use std::{
     net::Ipv6Addr,
 };
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use enum_as_inner::EnumAsInner;
 
 use crate::error::*;
@@ -62,6 +65,7 @@ use crate::serialize::binary::*;
 ///   If any RRs are malformed, the client MUST reject the entire RRSet and
 ///   fall back to non-SVCB connection establishment.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SVCB {
     svc_priority: u16,
@@ -189,6 +193,7 @@ impl SVCB {
 ///   *  a 2 octet field containing the SvcParamKey as an integer in
 ///      network byte order.  (See Section 14.3.2 for the defined values.)
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum SvcParamKey {
     /// Mandatory keys in this RR
@@ -339,6 +344,7 @@ impl PartialOrd for SvcParamKey {
 ///   *  an octet string of this length whose contents are in a format
 ///      determined by the SvcParamKey.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, EnumAsInner)]
 pub enum SvcParamValue {
     ///    In a ServiceMode RR, a SvcParamKey is considered "mandatory" if the
@@ -557,6 +563,7 @@ impl fmt::Display for SvcParamValue {
 ///    SHOULD NOT appear in the list either.  (Including them wastes space
 ///    and otherwise has no effect.)
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct Mandatory(pub Vec<SvcParamKey>);
@@ -720,6 +727,7 @@ impl fmt::Display for Mandatory {
 ///   operators SHOULD ensure that at least one RR in each RRSet supports
 ///   the default transports.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct Alpn(pub Vec<String>);
@@ -805,6 +813,7 @@ impl fmt::Display for Alpn {
 ///   apply only to the inner ClientHello.  Similarly, it is the inner
 ///   ClientHello whose Server Name Indication identifies the desired
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct EchConfig(pub Vec<u8>);
@@ -917,6 +926,7 @@ impl fmt::Debug for EchConfig {
 ///   server operators SHOULD NOT include these hints, because they are
 ///   unlikely to convey any performance benefit.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct IpHint<T>(pub Vec<T>);
@@ -989,6 +999,7 @@ where
 ///   SvcParams in presentation format MAY appear in any order, but keys
 ///   MUST NOT be repeated.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct Unknown(pub Vec<Vec<u8>>);

--- a/crates/proto/src/rr/rdata/tlsa.rs
+++ b/crates/proto/src/rr/rdata/tlsa.rs
@@ -8,6 +8,9 @@
 //! TLSA records for storing TLS certificate validation information
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use super::sshfp;
 
 use crate::error::*;
@@ -32,6 +35,7 @@ use crate::serialize::binary::*;
 ///    /                                                               /
 ///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TLSA {
     cert_usage: CertUsage,
@@ -66,6 +70,7 @@ pub struct TLSA {
 ///    that accept other formats for certificates, those certificates will
 ///    need their own certificate usage values.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum CertUsage {
     /// ```text
@@ -176,6 +181,7 @@ impl From<CertUsage> for u8 {
 ///    unrelated to the use of "selector" in DomainKeys Identified Mail
 ///    (DKIM) [RFC6376].)
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Selector {
     /// Full certificate: the Certificate binary structure as defined in [RFC5280](https://tools.ietf.org/html/rfc5280)
@@ -234,6 +240,7 @@ impl From<Selector> for u8 {
 ///    certificate (if possible) will assist clients that support a small
 ///    number of hash algorithms.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Matching {
     /// Exact match on selected content

--- a/crates/proto/src/rr/rdata/txt.rs
+++ b/crates/proto/src/rr/rdata/txt.rs
@@ -18,6 +18,9 @@
 use std::fmt;
 use std::slice::Iter;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::serialize::binary::*;
 
@@ -34,6 +37,7 @@ use crate::serialize::binary::*;
 /// TXT RRs are used to hold descriptive text.  The semantics of the text
 /// depends on the domain where it is found.
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TXT {
     txt_data: Box<[Box<[u8]>]>,

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -13,6 +13,9 @@ use std::convert::From;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use enum_as_inner::EnumAsInner;
 use log::{trace, warn};
 
@@ -47,6 +50,7 @@ use super::dnssec::rdata::DNSSECRData;
 /// is treated as binary information, and can be up to 256 characters in
 /// length (including the length octet).
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, EnumAsInner, PartialEq, Clone, Eq)]
 #[non_exhaustive]
 pub enum RData {

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -19,6 +19,9 @@
 use std::cmp::Ordering;
 use std::fmt;
 
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use crate::rr::dns_class::DNSClass;
 use crate::rr::rdata::NULL;
@@ -74,6 +77,7 @@ const MDNS_ENABLE_CACHE_FLUSH: u16 = 1 << 15;
 ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 ///
 /// ```
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Eq, Debug, Clone)]
 pub struct Record {
     name_labels: Name,


### PR DESCRIPTION
When using the `serde-config` feature, I noticed that the `trust_dns_proto::rr::Record` is not `Deserialize` and `Serialize`. This can be achieved by adding a conditional derive to all its subtypes.