### PR TITLE
speed up ci with rust cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
       with:
         version: ${{ env.CARGO_MAKE_VERSION }}
 
+    - name: Cache Dependencies
+      uses: Swatinem/rust-cache@v1.2.0
+
     - name: cargo make all-features
       run: cargo make all-features
 
@@ -78,6 +81,9 @@ jobs:
       with:
         version: ${{ env.CARGO_MAKE_VERSION }}
 
+    - name: Cache Dependencies
+      uses: Swatinem/rust-cache@v1.2.0
+
     - name: cargo make
       run: cargo make ${{ matrix.feature }}
 
@@ -120,6 +126,9 @@ jobs:
       with:
         version: ${{ env.CARGO_MAKE_VERSION }}
 
+    - name: Cache Dependencies
+      uses: Swatinem/rust-cache@v1.2.0
+
     - name: cargo make all-features
       run: cargo make all-features
 
@@ -133,6 +142,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Cache Dependencies
+      uses: Swatinem/rust-cache@v1.2.0
 
     # not using the cargo cache here, since this differs significantly
     - name: cargo-all cache
@@ -182,6 +194,9 @@ jobs:
     - uses: davidB/rust-cargo-make@v1
       with:
         version: ${{ env.CARGO_MAKE_VERSION }}
+
+    - name: Cache Dependencies
+      uses: Swatinem/rust-cache@v1.2.0
 
     - name: target/bind cache
       uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   CARGO_MAKE_VERSION: '0.34.0'
+  CARGO_INCREMENTAL: 0
 
 jobs:
   ## Run all default oriented feature sets across all platforms.


### PR DESCRIPTION
I decided to try this after reading https://matklad.github.io/2021/09/04/fast-rust-builds.html, but I'm not seeing any benefits. I wonder if I'm doing something wrong with other cache rules, or if it really doesn't make a difference.