### PR TITLE
use ResponseCode in Header rather than u8

### DIFF
--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -66,7 +66,7 @@ pub struct Header {
     recursion_available: bool,
     authentic_data: bool,
     checking_disabled: bool,
-    response_code: u8, /* ideally u4 */
+    response_code: ResponseCode,
     query_count: u16,
     answer_count: u16,
     name_server_count: u16,
@@ -94,7 +94,7 @@ impl Default for Header {
             recursion_available: false,
             authentic_data: false,
             checking_disabled: false,
-            response_code: 0,
+            response_code: ResponseCode::default(),
             query_count: 0,
             answer_count: 0,
             name_server_count: 0,
@@ -174,8 +174,13 @@ impl Header {
 
     /// The low response code (original response codes before EDNS extensions)
     pub fn set_response_code(&mut self, response_code: ResponseCode) -> &mut Self {
-        self.response_code = response_code.low();
+        self.response_code = response_code;
         self
+    }
+
+    /// This combines the high and low response code values to form the complete ResponseCode from the EDNS record
+    pub fn merge_response_code(&mut self, high_response_code: u8) {
+        self.response_code = ResponseCode::from(high_response_code, self.response_code.low());
     }
 
     /// Number or query records in the message
@@ -315,7 +320,7 @@ impl Header {
     ///                 responses.  The values have the following
     ///                 interpretation: <see super::response_code>
     /// ```
-    pub fn response_code(&self) -> u8 {
+    pub fn response_code(&self) -> ResponseCode {
         self.response_code
     }
 
@@ -409,7 +414,7 @@ impl BinEncodable for Header {
         } else {
             0b0000_0000
         };
-        r_z_ad_cd_rcod |= self.response_code;
+        r_z_ad_cd_rcod |= self.response_code.low();
         encoder.emit(r_z_ad_cd_rcod)?;
 
         encoder.emit_u16(self.query_count)?;
@@ -444,6 +449,7 @@ impl<'r> BinDecodable<'r> for Header {
         let authentic_data = (0b0010_0000 & r_z_ad_cd_rcod) == 0b0010_0000;
         let checking_disabled = (0b0001_0000 & r_z_ad_cd_rcod) == 0b0001_0000;
         let response_code: u8 = 0b0000_1111 & r_z_ad_cd_rcod;
+        let response_code = ResponseCode::from_low(response_code);
 
         // TODO: We should pass these restrictions on, they can't be trusted, but that would seriously complicate the Header type..
         // TODO: perhaps the read methods for BinDecodable should return Restrict?
@@ -496,7 +502,7 @@ fn test_parse() {
         recursion_available: true,
         authentic_data: false,
         checking_disabled: false,
-        response_code: ResponseCode::NXDomain.low(),
+        response_code: ResponseCode::NXDomain,
         query_count: 0x8877,
         answer_count: 0x6655,
         name_server_count: 0x4433,
@@ -520,7 +526,7 @@ fn test_write() {
         recursion_available: true,
         authentic_data: false,
         checking_disabled: false,
-        response_code: ResponseCode::NXDomain.low(),
+        response_code: ResponseCode::NXDomain,
         query_count: 0x8877,
         answer_count: 0x6655,
         name_server_count: 0x4433,

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -178,7 +178,12 @@ impl Header {
         self
     }
 
-    /// This combines the high and low response code values to form the complete ResponseCode from the EDNS record
+    /// This combines the high and low response code values to form the complete ResponseCode from the EDNS record.
+    ///   The existing high order bits will be overwritten (if set), and `high_response_code` will be merge with
+    ///   the existing low order bits.
+    ///
+    /// This is intended for use during decoding.
+    #[doc(hidden)]
     pub fn merge_response_code(&mut self, high_response_code: u8) {
         self.response_code = ResponseCode::from(high_response_code, self.response_code.low());
     }

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -141,6 +141,14 @@ impl ResponseCode {
         ((u16::from(self) & 0x0FF0) >> 4) as u8
     }
 
+    /// DNS can not store the entire space of ResponseCodes in 4 bit space of the Header, this function
+    ///   allows for a initial value of the first 4 bits to be set.
+    ///
+    /// After the EDNS is read, the entire ResponseCode (12 bits) can be reconstructed for the full ResponseCode.
+    pub fn from_low(low: u8) -> Self {
+        ((u16::from(low)) & 0x000F).into()
+    }
+
     /// Combines the EDNS high and low from the Header to produce the Extended ResponseCode
     pub fn from(high: u8, low: u8) -> ResponseCode {
         ((u16::from(high) << 4) | ((u16::from(low)) & 0x000F)).into()
@@ -171,6 +179,12 @@ impl ResponseCode {
             ResponseCode::BADCOOKIE => "Bad server cookie", // 23    BADCOOKIE (TEMPORARY - registered 2015-07-26, expires 2016-07-26)    Bad/missing server cookie    [draft-ietf-dnsop-cookies]
             ResponseCode::Unknown(_) => "Unknown response code",
         }
+    }
+}
+
+impl Default for ResponseCode {
+    fn default() -> Self {
+        Self::NoError
     }
 }
 

--- a/crates/server/src/authority/message_request.rs
+++ b/crates/server/src/authority/message_request.rs
@@ -75,10 +75,7 @@ impl MessageRequest {
     /// The `ResponseCode`, if this is an EDNS message then this will join the section from the OPT
     ///  record to create the EDNS `ResponseCode`
     pub fn response_code(&self) -> ResponseCode {
-        ResponseCode::from(
-            self.edns.as_ref().map_or(0, Edns::rcode_high),
-            self.header.response_code(),
-        )
+        self.header.response_code()
     }
 
     /// ```text
@@ -179,7 +176,7 @@ impl<'q> BinDecodable<'q> for MessageRequest {
     // TODO: generify this with Message?
     /// Reads a MessageRequest from the decoder
     fn read(decoder: &mut BinDecoder<'q>) -> ProtoResult<Self> {
-        let header = Header::read(decoder)?;
+        let mut header = Header::read(decoder)?;
 
         // TODO: return just header, and in the case of the rest of message getting an error.
         //  this could improve error detection while decoding.
@@ -196,6 +193,12 @@ impl<'q> BinDecodable<'q> for MessageRequest {
         let (answers, _, _) = Message::read_records(decoder, answer_count, false)?;
         let (name_servers, _, _) = Message::read_records(decoder, name_server_count, false)?;
         let (additionals, edns, sig0) = Message::read_records(decoder, additional_count, true)?;
+
+        // need to grab error code from EDNS (which might have a higher value)
+        if let Some(edns) = &edns {
+            let high_response_code = edns.rcode_high();
+            header.merge_response_code(high_response_code);
+        }
 
         Ok(MessageRequest {
             header,


### PR DESCRIPTION
I noticed in reviewing logs of the server that the ResponseCode was always being reported as a simple number, rather than using the name associated with the enum value. While researching the change, it became clear that this is partially because we do not store the ResponseCode in the Header, but instead only the low order 4 bits. The high-order bits are associated with the EDNS record, which have always been split.

This change fixes the logging issue and also stores the full ResponseCode in the Header of the Message, rather than only the partial value.