### PR TITLE
Remove AsyncClientConnect and AsyncSecureClientConnect in favor of async constructors

### DIFF
--- a/crates/client/src/client/mod.rs
+++ b/crates/client/src/client/mod.rs
@@ -27,14 +27,10 @@ mod memoize_client_handle;
 mod rc_stream;
 
 #[allow(deprecated)]
-pub use self::async_client::{
-    AsyncClient, AsyncClientConnect, ClientFuture, ClientHandle, ClientStreamingResponse,
-};
+pub use self::async_client::{AsyncClient, ClientFuture, ClientHandle, ClientStreamingResponse};
 #[cfg(feature = "dnssec")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
-pub use self::async_secure_client::{
-    AsyncDnssecClient, AsyncSecureClientBuilder, AsyncSecureClientConnect,
-};
+pub use self::async_secure_client::{AsyncDnssecClient, AsyncSecureClientBuilder};
 #[cfg(feature = "dnssec")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
 pub use self::client::SyncDnssecClient;


### PR DESCRIPTION
This is the second PR associated with #1532, removing the intermediate `AsyncClientConnect` object in favor of `async` functions to construct the `AsyncClient`, as discussed on the issue.


> > On another note, I am quite confused by the AsyncClient vs AsyncClientConnect distinction. Are there reasons not to define AsyncClient::new and AsyncClient::connect as async fn that return an AsyncClient once they have been awaited ? This could remove the need for this intermediary AsyncConnect object.
> 
> I think those functions can be simplified. The only reason I can think that didn't happen is because AsyncClient is older than async/await in Rust. Most likely it can be simplified to be `async fn` instead of Future implementations. If that's something you'd be interested in working on, it would be appreciated...

I also removed `AsyncSecureClientConnect` and make similar changes to `AsyncDnssecClient` as they were also based on `AsyncClientConnect`/`AsyncClient`.

There should be very little to no changes in usage for users, and the tests still all pass on my machine without having had to make any change to them.