### PR TITLE
Narrow range for ephemeral ports to IANA-suggested range

### DIFF
--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -378,11 +378,16 @@ impl Future for NextRandomUdpSocket {
         } else {
             // TODO: this is basically identical to UdpStream from here... share some code? (except for the port restriction)
             // one-shot queries look very similar to UDP socket, but can't listen on 5353
-            let rand_port_range = Uniform::new_inclusive(1025_u16, u16::max_value());
+
+            // Per RFC 6056 Section 2.1:
+            //
+            //    The dynamic port range defined by IANA consists of the 49152-65535
+            //    range, and is meant for the selection of ephemeral ports.
+            let rand_port_range = Uniform::new_inclusive(49152_u16, u16::max_value());
             let mut rand = rand::thread_rng();
 
             for attempt in 0..10 {
-                let port = rand_port_range.sample(&mut rand); // the range is [0 ... u16::max]
+                let port = rand_port_range.sample(&mut rand);
 
                 // see one_shot usage info: https://tools.ietf.org/html/rfc6762#section-5
                 //  the MDNS_PORT is used to signal to remote processes that this is capable of receiving multicast packets


### PR DESCRIPTION
The IANA [suggests](https://datatracker.ietf.org/doc/html/rfc6335#section-6) using ports 49152 and above for the purpose of ephemeral ports, so when choosing a random source port for a new UDP socket, restrict it to this range.

Fixes #1555