### PR TITLE
correct behavior around trust_nx_responses

### DIFF
--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -139,15 +139,9 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> NameSe
 
         match response {
             Ok(response) => {
-                // first we'll evaluate if the message succeeded
-                //   see https://github.com/bluejekyll/trust-dns/issues/606
-                //   TODO: there are probably other return codes from the server we may want to
-                //    retry on. We may also want to evaluate NoError responses that lack records as errors as well
-                let response = if self.config.trust_nx_responses {
-                    ResolveError::from_response(response, self.config.trust_nx_responses)?
-                } else {
-                    response
-                };
+                // First evaluate if the message succeeded.
+                let response =
+                    ResolveError::from_response(response, self.config.trust_nx_responses)?;
 
                 // TODO: consider making message::take_edns...
                 let remote_edns = response.edns().cloned();

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -25,7 +25,8 @@ pub struct MockClientHandle<O: OnSend, E> {
 }
 
 impl<E> MockClientHandle<DefaultOnSend, E> {
-    /// constructs a new MockClient which returns each Message one after the other
+    /// constructs a new MockClient which returns each Message one after the other (messages are
+    /// popped off the back of `messages`, so they are sent in reverse order).
     pub fn mock(messages: Vec<Result<DnsResponse, E>>) -> Self {
         println!("MockClientHandle::mock message count: {}", messages.len());
 
@@ -37,7 +38,8 @@ impl<E> MockClientHandle<DefaultOnSend, E> {
 }
 
 impl<O: OnSend, E> MockClientHandle<O, E> {
-    /// constructs a new MockClient which returns each Message one after the other
+    /// constructs a new MockClient which returns each Message one after the other (messages are
+    /// popped off the back of `messages`, so they are sent in reverse order).
     pub fn mock_on_send(messages: Vec<Result<DnsResponse, E>>, on_send: O) -> Self {
         println!(
             "MockClientHandle::mock_on_send message count: {}",


### PR DESCRIPTION
In [this change](https://github.com/bluejekyll/trust-dns/pull/1212) which moved the [`trust_nx_responses`](https://docs.rs/trust-dns-resolver/0.21.0-alpha.2/trust_dns_resolver/config/struct.NameServerConfig.html#structfield.trust_nx_responses) config from a configuration on the Resolver to a configuration at the name server level, the option was also renamed from `distrust_nx_responses`. There were some places in the codebase where the corresponding boolean value was not also flipped, unintentionally changing the semantics. This has led to some confusing behavior. For example, in [this name_server_pool_test](https://github.com/bluejekyll/trust-dns/pull/1212/files#diff-90f333e308fae6ca92b573fb451e69b70155c72e3f8d1a7f0c836062d0e7b8d1L250), where `distrust_nx_responses` was previously set to `false`, `trust_nx_responses` was left as `false` in the change, where it should have been changed to `true`.

This PR fixes a bug where retry behavior doesn't occur unless `trust_nx_responses` is set to true (due to an error response not being considered a `ResolveError`), and reworks the tests to accurately test the current behavior. It also consolidates the `test_distrust_nx_responses` and `test_retry_on_error_response` tests into one test, as they exercised the same functionality.