### PR TITLE
Change transport traits to use instance methods.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
 name = "trust-dns-resolver"
 version = "0.21.0-alpha.4"
 dependencies = [
+ "async-trait",
  "cfg-if",
  "env_logger",
  "futures-executor",

--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -24,9 +24,8 @@ use trust_dns_client::tcp::*;
 use trust_dns_client::udp::*;
 use trust_dns_proto::error::*;
 use trust_dns_proto::op::NoopMessageFinalizer;
-use trust_dns_proto::tcp::TokioTcpConnector;
-use trust_dns_proto::udp::TokioUdpBinder;
 use trust_dns_proto::xfer::*;
+use trust_dns_proto::TokioRuntime;
 
 fn find_test_port() -> u16 {
     let server = std::net::UdpSocket::bind(("0.0.0.0", 0)).unwrap();
@@ -55,7 +54,7 @@ fn wrap_process(named: Child, server_port: u16) -> NamedProcess {
             .unwrap()
             .next()
             .unwrap();
-        let stream = UdpClientStream::new(addr, TokioUdpBinder);
+        let stream = UdpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::connect(stream);
         let (mut client, bg) = io_loop.block_on(client).expect("failed to create client");
         io_loop.spawn(bg);
@@ -152,7 +151,7 @@ fn trust_dns_udp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr, TokioUdpBinder);
+    let stream = UdpClientStream::new(addr, TokioRuntime);
     bench(b, stream);
 
     // cleaning up the named process
@@ -169,7 +168,7 @@ fn trust_dns_udp_bench_prof(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr, TokioUdpBinder);
+    let stream = UdpClientStream::new(addr, TokioRuntime);
     bench(b, stream);
 }
 
@@ -182,7 +181,7 @@ fn trust_dns_tcp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+    let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
     let mp = DnsMultiplexer::new(stream, sender, None::<Arc<NoopMessageFinalizer>>);
     bench(b, mp);
 
@@ -240,7 +239,7 @@ fn bind_udp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr, TokioUdpBinder);
+    let stream = UdpClientStream::new(addr, TokioRuntime);
     bench(b, stream);
 
     // cleaning up the named process
@@ -257,7 +256,7 @@ fn bind_tcp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+    let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
     let mp = DnsMultiplexer::new(stream, sender, None::<Arc<NoopMessageFinalizer>>);
     bench(b, mp);
 

--- a/bin/tests/named_https_tests.rs
+++ b/bin/tests/named_https_tests.rs
@@ -20,11 +20,10 @@ use std::net::*;
 use std::sync::Arc;
 
 use rustls::{Certificate, ClientConfig, OwnedTrustAnchor, RootCertStore};
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 use trust_dns_client::client::*;
 use trust_dns_proto::https::HttpsClientStreamBuilder;
-use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
+use trust_dns_proto::tcp::TokioTcpConnector;
 
 use server_harness::{named_test_harness, query_a};
 
@@ -80,10 +79,10 @@ fn test_example_https_toml_startup() {
 
         let client_config = Arc::new(client_config);
 
-        let https_builder = HttpsClientStreamBuilder::with_client_config(client_config);
+        let https_builder =
+            HttpsClientStreamBuilder::with_client_config(TokioTcpConnector, client_config);
 
-        let mp = https_builder
-            .build::<AsyncIoTokioAsStd<TokioTcpStream>>(addr, "ns.example.com".to_string());
+        let mp = https_builder.build(addr, "ns.example.com".to_string());
         let client = AsyncClient::connect(mp);
 
         // ipv4 should succeed

--- a/bin/tests/named_https_tests.rs
+++ b/bin/tests/named_https_tests.rs
@@ -23,7 +23,7 @@ use rustls::{Certificate, ClientConfig, OwnedTrustAnchor, RootCertStore};
 use tokio::runtime::Runtime;
 use trust_dns_client::client::*;
 use trust_dns_proto::https::HttpsClientStreamBuilder;
-use trust_dns_proto::tcp::TokioTcpConnector;
+use trust_dns_proto::TokioRuntime;
 
 use server_harness::{named_test_harness, query_a};
 
@@ -80,7 +80,7 @@ fn test_example_https_toml_startup() {
         let client_config = Arc::new(client_config);
 
         let https_builder =
-            HttpsClientStreamBuilder::with_client_config(TokioTcpConnector, client_config);
+            HttpsClientStreamBuilder::with_client_config(TokioRuntime, client_config);
 
         let mp = https_builder.build(addr, "ns.example.com".to_string());
         let client = AsyncClient::connect(mp);

--- a/bin/tests/named_rustls_tests.rs
+++ b/bin/tests/named_rustls_tests.rs
@@ -22,12 +22,11 @@ use std::sync::Arc;
 use rustls::Certificate;
 use rustls::ClientConfig;
 use rustls::RootCertStore;
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 
 use trust_dns_client::client::*;
-use trust_dns_proto::iocompat::AsyncIoTokioAsStd;
 use trust_dns_proto::rustls::tls_client_connect;
+use trust_dns_proto::tcp::TokioTcpConnector;
 
 use server_harness::{named_test_harness, query_a};
 
@@ -66,10 +65,11 @@ fn test_example_tls_toml_startup() {
 
             let config = Arc::new(config);
 
-            let (stream, sender) = tls_client_connect::<AsyncIoTokioAsStd<TokioTcpStream>>(
+            let (stream, sender) = tls_client_connect(
                 addr,
                 "ns.example.com".to_string(),
                 config.clone(),
+                TokioTcpConnector,
             );
             let client = AsyncClient::new(stream, sender, None);
 
@@ -84,10 +84,11 @@ fn test_example_tls_toml_startup() {
                 .unwrap()
                 .next()
                 .unwrap();
-            let (stream, sender) = tls_client_connect::<AsyncIoTokioAsStd<TokioTcpStream>>(
+            let (stream, sender) = tls_client_connect(
                 addr,
                 "ns.example.com".to_string(),
                 config,
+                TokioTcpConnector,
             );
             let client = AsyncClient::new(stream, sender, None);
 

--- a/bin/tests/named_rustls_tests.rs
+++ b/bin/tests/named_rustls_tests.rs
@@ -26,7 +26,7 @@ use tokio::runtime::Runtime;
 
 use trust_dns_client::client::*;
 use trust_dns_proto::rustls::tls_client_connect;
-use trust_dns_proto::tcp::TokioTcpConnector;
+use trust_dns_proto::TokioRuntime;
 
 use server_harness::{named_test_harness, query_a};
 
@@ -69,7 +69,7 @@ fn test_example_tls_toml_startup() {
                 addr,
                 "ns.example.com".to_string(),
                 config.clone(),
-                TokioTcpConnector,
+                TokioRuntime,
             );
             let client = AsyncClient::new(stream, sender, None);
 
@@ -84,12 +84,8 @@ fn test_example_tls_toml_startup() {
                 .unwrap()
                 .next()
                 .unwrap();
-            let (stream, sender) = tls_client_connect(
-                addr,
-                "ns.example.com".to_string(),
-                config,
-                TokioTcpConnector,
-            );
+            let (stream, sender) =
+                tls_client_connect(addr, "ns.example.com".to_string(), config, TokioRuntime);
             let client = AsyncClient::new(stream, sender, None);
 
             let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");

--- a/bin/tests/named_test_rsa_dnssec.rs
+++ b/bin/tests/named_test_rsa_dnssec.rs
@@ -20,7 +20,7 @@ use trust_dns_client::proto::tcp::TcpClientStream;
 use trust_dns_client::proto::xfer::{DnsExchangeBackground, DnsMultiplexer};
 use trust_dns_client::proto::DnssecDnsHandle;
 use trust_dns_client::rr::dnssec::*;
-use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, tcp::TokioTcpConnector, TokioTime};
+use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, TokioRuntime, TokioTime};
 
 use server_harness::*;
 
@@ -70,7 +70,7 @@ async fn standard_tcp_conn(
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+    let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
     AsyncClient::new(stream, sender, None)
         .await
         .expect("new AsyncClient failed")

--- a/bin/tests/named_test_rsa_dnssec.rs
+++ b/bin/tests/named_test_rsa_dnssec.rs
@@ -20,7 +20,7 @@ use trust_dns_client::proto::tcp::TcpClientStream;
 use trust_dns_client::proto::xfer::{DnsExchangeBackground, DnsMultiplexer};
 use trust_dns_client::proto::DnssecDnsHandle;
 use trust_dns_client::rr::dnssec::*;
-use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, TokioTime};
+use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, tcp::TokioTcpConnector, TokioTime};
 
 use server_harness::*;
 
@@ -70,7 +70,7 @@ async fn standard_tcp_conn(
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
+    let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
     AsyncClient::new(stream, sender, None)
         .await
         .expect("new AsyncClient failed")

--- a/bin/tests/named_tests.rs
+++ b/bin/tests/named_tests.rs
@@ -27,8 +27,7 @@ use trust_dns_client::udp::UdpClientStream;
 // use trust_dns_proto::openssl::TlsClientStreamBuilder;
 
 use server_harness::{named_test_harness, query_a};
-use trust_dns_proto::tcp::TokioTcpConnector;
-use trust_dns_proto::udp::TokioUdpBinder;
+use trust_dns_proto::TokioRuntime;
 
 #[test]
 fn test_example_toml_startup() {
@@ -38,7 +37,7 @@ fn test_example_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -51,7 +50,7 @@ fn test_example_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -69,7 +68,7 @@ fn test_ipv4_only_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -82,7 +81,7 @@ fn test_ipv4_only_toml_startup() {
             Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         assert!(io_loop.block_on(client).is_err());
@@ -132,7 +131,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -144,7 +143,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
             Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -162,7 +161,7 @@ fn test_nodata_where_name_exists() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -187,7 +186,7 @@ fn test_nxdomain_where_no_name_exists() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -212,7 +211,7 @@ fn test_server_continues_on_bad_data_udp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             udp_port.expect("no udp_port"),
         );
-        let stream = UdpClientStream::new(addr, TokioUdpBinder);
+        let stream = UdpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::connect(stream);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -232,7 +231,7 @@ fn test_server_continues_on_bad_data_udp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             udp_port.expect("no udp_port"),
         );
-        let stream = UdpClientStream::new(addr, TokioUdpBinder);
+        let stream = UdpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::connect(stream);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -250,7 +249,7 @@ fn test_server_continues_on_bad_data_tcp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -270,7 +269,7 @@ fn test_server_continues_on_bad_data_tcp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -292,7 +291,7 @@ fn test_forward() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -314,7 +313,7 @@ fn test_forward() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             tcp_port.expect("no tcp_port"),
         );
-        let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+        let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
         let client = AsyncClient::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");

--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -96,7 +96,7 @@ use trust_dns_resolver::AsyncResolver;
 
 pub use crate::runtime::AsyncStdConnection;
 pub use crate::runtime::AsyncStdConnectionProvider;
-use crate::runtime::AsyncStdRuntimeHandle;
+use crate::runtime::AsyncStdRuntime;
 
 mod net;
 mod runtime;
@@ -130,7 +130,7 @@ pub async fn resolver(
     config: config::ResolverConfig,
     options: config::ResolverOpts,
 ) -> Result<AsyncStdResolver, ResolveError> {
-    AsyncStdResolver::new(config, options, AsyncStdRuntimeHandle)
+    AsyncStdResolver::new(config, options, AsyncStdRuntime)
 }
 
 /// Constructs a new async-std based Resolver with the system configuration.
@@ -139,5 +139,5 @@ pub async fn resolver(
 #[cfg(any(unix, target_os = "windows"))]
 #[cfg(feature = "system-config")]
 pub async fn resolver_from_system_conf() -> Result<AsyncStdResolver, ResolveError> {
-    AsyncStdResolver::from_system_conf(AsyncStdRuntimeHandle)
+    AsyncStdResolver::from_system_conf(AsyncStdRuntime)
 }

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::future::FutureExt;
 use pin_utils::pin_mut;
-use trust_dns_resolver::proto::tcp::{Connect, DnsTcpStream};
+use trust_dns_resolver::proto::tcp::DnsTcpStream;
 use trust_dns_resolver::proto::udp::UdpSocket;
 
 use crate::time::AsyncStdTime;
@@ -57,19 +57,10 @@ impl UdpSocket for AsyncStdUdpSocket {
     }
 }
 
-pub struct AsyncStdTcpStream(async_std::net::TcpStream);
+pub struct AsyncStdTcpStream(pub(crate) async_std::net::TcpStream);
 
 impl DnsTcpStream for AsyncStdTcpStream {
     type Time = AsyncStdTime;
-}
-
-#[async_trait]
-impl Connect for AsyncStdTcpStream {
-    async fn connect(addr: SocketAddr) -> io::Result<Self> {
-        let stream = async_std::net::TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
-        Ok(AsyncStdTcpStream(stream))
-    }
 }
 
 impl AsyncWrite for AsyncStdTcpStream {

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -19,17 +19,11 @@ use trust_dns_resolver::proto::udp::UdpSocket;
 
 use crate::time::AsyncStdTime;
 
-pub struct AsyncStdUdpSocket(async_std::net::UdpSocket);
+pub struct AsyncStdUdpSocket(pub(crate) async_std::net::UdpSocket);
 
 #[async_trait]
 impl UdpSocket for AsyncStdUdpSocket {
     type Time = AsyncStdTime;
-
-    async fn bind(addr: SocketAddr) -> io::Result<Self> {
-        async_std::net::UdpSocket::bind(addr)
-            .await
-            .map(AsyncStdUdpSocket)
-    }
 
     fn poll_recv_from(
         &self,

--- a/crates/async-std-resolver/src/runtime.rs
+++ b/crates/async-std-resolver/src/runtime.rs
@@ -8,6 +8,7 @@
 use std::future::Future;
 
 use trust_dns_resolver::proto::error::ProtoError;
+use trust_dns_resolver::proto::tcp::TcpConnector;
 use trust_dns_resolver::proto::udp::UdpSocketBinder;
 use trust_dns_resolver::proto::Executor;
 
@@ -77,6 +78,16 @@ impl UdpSocketBinder for AsyncStdRuntimeHandle {
         async_std::net::UdpSocket::bind(addr)
             .await
             .map(AsyncStdUdpSocket)
+    }
+}
+
+#[async_trait::async_trait]
+impl TcpConnector for AsyncStdRuntimeHandle {
+    type Socket = AsyncStdTcpStream;
+    async fn connect(self, addr: std::net::SocketAddr) -> std::io::Result<Self::Socket> {
+        let stream = async_std::net::TcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        Ok(AsyncStdTcpStream(stream))
     }
 }
 

--- a/crates/async-std-resolver/src/runtime.rs
+++ b/crates/async-std-resolver/src/runtime.rs
@@ -8,6 +8,7 @@
 use std::future::Future;
 
 use trust_dns_resolver::proto::error::ProtoError;
+use trust_dns_resolver::proto::udp::UdpSocketBinder;
 use trust_dns_resolver::proto::Executor;
 
 use trust_dns_resolver::name_server::{
@@ -65,6 +66,17 @@ impl Spawn for AsyncStdRuntimeHandle {
         F: Future<Output = Result<(), ProtoError>> + Send + 'static,
     {
         let _join = async_std::task::spawn(future);
+    }
+}
+
+#[async_trait::async_trait]
+impl UdpSocketBinder for AsyncStdRuntimeHandle {
+    type Socket = AsyncStdUdpSocket;
+    type Time = AsyncStdTime;
+    async fn bind(&self, addr: std::net::SocketAddr) -> std::io::Result<Self::Socket> {
+        async_std::net::UdpSocket::bind(addr)
+            .await
+            .map(AsyncStdUdpSocket)
     }
 }
 

--- a/crates/async-std-resolver/src/runtime.rs
+++ b/crates/async-std-resolver/src/runtime.rs
@@ -64,6 +64,7 @@ impl RuntimeProvider for AsyncStdRuntime {
     type Time = AsyncStdTime;
     type TcpConnection = AsyncStdTcpStream;
 
+    #[inline(always)]
     fn bind_udp(
         &self,
         addr: std::net::SocketAddr,
@@ -75,6 +76,7 @@ impl RuntimeProvider for AsyncStdRuntime {
         })
     }
 
+    #[inline(always)]
     fn connect_tcp(
         &self,
         addr: std::net::SocketAddr,

--- a/crates/async-std-resolver/src/runtime.rs
+++ b/crates/async-std-resolver/src/runtime.rs
@@ -59,16 +59,20 @@ impl Executor for AsyncStdRuntime {
     }
 }
 
-#[async_trait::async_trait]
 impl RuntimeProvider for AsyncStdRuntime {
     type UdpSocket = AsyncStdUdpSocket;
     type Time = AsyncStdTime;
     type TcpConnection = AsyncStdTcpStream;
 
-    async fn bind_udp(&self, addr: std::net::SocketAddr) -> io::Result<Self::UdpSocket> {
-        async_std::net::UdpSocket::bind(addr)
-            .await
-            .map(AsyncStdUdpSocket)
+    fn bind_udp(
+        &self,
+        addr: std::net::SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Self::UdpSocket>> + Send>> {
+        Box::pin(async move {
+            async_std::net::UdpSocket::bind(addr)
+                .await
+                .map(AsyncStdUdpSocket)
+        })
     }
 
     fn connect_tcp(

--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -36,40 +36,35 @@ fn test_send_sync() {
 fn test_lookup_google() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::google(), io_loop, handle)
+    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::google(), io_loop, io_loop)
 }
 
 #[test]
 fn test_lookup_cloudflare() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::cloudflare(), io_loop, handle)
+    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::cloudflare(), io_loop, io_loop)
 }
 
 #[test]
 fn test_lookup_quad9() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::quad9(), io_loop, handle)
+    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::quad9(), io_loop, io_loop)
 }
 
 #[test]
 fn test_ip_lookup() {
     use testing::ip_lookup_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    ip_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle)
+    ip_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop)
 }
 
 #[test]
 fn test_ip_lookup_across_threads() {
     use testing::ip_lookup_across_threads_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    ip_lookup_across_threads_test::<AsyncStdRuntime, AsyncStdRuntime>(handle)
+    ip_lookup_across_threads_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop)
 }
 
 #[test]
@@ -77,8 +72,7 @@ fn test_ip_lookup_across_threads() {
 fn test_sec_lookup() {
     use testing::sec_lookup_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    sec_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    sec_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
@@ -86,8 +80,7 @@ fn test_sec_lookup() {
 fn test_sec_lookup_fails() {
     use testing::sec_lookup_fails_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    sec_lookup_fails_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    sec_lookup_fails_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
@@ -97,8 +90,7 @@ fn test_sec_lookup_fails() {
 fn test_system_lookup() {
     use testing::system_lookup_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    system_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    system_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
@@ -109,94 +101,82 @@ fn test_system_lookup() {
 fn test_hosts_lookup() {
     use testing::hosts_lookup_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    hosts_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    hosts_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_fqdn() {
     use testing::fqdn_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    fqdn_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    fqdn_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_ndots() {
     use testing::ndots_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_large_ndots() {
     use testing::large_ndots_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_domain_search() {
     use testing::domain_search_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    domain_search_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    domain_search_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_search_list() {
     use testing::search_list_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    search_list_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    search_list_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_idna() {
     use testing::idna_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    idna_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    idna_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_localhost_ipv4() {
     use testing::localhost_ipv4_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    localhost_ipv4_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    localhost_ipv4_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_localhost_ipv6() {
     use testing::localhost_ipv6_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    localhost_ipv6_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    localhost_ipv6_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_search_ipv4_large_ndots() {
     use testing::search_ipv4_large_ndots_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    search_ipv4_large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    search_ipv4_large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_search_ipv6_large_ndots() {
     use testing::search_ipv6_large_ndots_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    search_ipv6_large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    search_ipv6_large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }
 
 #[test]
 fn test_search_ipv6_name_parse_fails() {
     use testing::search_ipv6_name_parse_fails_test;
     let io_loop = AsyncStdRuntime::new();
-    let handle = io_loop.handle();
-    search_ipv6_name_parse_fails_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    search_ipv6_name_parse_fails_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, io_loop);
 }

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -624,8 +624,10 @@ fn assert_send_and_sync<T: Send + Sync>() {}
 fn test_sync_client_send_and_sync() {
     use crate::tcp::TcpClientConnection;
     use crate::udp::UdpClientConnection;
-    assert_send_and_sync::<SyncClient<UdpClientConnection>>();
-    assert_send_and_sync::<SyncClient<TcpClientConnection>>();
+    use trust_dns_proto::tcp::TokioTcpConnector;
+    use trust_dns_proto::udp::TokioUdpBinder;
+    assert_send_and_sync::<SyncClient<UdpClientConnection<TokioUdpBinder>>>();
+    assert_send_and_sync::<SyncClient<TcpClientConnection<TokioTcpConnector>>>();
 }
 
 #[test]
@@ -633,6 +635,8 @@ fn test_sync_client_send_and_sync() {
 fn test_secure_client_send_and_sync() {
     use crate::tcp::TcpClientConnection;
     use crate::udp::UdpClientConnection;
-    assert_send_and_sync::<SyncDnssecClient<UdpClientConnection>>();
-    assert_send_and_sync::<SyncDnssecClient<TcpClientConnection>>();
+    use trust_dns_proto::tcp::TokioTcpConnector;
+    use trust_dns_proto::udp::TokioUdpBinder;
+    assert_send_and_sync::<SyncDnssecClient<UdpClientConnection<TokioUdpBinder>>>();
+    assert_send_and_sync::<SyncDnssecClient<TcpClientConnection<TokioTcpConnector>>>();
 }

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -624,10 +624,9 @@ fn assert_send_and_sync<T: Send + Sync>() {}
 fn test_sync_client_send_and_sync() {
     use crate::tcp::TcpClientConnection;
     use crate::udp::UdpClientConnection;
-    use trust_dns_proto::tcp::TokioTcpConnector;
-    use trust_dns_proto::udp::TokioUdpBinder;
-    assert_send_and_sync::<SyncClient<UdpClientConnection<TokioUdpBinder>>>();
-    assert_send_and_sync::<SyncClient<TcpClientConnection<TokioTcpConnector>>>();
+    use trust_dns_proto::TokioRuntime;
+    assert_send_and_sync::<SyncClient<UdpClientConnection<TokioRuntime>>>();
+    assert_send_and_sync::<SyncClient<TcpClientConnection<TokioRuntime>>>();
 }
 
 #[test]
@@ -635,8 +634,7 @@ fn test_sync_client_send_and_sync() {
 fn test_secure_client_send_and_sync() {
     use crate::tcp::TcpClientConnection;
     use crate::udp::UdpClientConnection;
-    use trust_dns_proto::tcp::TokioTcpConnector;
-    use trust_dns_proto::udp::TokioUdpBinder;
-    assert_send_and_sync::<SyncDnssecClient<UdpClientConnection<TokioUdpBinder>>>();
-    assert_send_and_sync::<SyncDnssecClient<TcpClientConnection<TokioTcpConnector>>>();
+    use trust_dns_proto::TokioRuntime;
+    assert_send_and_sync::<SyncDnssecClient<UdpClientConnection<TokioRuntime>>>();
+    assert_send_and_sync::<SyncDnssecClient<TcpClientConnection<TokioRuntime>>>();
 }

--- a/crates/client/src/https_client_connection.rs
+++ b/crates/client/src/https_client_connection.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use rustls::ClientConfig;
 use trust_dns_proto::https::{HttpsClientConnect, HttpsClientStream, HttpsClientStreamBuilder};
-use trust_dns_proto::tcp::TcpConnector;
+use trust_dns_proto::RuntimeProvider;
 
 use crate::client::{ClientConnection, Signer};
 
@@ -27,8 +27,8 @@ pub struct HttpsClientConnection<T> {
     connector: T,
 }
 
-impl<T: TcpConnector> HttpsClientConnection<T> {
-    /// Creates a new client connection.
+impl<T: RuntimeProvider> HttpsClientConnection<T> {
+    /// Creates a new client connection with runtime provider.
     ///
     /// *Note* this has side affects of starting the listening event_loop. Expect this to change in
     /// the future.
@@ -56,7 +56,7 @@ impl<T: TcpConnector> HttpsClientConnection<T> {
 
 impl<T> ClientConnection for HttpsClientConnection<T>
 where
-    T: TcpConnector,
+    T: RuntimeProvider,
 {
     type Sender = HttpsClientStream;
     type SenderFuture = HttpsClientConnect<T>;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -78,12 +78,12 @@
 //! ## Setup a connection
 //!
 //! ```rust
-//! use trust_dns_proto::DnsStreamHandle;
+//! use trust_dns_client::proto::{DnsStreamHandle, udp::TokioUdpBinder};
 //! use trust_dns_client::client::{Client, ClientConnection, SyncClient};
 //! use trust_dns_client::udp::UdpClientConnection;
 //!
 //! let address = "8.8.8.8:53".parse().unwrap();
-//! let conn = UdpClientConnection::new(address).unwrap();
+//! let conn = UdpClientConnection::new(address, TokioUdpBinder).unwrap();
 //!
 //! // and then create the Client
 //! let client = SyncClient::new(conn);
@@ -100,11 +100,12 @@
 //! use std::str::FromStr;
 //! # use trust_dns_client::client::{Client, SyncClient};
 //! # use trust_dns_client::udp::UdpClientConnection;
+//! # use trust_dns_client::proto::udp::TokioUdpBinder;
 //! use trust_dns_client::op::DnsResponse;
 //! use trust_dns_client::rr::{DNSClass, Name, RData, Record, RecordType};
 //! #
 //! # let address = "8.8.8.8:53".parse().unwrap();
-//! # let conn = UdpClientConnection::new(address).unwrap();
+//! # let conn = UdpClientConnection::new(address, TokioUdpBinder).unwrap();
 //! # let client = SyncClient::new(conn);
 //!
 //! // Specify the name, note the final '.' which specifies it's an FQDN
@@ -154,13 +155,14 @@
 //! use openssl::rsa::Rsa;
 //! use trust_dns_client::client::{Client, SyncClient};
 //! use trust_dns_client::udp::UdpClientConnection;
+//! use trust_dns_client::proto::udp::TokioUdpBinder;
 //! use trust_dns_client::rr::{Name, RData, Record, RecordType};
 //! use trust_dns_client::rr::dnssec::{Algorithm, SigSigner, KeyPair};
 //! use trust_dns_client::op::ResponseCode;
 //! use trust_dns_client::rr::rdata::key::KEY;
 //!
 //! # let address = "0.0.0.0:53".parse().unwrap();
-//! # let conn = UdpClientConnection::new(address).unwrap();
+//! # let conn = UdpClientConnection::new(address, TokioUdpBinder).unwrap();
 //!
 //! // The format of the key is dependent on the KeyPair type, in this example we're using RSA
 //! //  if the key was generated with BIND, the binary in Trust-DNS client lib `dnskey-to-pem`

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -228,7 +228,7 @@
 //! use std::str::FromStr;
 //! use tokio::net::TcpStream as TokioTcpStream;
 //! use trust_dns_client::client::{AsyncClient, ClientHandle};
-//! use trust_dns_client::proto::iocompat::AsyncIoTokioAsStd;
+//! use trust_dns_client::proto::{iocompat::AsyncIoTokioAsStd, tcp::TokioTcpConnector};
 //! use trust_dns_client::rr::{DNSClass, Name, RData, RecordType};
 //! use trust_dns_client::tcp::TcpClientStream;
 //!
@@ -236,7 +236,7 @@
 //! async fn main() {
 //!     // Since we used UDP in the previous examples, let's change things up a bit and use TCP here
 //!     let (stream, sender) =
-//!         TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(([8, 8, 8, 8], 53).into());
+//!         TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(([8, 8, 8, 8], 53).into(), TokioTcpConnector);
 //!
 //!     // Create a new client, the bg is a background future which handles
 //!     //   the multiplexing of the DNS requests to the server.

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -78,12 +78,12 @@
 //! ## Setup a connection
 //!
 //! ```rust
-//! use trust_dns_client::proto::{DnsStreamHandle, udp::TokioUdpBinder};
+//! use trust_dns_client::proto::{DnsStreamHandle, TokioRuntime};
 //! use trust_dns_client::client::{Client, ClientConnection, SyncClient};
 //! use trust_dns_client::udp::UdpClientConnection;
 //!
 //! let address = "8.8.8.8:53".parse().unwrap();
-//! let conn = UdpClientConnection::new(address, TokioUdpBinder).unwrap();
+//! let conn = UdpClientConnection::new(address, TokioRuntime).unwrap();
 //!
 //! // and then create the Client
 //! let client = SyncClient::new(conn);
@@ -100,12 +100,12 @@
 //! use std::str::FromStr;
 //! # use trust_dns_client::client::{Client, SyncClient};
 //! # use trust_dns_client::udp::UdpClientConnection;
-//! # use trust_dns_client::proto::udp::TokioUdpBinder;
+//! # use trust_dns_client::proto::TokioRuntime;
 //! use trust_dns_client::op::DnsResponse;
 //! use trust_dns_client::rr::{DNSClass, Name, RData, Record, RecordType};
 //! #
 //! # let address = "8.8.8.8:53".parse().unwrap();
-//! # let conn = UdpClientConnection::new(address, TokioUdpBinder).unwrap();
+//! # let conn = UdpClientConnection::new(address, TokioRuntime).unwrap();
 //! # let client = SyncClient::new(conn);
 //!
 //! // Specify the name, note the final '.' which specifies it's an FQDN
@@ -155,14 +155,14 @@
 //! use openssl::rsa::Rsa;
 //! use trust_dns_client::client::{Client, SyncClient};
 //! use trust_dns_client::udp::UdpClientConnection;
-//! use trust_dns_client::proto::udp::TokioUdpBinder;
+//! use trust_dns_client::proto::TokioRuntime;
 //! use trust_dns_client::rr::{Name, RData, Record, RecordType};
 //! use trust_dns_client::rr::dnssec::{Algorithm, SigSigner, KeyPair};
 //! use trust_dns_client::op::ResponseCode;
 //! use trust_dns_client::rr::rdata::key::KEY;
 //!
 //! # let address = "0.0.0.0:53".parse().unwrap();
-//! # let conn = UdpClientConnection::new(address, TokioUdpBinder).unwrap();
+//! # let conn = UdpClientConnection::new(address, TokioRuntime).unwrap();
 //!
 //! // The format of the key is dependent on the KeyPair type, in this example we're using RSA
 //! //  if the key was generated with BIND, the binary in Trust-DNS client lib `dnskey-to-pem`
@@ -228,7 +228,7 @@
 //! use std::str::FromStr;
 //! use tokio::net::TcpStream as TokioTcpStream;
 //! use trust_dns_client::client::{AsyncClient, ClientHandle};
-//! use trust_dns_client::proto::{iocompat::AsyncIoTokioAsStd, tcp::TokioTcpConnector};
+//! use trust_dns_client::proto::{iocompat::AsyncIoTokioAsStd, TokioRuntime};
 //! use trust_dns_client::rr::{DNSClass, Name, RData, RecordType};
 //! use trust_dns_client::tcp::TcpClientStream;
 //!
@@ -236,7 +236,7 @@
 //! async fn main() {
 //!     // Since we used UDP in the previous examples, let's change things up a bit and use TCP here
 //!     let (stream, sender) =
-//!         TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(([8, 8, 8, 8], 53).into(), TokioTcpConnector);
+//!         TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(([8, 8, 8, 8], 53).into(), TokioRuntime);
 //!
 //!     // Create a new client, the bg is a background future which handles
 //!     //   the multiplexing of the DNS requests to the server.

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -252,6 +252,7 @@ pub enum ProtoErrorKind {
 
 /// The error type for errors that get returned in the crate
 #[derive(Error, Clone, Debug)]
+// TODO: Should this not be removed?
 #[non_exhaustive]
 pub struct ProtoError {
     /// Kind of error that ocurred

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -142,6 +142,31 @@ pub mod iocompat {
         }
     }
 
+    impl<W: TokioAsyncRead + TokioAsyncWrite + Unpin> TokioAsyncWrite for AsyncIoTokioAsStd<W> {
+        fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.0).poll_shutdown(cx)
+        }
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.0).poll_flush(cx)
+        }
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+    }
+    impl<W: TokioAsyncRead + TokioAsyncWrite + Unpin> TokioAsyncRead for AsyncIoTokioAsStd<W> {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.0).poll_read(cx, buf)
+        }
+    }
+
     /// Conversion from `std::io::{AsyncRead, AsyncWrite}` to `tokio::io::{AsyncRead, AsyncWrite}`
     pub struct AsyncIoStdAsTokio<T: AsyncRead + AsyncWrite>(pub T);
 

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -84,6 +84,12 @@ pub mod tests;
 pub mod udp;
 pub mod xfer;
 
+pub mod runtime_provider;
+
+pub use runtime_provider::RuntimeProvider;
+#[cfg(feature = "tokio-runtime")]
+pub use runtime_provider::TokioRuntime;
+
 #[doc(hidden)]
 pub use crate::xfer::dns_handle::{DnsHandle, DnsStreamHandle};
 #[doc(hidden)]

--- a/crates/proto/src/native_tls/tests.rs
+++ b/crates/proto/src/native_tls/tests.rs
@@ -26,14 +26,13 @@ use std::{thread, time};
 use futures_util::stream::StreamExt;
 use native_tls;
 use native_tls::{Certificate, TlsAcceptor};
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 
 #[allow(clippy::useless_attribute)]
 #[allow(unused)]
 use crate::native_tls::{TlsStream, TlsStreamBuilder};
-use crate::tcp::TokioTcpConnector;
 use crate::xfer::SerialMessage;
+use crate::TokioRuntime;
 use crate::{iocompat::AsyncIoTokioAsStd, DnsStreamHandle};
 
 // this fails on linux for some reason. It appears that a buffer somewhere is dirty
@@ -195,7 +194,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     let trust_chain = Certificate::from_der(&root_cert_der).unwrap();
 
     // barrier.wait();
-    let mut builder = TlsStreamBuilder::<TokioTcpConnector>::new(Default::default());
+    let mut builder = TlsStreamBuilder::<TokioRuntime>::new(Default::default());
     builder.add_ca(trust_chain);
 
     // fix MTLS

--- a/crates/proto/src/native_tls/tests.rs
+++ b/crates/proto/src/native_tls/tests.rs
@@ -32,6 +32,7 @@ use tokio::runtime::Runtime;
 #[allow(clippy::useless_attribute)]
 #[allow(unused)]
 use crate::native_tls::{TlsStream, TlsStreamBuilder};
+use crate::tcp::TokioTcpConnector;
 use crate::xfer::SerialMessage;
 use crate::{iocompat::AsyncIoTokioAsStd, DnsStreamHandle};
 
@@ -194,7 +195,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     let trust_chain = Certificate::from_der(&root_cert_der).unwrap();
 
     // barrier.wait();
-    let mut builder = TlsStreamBuilder::<AsyncIoTokioAsStd<TokioTcpStream>>::new();
+    let mut builder = TlsStreamBuilder::<TokioTcpConnector>::new(Default::default());
     builder.add_ca(trust_chain);
 
     // fix MTLS

--- a/crates/proto/src/runtime_provider.rs
+++ b/crates/proto/src/runtime_provider.rs
@@ -49,6 +49,7 @@ mod tokio_runtime {
         type UdpSocket = tokio::net::UdpSocket;
         type TcpConnection = AsyncIoTokioAsStd<tokio::net::TcpStream>;
 
+        #[inline(always)]
         fn bind_udp(
             &self,
             addr: std::net::SocketAddr,

--- a/crates/proto/src/runtime_provider.rs
+++ b/crates/proto/src/runtime_provider.rs
@@ -1,0 +1,72 @@
+//! Runtime abstraction component for DNS clients
+use crate::{error::ProtoError, tcp::DnsTcpStream, udp::UdpSocket, Time};
+use std::{future::Future, io, net::SocketAddr, pin::Pin};
+
+/// RuntimeProvider defines which async runtime that handles IO and timers.
+#[async_trait::async_trait]
+pub trait RuntimeProvider: Clone + 'static + Send + Sync + Unpin {
+    /// Time implementation used for this type
+    type Time: Time + Unpin + Send;
+    /// Type of socket that would be bound by the trait implementation. E.g. for tokio, it would be
+    /// `tokio::net::UdpSocket`.
+    type UdpSocket: UdpSocket + Send + 'static;
+
+    /// A succesfully established TCP connection.
+    type TcpConnection: DnsTcpStream;
+
+    /// Bind an UDP socket to the given socket address.
+    async fn bind_udp(&self, addr: SocketAddr) -> io::Result<Self::UdpSocket>;
+
+    /// Create a socket and connect to the specified socket address.
+    fn connect_tcp(
+        &self,
+        addr: SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Self::TcpConnection>> + Send>>;
+
+    /// Spawn a future on the given runtime.
+    fn spawn_bg<F>(&self, future: F)
+    where
+        F: Future<Output = Result<(), ProtoError>> + Send + 'static;
+}
+
+#[cfg(feature = "tokio-runtime")]
+pub use tokio_runtime::TokioRuntime;
+
+#[cfg(feature = "tokio-runtime")]
+mod tokio_runtime {
+    use super::*;
+    use crate::iocompat::AsyncIoTokioAsStd;
+
+    /// An implementation of a runtime provider using the tokio runtime.
+    #[derive(Clone, Default, Copy)]
+    pub struct TokioRuntime;
+
+    #[async_trait::async_trait]
+    impl RuntimeProvider for TokioRuntime {
+        type Time = crate::TokioTime;
+        type UdpSocket = tokio::net::UdpSocket;
+        type TcpConnection = AsyncIoTokioAsStd<tokio::net::TcpStream>;
+
+        async fn bind_udp(&self, addr: std::net::SocketAddr) -> std::io::Result<Self::UdpSocket> {
+            tokio::net::UdpSocket::bind(addr).await
+        }
+
+        fn connect_tcp(
+            &self,
+            addr: std::net::SocketAddr,
+        ) -> Pin<Box<dyn Future<Output = io::Result<Self::TcpConnection>> + Send>> {
+            Box::pin(async move {
+                tokio::net::TcpStream::connect(addr)
+                    .await
+                    .map(AsyncIoTokioAsStd)
+            })
+        }
+
+        fn spawn_bg<F>(&self, future: F)
+        where
+            F: Future<Output = Result<(), ProtoError>> + Send + 'static,
+        {
+            let _join = tokio::spawn(future);
+        }
+    }
+}

--- a/crates/proto/src/rustls/tests.rs
+++ b/crates/proto/src/rustls/tests.rs
@@ -25,12 +25,12 @@ use openssl::x509::*;
 
 use futures_util::stream::StreamExt;
 use rustls::ClientConfig;
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 
 use crate::rustls::tls_connect;
+use crate::tcp::TokioTcpConnector;
 use crate::xfer::SerialMessage;
-use crate::{iocompat::AsyncIoTokioAsStd, DnsStreamHandle};
+use crate::DnsStreamHandle;
 
 // this fails on linux for some reason. It appears that a buffer somewhere is dirty
 //  and subsequent reads of a message buffer reads the wrong length. It works for 2 iterations
@@ -214,10 +214,11 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     //     config_mtls(&root_pkey, &root_name, &root_cert, &mut builder);
     // }
 
-    let (stream, mut sender) = tls_connect::<AsyncIoTokioAsStd<TokioTcpStream>>(
+    let (stream, mut sender) = tls_connect::<TokioTcpConnector>(
         server_addr,
         dns_name.to_string(),
         Arc::new(config),
+        TokioTcpConnector,
     );
 
     // TODO: there is a race failure here... a race with the server thread most likely...

--- a/crates/proto/src/rustls/tests.rs
+++ b/crates/proto/src/rustls/tests.rs
@@ -28,9 +28,9 @@ use rustls::ClientConfig;
 use tokio::runtime::Runtime;
 
 use crate::rustls::tls_connect;
-use crate::tcp::TokioTcpConnector;
 use crate::xfer::SerialMessage;
 use crate::DnsStreamHandle;
+use crate::TokioRuntime;
 
 // this fails on linux for some reason. It appears that a buffer somewhere is dirty
 //  and subsequent reads of a message buffer reads the wrong length. It works for 2 iterations
@@ -214,11 +214,11 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     //     config_mtls(&root_pkey, &root_name, &root_cert, &mut builder);
     // }
 
-    let (stream, mut sender) = tls_connect::<TokioTcpConnector>(
+    let (stream, mut sender) = tls_connect::<TokioRuntime>(
         server_addr,
         dns_name.to_string(),
         Arc::new(config),
-        TokioTcpConnector,
+        TokioRuntime,
     );
 
     // TODO: there is a race failure here... a race with the server thread most likely...

--- a/crates/proto/src/tcp/mod.rs
+++ b/crates/proto/src/tcp/mod.rs
@@ -19,7 +19,9 @@ mod tcp_client_stream;
 mod tcp_stream;
 
 pub use self::tcp_client_stream::{TcpClientConnect, TcpClientStream};
-pub use self::tcp_stream::{Connect, DnsTcpStream, TcpStream};
+#[cfg(feature = "tokio-runtime")]
+pub use self::tcp_stream::TokioTcpConnector;
+pub use self::tcp_stream::{DnsTcpStream, TcpConnector, TcpStream};
 
 #[cfg(feature = "tokio-runtime")]
 #[doc(hidden)]

--- a/crates/proto/src/tcp/mod.rs
+++ b/crates/proto/src/tcp/mod.rs
@@ -19,9 +19,7 @@ mod tcp_client_stream;
 mod tcp_stream;
 
 pub use self::tcp_client_stream::{TcpClientConnect, TcpClientStream};
-#[cfg(feature = "tokio-runtime")]
-pub use self::tcp_stream::TokioTcpConnector;
-pub use self::tcp_stream::{DnsTcpStream, TcpConnector, TcpStream};
+pub use self::tcp_stream::{DnsTcpStream, TcpStream};
 
 #[cfg(feature = "tokio-runtime")]
 #[doc(hidden)]

--- a/crates/proto/src/tests/tcp.rs
+++ b/crates/proto/src/tests/tcp.rs
@@ -5,10 +5,10 @@ use std::sync::{atomic::AtomicBool, Arc};
 use futures_util::stream::StreamExt;
 
 use crate::error::ProtoError;
-use crate::tcp::{TcpClientStream, TcpConnector, TcpStream};
+use crate::tcp::{TcpClientStream, TcpStream};
 use crate::xfer::dns_handle::DnsStreamHandle;
 use crate::xfer::SerialMessage;
-use crate::{Executor, Time};
+use crate::{Executor, RuntimeProvider, Time};
 
 const TEST_BYTES: &[u8; 8] = b"DEADBEEF";
 const TEST_BYTES_LEN: usize = 8;
@@ -85,10 +85,10 @@ fn tcp_server_setup(
 }
 
 /// Test tcp_stream.
-pub fn tcp_stream_test<S: TcpConnector, E: Executor, TE: Time>(
+pub fn tcp_stream_test<R: RuntimeProvider, E: Executor, TE: Time>(
     server_addr: IpAddr,
     mut exec: E,
-    connector: S,
+    runtime: R,
 ) {
     let (succeeded, server_handle, server_addr) =
         tcp_server_setup("test_tcp_stream:server", server_addr);
@@ -98,7 +98,8 @@ pub fn tcp_stream_test<S: TcpConnector, E: Executor, TE: Time>(
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5));
-    let (stream, mut sender) = TcpStream::<S::Socket>::new::<S, ProtoError>(server_addr, connector);
+    let (stream, mut sender) =
+        TcpStream::<R::TcpConnection>::new::<R, ProtoError>(server_addr, runtime);
 
     let mut stream = exec.block_on(stream).expect("run failed to get stream");
 
@@ -121,10 +122,10 @@ pub fn tcp_stream_test<S: TcpConnector, E: Executor, TE: Time>(
 }
 
 /// Test tcp_client_stream.
-pub fn tcp_client_stream_test<S: TcpConnector, E: Executor, TE: Time + 'static>(
+pub fn tcp_client_stream_test<R: RuntimeProvider, E: Executor, TE: Time + 'static>(
     server_addr: IpAddr,
     mut exec: E,
-    connector: S,
+    runtime: R,
 ) {
     let (succeeded, server_handle, server_addr) =
         tcp_server_setup("test_tcp_client_stream:server", server_addr);
@@ -134,7 +135,7 @@ pub fn tcp_client_stream_test<S: TcpConnector, E: Executor, TE: Time + 'static>(
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5));
-    let (stream, mut sender) = TcpClientStream::<S::Socket>::new(server_addr, connector);
+    let (stream, mut sender) = TcpClientStream::<R::TcpConnection>::new(server_addr, runtime);
 
     let mut stream = exec.block_on(stream).expect("run failed to get stream");
 

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -12,7 +12,7 @@ use crate::{Executor, Time};
 pub fn next_random_socket_test<S: UdpSocketBinder + Default + Send + 'static, E: Executor>(
     mut exec: E,
 ) {
-    let (stream, _) = UdpStream::<S::Socket>::with_binder::<S>(
+    let (stream, _) = UdpStream::with_binder::<S>(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 52),
         Default::default(),
     );

--- a/crates/proto/src/udp/mod.rs
+++ b/crates/proto/src/udp/mod.rs
@@ -20,6 +20,4 @@ mod udp_client_stream;
 mod udp_stream;
 
 pub use self::udp_client_stream::{UdpClientConnect, UdpClientStream};
-pub use self::udp_stream::{UdpSocket, UdpSocketBinder, UdpStream};
-#[cfg(feature = "tokio-runtime")]
-pub use udp_stream::TokioUdpBinder;
+pub use self::udp_stream::{UdpSocket, UdpStream};

--- a/crates/proto/src/udp/mod.rs
+++ b/crates/proto/src/udp/mod.rs
@@ -20,4 +20,6 @@ mod udp_client_stream;
 mod udp_stream;
 
 pub use self::udp_client_stream::{UdpClientConnect, UdpClientStream};
-pub use self::udp_stream::{UdpSocket, UdpStream};
+pub use self::udp_stream::{UdpSocket, UdpSocketBinder, UdpStream};
+#[cfg(feature = "tokio-runtime")]
+pub use udp_stream::TokioUdpBinder;

--- a/crates/proto/tests/openssl_tests.rs
+++ b/crates/proto/tests/openssl_tests.rs
@@ -31,9 +31,9 @@ use openssl::pkcs12::*;
 use openssl::rsa::*;
 use openssl::x509::extension::*;
 
-use trust_dns_proto::tcp::{TcpConnector, TokioTcpConnector};
 use trust_dns_proto::xfer::SerialMessage;
 use trust_dns_proto::DnsStreamHandle;
+use trust_dns_proto::{RuntimeProvider, TokioRuntime};
 
 use trust_dns_proto::openssl::TlsStreamBuilder;
 
@@ -202,7 +202,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     let trust_chain = X509::from_der(&root_cert_der).unwrap();
 
     // barrier.wait();
-    let mut builder = TlsStreamBuilder::new(TokioTcpConnector);
+    let mut builder = TlsStreamBuilder::new(TokioRuntime);
     builder.add_ca(trust_chain);
 
     if mtls {
@@ -232,7 +232,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
 }
 
 #[allow(unused_variables)]
-fn config_mtls<T: TcpConnector>(
+fn config_mtls<T: RuntimeProvider>(
     root_pkey: &PKey<Private>,
     root_name: &X509Name,
     root_cert: &X509,

--- a/crates/proto/tests/openssl_tests.rs
+++ b/crates/proto/tests/openssl_tests.rs
@@ -21,7 +21,6 @@ use openssl::pkey::*;
 use openssl::ssl::*;
 use openssl::x509::store::X509StoreBuilder;
 use openssl::x509::*;
-use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 
 use openssl::asn1::*;
@@ -32,9 +31,9 @@ use openssl::pkcs12::*;
 use openssl::rsa::*;
 use openssl::x509::extension::*;
 
-use trust_dns_proto::tcp::Connect;
+use trust_dns_proto::tcp::{TcpConnector, TokioTcpConnector};
 use trust_dns_proto::xfer::SerialMessage;
-use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, DnsStreamHandle};
+use trust_dns_proto::DnsStreamHandle;
 
 use trust_dns_proto::openssl::TlsStreamBuilder;
 
@@ -203,7 +202,7 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
     let trust_chain = X509::from_der(&root_cert_der).unwrap();
 
     // barrier.wait();
-    let mut builder = TlsStreamBuilder::<AsyncIoTokioAsStd<TokioTcpStream>>::new();
+    let mut builder = TlsStreamBuilder::new(TokioTcpConnector);
     builder.add_ca(trust_chain);
 
     if mtls {
@@ -233,11 +232,11 @@ fn tls_client_stream_test(server_addr: IpAddr, mtls: bool) {
 }
 
 #[allow(unused_variables)]
-fn config_mtls<S: Connect>(
+fn config_mtls<T: TcpConnector>(
     root_pkey: &PKey<Private>,
     root_name: &X509Name,
     root_cert: &X509,
-    builder: &mut TlsStreamBuilder<S>,
+    builder: &mut TlsStreamBuilder<T>,
 ) {
     #[cfg(feature = "mtls")]
     {

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -67,6 +67,7 @@ name = "trust_dns_resolver"
 path = "src/lib.rs"
 
 [dependencies]
+async-trait = "0.1.42"
 cfg-if = "1.0.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 lazy_static = "1.0"

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -15,7 +15,7 @@ use futures_util::future;
 #[cfg(feature = "tokio-runtime")]
 use trust_dns_resolver::{IntoName, TryParseIp};
 #[cfg(feature = "tokio-runtime")]
-use trust_dns_resolver::{TokioAsyncResolver, TokioHandle};
+use trust_dns_resolver::{TokioAsyncResolver, TokioRuntime};
 
 // This is an example of registering a static global resolver into any system.
 //
@@ -51,7 +51,7 @@ lazy_static! {
                 #[cfg(any(unix, windows))]
                 {
                     // use the system resolver configuration
-                    TokioAsyncResolver::from_system_conf(TokioHandle)
+                    TokioAsyncResolver::from_system_conf(TokioRuntime)
                 }
 
                 // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "tokio-runtime")]
 fn main() {
     use tokio::runtime::Runtime;
-    use trust_dns_resolver::{TokioAsyncResolver, TokioHandle};
+    use trust_dns_resolver::{TokioAsyncResolver, TokioRuntime};
 
     env_logger::init();
 
@@ -18,7 +18,7 @@ fn main() {
         #[cfg(any(unix, windows))]
         {
             // use the system resolver configuration
-            TokioAsyncResolver::from_system_conf(TokioHandle)
+            TokioAsyncResolver::from_system_conf(TokioRuntime)
         }
 
         // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -14,8 +14,8 @@ pub(crate) fn new_https_stream<R>(
     socket_addr: SocketAddr,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
-    handle: R::Handle,
-) -> DnsExchangeConnect<HttpsClientConnect<R::Handle>, HttpsClientStream, TokioTime>
+    handle: R,
+) -> DnsExchangeConnect<HttpsClientConnect<R>, HttpsClientStream, TokioTime>
 where
     R: RuntimeProvider,
 {
@@ -35,7 +35,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::{TokioAsyncResolver, TokioHandle};
+    use crate::{TokioAsyncResolver, TokioRuntime};
 
     fn https_test(config: ResolverConfig) {
         let io_loop = Runtime::new().unwrap();
@@ -46,7 +46,7 @@ mod tests {
                 try_tcp_on_error: true,
                 ..Default::default()
             },
-            TokioHandle,
+            TokioRuntime,
         )
         .expect("failed to create resolver");
 

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -14,7 +14,8 @@ pub(crate) fn new_https_stream<R>(
     socket_addr: SocketAddr,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
-) -> DnsExchangeConnect<HttpsClientConnect<R::Tcp>, HttpsClientStream, TokioTime>
+    handle: R::Handle,
+) -> DnsExchangeConnect<HttpsClientConnect<R::Handle>, HttpsClientStream, TokioTime>
 where
     R: RuntimeProvider,
 {
@@ -23,8 +24,8 @@ where
         |TlsClientConfig(client_config)| client_config,
     );
 
-    let https_builder = HttpsClientStreamBuilder::with_client_config(client_config);
-    DnsExchange::connect(https_builder.build::<R::Tcp>(socket_addr, dns_name))
+    let https_builder = HttpsClientStreamBuilder::with_client_config(handle, client_config);
+    DnsExchange::connect(https_builder.build(socket_addr, dns_name))
 }
 
 #[cfg(test)]

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -288,7 +288,7 @@ pub use hosts::Hosts;
 pub use name_server::ConnectionProvider;
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
-pub use name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
+pub use name_server::{TokioConnection, TokioConnectionProvider, TokioRuntime};
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
 pub use resolver::Resolver;

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -12,7 +12,8 @@ mod name_server_pool;
 mod name_server_state;
 mod name_server_stats;
 
-pub use self::connection_provider::{ConnectionProvider, RuntimeProvider, Spawn};
+//TODO: Stop exposing RuntimeProvider here
+pub use self::connection_provider::{ConnectionProvider, Spawn};
 pub use self::connection_provider::{GenericConnection, GenericConnectionProvider};
 #[cfg(feature = "mdns")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
@@ -21,9 +22,11 @@ pub use self::name_server::NameServer;
 pub use self::name_server_pool::NameServerPool;
 use self::name_server_state::NameServerState;
 use self::name_server_stats::NameServerStats;
+pub use crate::proto::RuntimeProvider;
 
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
-pub use self::connection_provider::tokio_runtime::{
-    TokioConnection, TokioConnectionProvider, TokioHandle, TokioRuntime,
-};
+pub use self::connection_provider::tokio_runtime::{TokioConnection, TokioConnectionProvider};
+#[cfg(feature = "tokio-runtime")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
+pub use crate::proto::TokioRuntime;

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -24,7 +24,7 @@ use crate::config::{NameServerConfig, ResolverOpts};
 use crate::error::ResolveError;
 use crate::name_server::{ConnectionProvider, NameServerState, NameServerStats};
 #[cfg(feature = "tokio-runtime")]
-use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
+use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioRuntime};
 
 /// Specifies the details of a remote NameServer used for lookups
 #[derive(Clone)]
@@ -51,7 +51,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> Debug
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
 impl NameServer<TokioConnection, TokioConnectionProvider> {
-    pub fn new(config: NameServerConfig, options: ResolverOpts, runtime: TokioHandle) -> Self {
+    pub fn new(config: NameServerConfig, options: ResolverOpts, runtime: TokioRuntime) -> Self {
         Self::new_with_provider(config, options, TokioConnectionProvider::new(runtime))
     }
 }
@@ -286,7 +286,7 @@ mod tests {
             tls_config: None,
         };
         let io_loop = Runtime::new().unwrap();
-        let runtime_handle = TokioHandle;
+        let runtime_handle = TokioRuntime;
         let name_server = future::lazy(|_| {
             NameServer::<_, TokioConnectionProvider>::new(
                 config,
@@ -324,7 +324,7 @@ mod tests {
             tls_config: None,
         };
         let io_loop = Runtime::new().unwrap();
-        let runtime_handle = TokioHandle;
+        let runtime_handle = TokioRuntime;
         let name_server = future::lazy(|_| {
             NameServer::<_, TokioConnectionProvider>::new(config, options, runtime_handle)
         });

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -25,7 +25,7 @@ use crate::name_server;
 use crate::name_server::{ConnectionProvider, NameServer};
 #[cfg(test)]
 #[cfg(feature = "tokio-runtime")]
-use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
+use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioRuntime};
 
 /// A pool of NameServers
 ///
@@ -49,7 +49,7 @@ impl NameServerPool<TokioConnection, TokioConnectionProvider> {
     pub(crate) fn from_config(
         config: &ResolverConfig,
         options: &ResolverOpts,
-        runtime: TokioHandle,
+        runtime: TokioRuntime,
     ) -> Self {
         Self::from_config_with_provider(config, options, TokioConnectionProvider::new(runtime))
     }
@@ -467,7 +467,7 @@ mod tests {
         let mut pool = NameServerPool::<_, TokioConnectionProvider>::from_config(
             &resolver_config,
             &ResolverOpts::default(),
-            TokioHandle,
+            TokioRuntime,
         );
 
         let name = Name::parse("www.example.com.", None).unwrap();
@@ -511,7 +511,7 @@ mod tests {
         env_logger::try_init().ok();
 
         let io_loop = Runtime::new().unwrap();
-        let conn_provider = TokioConnectionProvider::new(TokioHandle);
+        let conn_provider = TokioConnectionProvider::new(TokioRuntime);
 
         let tcp = NameServerConfig {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -20,7 +20,7 @@ use crate::error::*;
 use crate::lookup;
 use crate::lookup::Lookup;
 use crate::lookup_ip::LookupIp;
-use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
+use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioRuntime};
 use crate::AsyncResolver;
 
 /// The Resolver is used for performing DNS queries.
@@ -81,7 +81,7 @@ impl Resolver {
 
         let runtime = builder.build()?;
         let async_resolver =
-            AsyncResolver::new(config, options, TokioHandle).expect("failed to create resolver");
+            AsyncResolver::new(config, options, TokioRuntime).expect("failed to create resolver");
 
         Ok(Resolver {
             runtime: Mutex::new(runtime),

--- a/crates/resolver/src/tls/dns_over_native_tls.rs
+++ b/crates/resolver/src/tls/dns_over_native_tls.rs
@@ -23,10 +23,11 @@ use crate::name_server::RuntimeProvider;
 pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
     dns_name: String,
+    connector: R::Handle,
 ) -> (
     Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
-    let tls_builder = TlsClientStreamBuilder::new();
+    let tls_builder = TlsClientStreamBuilder::new(connector);
     tls_builder.build(socket_addr, dns_name)
 }

--- a/crates/resolver/src/tls/dns_over_native_tls.rs
+++ b/crates/resolver/src/tls/dns_over_native_tls.rs
@@ -16,18 +16,17 @@ use futures_util::future::Future;
 use proto::error::ProtoError;
 use proto::native_tls::{TlsClientStream, TlsClientStreamBuilder};
 use proto::BufDnsStreamHandle;
-
-use crate::name_server::RuntimeProvider;
+use proto::RuntimeProvider;
 
 #[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
     dns_name: String,
-    connector: R::Handle,
+    runtime: R,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::TcpConnection>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
-    let tls_builder = TlsClientStreamBuilder::new(connector);
+    let tls_builder = TlsClientStreamBuilder::new(runtime);
     tls_builder.build(socket_addr, dns_name)
 }

--- a/crates/resolver/src/tls/dns_over_openssl.rs
+++ b/crates/resolver/src/tls/dns_over_openssl.rs
@@ -23,10 +23,11 @@ use crate::name_server::RuntimeProvider;
 pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
     dns_name: String,
+    connector: R::Handle,
 ) -> (
     Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
-    let tls_builder = TlsClientStreamBuilder::new();
+    let tls_builder = TlsClientStreamBuilder::new(connector);
     tls_builder.build(socket_addr, dns_name)
 }

--- a/crates/resolver/src/tls/dns_over_openssl.rs
+++ b/crates/resolver/src/tls/dns_over_openssl.rs
@@ -16,18 +16,17 @@ use futures_util::future::Future;
 use proto::error::ProtoError;
 use proto::openssl::{TlsClientStream, TlsClientStreamBuilder};
 use proto::BufDnsStreamHandle;
-
-use crate::name_server::RuntimeProvider;
+use proto::RuntimeProvider;
 
 #[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
     dns_name: String,
-    connector: R::Handle,
+    runtime: R,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::TcpConnection>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
-    let tls_builder = TlsClientStreamBuilder::new(connector);
+    let tls_builder = TlsClientStreamBuilder::new(runtime);
     tls_builder.build(socket_addr, dns_name)
 }

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -55,6 +55,7 @@ pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
+    connector: R::Handle,
 ) -> (
     Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
@@ -63,6 +64,6 @@ pub(crate) fn new_tls_stream<R: RuntimeProvider>(
         || CLIENT_CONFIG.clone(),
         |TlsClientConfig(client_config)| client_config,
     );
-    let (stream, handle) = tls_client_connect(socket_addr, dns_name, client_config);
+    let (stream, handle) = tls_client_connect(socket_addr, dns_name, client_config, connector);
     (Box::pin(stream), handle)
 }

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -33,7 +33,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::{TokioAsyncResolver, TokioHandle};
+    use crate::{TokioAsyncResolver, TokioRuntime};
 
     fn tls_test(config: ResolverConfig) {
         let io_loop = Runtime::new().unwrap();
@@ -44,7 +44,7 @@ mod tests {
                 try_tcp_on_error: true,
                 ..Default::default()
             },
-            TokioHandle,
+            TokioRuntime,
         )
         .expect("failed to create resolver");
 

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -18,7 +18,7 @@ use crate::{
         rr::{LowerName, Name, Record, RecordType},
     },
     resolver::{
-        config::ResolverConfig, lookup::Lookup as ResolverLookup, TokioAsyncResolver, TokioHandle,
+        config::ResolverConfig, lookup::Lookup as ResolverLookup, TokioAsyncResolver, TokioRuntime,
     },
     store::forwarder::ForwardConfig,
 };
@@ -35,7 +35,7 @@ impl ForwardAuthority {
     /// TODO: change this name to create or something
     #[allow(clippy::new_without_default)]
     #[doc(hidden)]
-    pub async fn new(runtime: TokioHandle) -> Result<Self, String> {
+    pub async fn new(runtime: TokioRuntime) -> Result<Self, String> {
         let resolver = TokioAsyncResolver::from_system_conf(runtime)
             .map_err(|e| format!("error constructing new Resolver: {}", e))?;
 
@@ -57,7 +57,7 @@ impl ForwardAuthority {
         let options = config.options.unwrap_or_default();
         let config = ResolverConfig::from_parts(None, vec![], name_servers);
 
-        let resolver = TokioAsyncResolver::new(config, options, TokioHandle)
+        let resolver = TokioAsyncResolver::new(config, options, TokioRuntime)
             .map_err(|e| format!("error constructing new Resolver: {}", e))?;
 
         info!("forward resolver configured: {}: ", origin);

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 use trust_dns_client::rr::{Name, RecordType};
-use trust_dns_resolver::TokioHandle;
+use trust_dns_resolver::TokioRuntime;
 use trust_dns_server::authority::{Authority, LookupObject};
 use trust_dns_server::store::forwarder::ForwardAuthority;
 
@@ -15,7 +15,7 @@ use trust_dns_server::store::forwarder::ForwardAuthority;
 #[test]
 fn test_lookup() {
     let runtime = Runtime::new().expect("failed to create Tokio Runtime");
-    let forwarder = ForwardAuthority::new(TokioHandle);
+    let forwarder = ForwardAuthority::new(TokioRuntime);
     let forwarder = runtime
         .block_on(forwarder)
         .expect("failed to create forwarder");

--- a/tests/compatibility-tests/tests/sig0_tests.rs
+++ b/tests/compatibility-tests/tests/sig0_tests.rs
@@ -21,6 +21,8 @@ use trust_dns_client::client::Client;
 use trust_dns_client::client::{ClientConnection, SyncClient};
 #[cfg(not(feature = "none"))]
 use trust_dns_client::op::ResponseCode;
+#[cfg(not(feature = "none"))]
+use trust_dns_client::proto::udp::TokioUdpBinder;
 use trust_dns_client::rr::dnssec::{Algorithm, KeyPair, SigSigner};
 use trust_dns_client::rr::rdata::key::{KeyUsage, KEY};
 use trust_dns_client::rr::Name;
@@ -37,7 +39,7 @@ use trust_dns_compatibility::named_process;
 fn test_get() {
     let (process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn = UdpClientConnection::new(socket).unwrap();
+    let conn = UdpClientConnection::new(socket, TokioUdpBinder).unwrap();
     let client = SyncClient::new(conn);
 
     let name = Name::from_str("www.example.com.").unwrap();
@@ -95,7 +97,7 @@ where
 fn test_create() {
     let (process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn = UdpClientConnection::new(socket).unwrap();
+    let conn = UdpClientConnection::new(socket, TokioUdpBinder).unwrap();
 
     let client = create_sig0_ready_client(conn);
     let origin = Name::from_str("example.com.").unwrap();

--- a/tests/compatibility-tests/tests/sig0_tests.rs
+++ b/tests/compatibility-tests/tests/sig0_tests.rs
@@ -22,7 +22,7 @@ use trust_dns_client::client::{ClientConnection, SyncClient};
 #[cfg(not(feature = "none"))]
 use trust_dns_client::op::ResponseCode;
 #[cfg(not(feature = "none"))]
-use trust_dns_client::proto::udp::TokioUdpBinder;
+use trust_dns_client::proto::TokioRuntime;
 use trust_dns_client::rr::dnssec::{Algorithm, KeyPair, SigSigner};
 use trust_dns_client::rr::rdata::key::{KeyUsage, KEY};
 use trust_dns_client::rr::Name;
@@ -39,7 +39,7 @@ use trust_dns_compatibility::named_process;
 fn test_get() {
     let (process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn = UdpClientConnection::new(socket, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(socket, TokioRuntime).unwrap();
     let client = SyncClient::new(conn);
 
     let name = Name::from_str("www.example.com.").unwrap();
@@ -97,7 +97,7 @@ where
 fn test_create() {
     let (process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn = UdpClientConnection::new(socket, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(socket, TokioRuntime).unwrap();
 
     let client = create_sig0_ready_client(conn);
     let origin = Name::from_str("example.com.").unwrap();

--- a/tests/compatibility-tests/tests/tsig_tests.rs
+++ b/tests/compatibility-tests/tests/tsig_tests.rs
@@ -20,7 +20,7 @@ use trust_dns_client::client::{ClientConnection, SyncClient};
 use trust_dns_client::op::ResponseCode;
 use trust_dns_client::proto::rr::dnssec::rdata::tsig::TsigAlgorithm;
 #[cfg(feature = "tokio-runtime")]
-use trust_dns_client::proto::{tcp::TokioTcpConnector, udp::TokioUdpBinder};
+use trust_dns_client::proto::TokioRuntime;
 use trust_dns_client::rr::dnssec::tsig::TSigner;
 use trust_dns_client::rr::Name;
 use trust_dns_client::rr::{RData, Record, RecordType};
@@ -57,7 +57,7 @@ where
 fn test_create() {
     let (_process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn = UdpClientConnection::new(socket, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(socket, TokioRuntime).unwrap();
 
     let client = create_tsig_ready_client(conn);
     let origin = Name::from_str("example.net.").unwrap();

--- a/tests/compatibility-tests/tests/tsig_tests.rs
+++ b/tests/compatibility-tests/tests/tsig_tests.rs
@@ -19,6 +19,8 @@ use trust_dns_client::client::Client;
 use trust_dns_client::client::{ClientConnection, SyncClient};
 use trust_dns_client::op::ResponseCode;
 use trust_dns_client::proto::rr::dnssec::rdata::tsig::TsigAlgorithm;
+#[cfg(feature = "tokio-runtime")]
+use trust_dns_client::proto::{tcp::TokioTcpConnector, udp::TokioUdpBinder};
 use trust_dns_client::rr::dnssec::tsig::TSigner;
 use trust_dns_client::rr::Name;
 use trust_dns_client::rr::{RData, Record, RecordType};
@@ -50,12 +52,12 @@ where
     SyncClient::with_tsigner(conn, signer)
 }
 
-#[cfg(not(feature = "none"))]
+#[cfg(feature = "tokio-runtime")]
 #[test]
 fn test_create() {
     let (_process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn = UdpClientConnection::new(socket).unwrap();
+    let conn = UdpClientConnection::new(socket, TokioUdpBinder).unwrap();
 
     let client = create_tsig_ready_client(conn);
     let origin = Name::from_str("example.net.").unwrap();
@@ -94,12 +96,12 @@ fn test_create() {
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
 }
 
-#[cfg(not(feature = "none"))]
+#[cfg(feature = "tokio-runtime")]
 #[test]
 fn test_tsig_zone_transfer() {
     let (_process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn = TcpClientConnection::new(socket).unwrap();
+    let conn = TcpClientConnection::new(socket, TcpClientConnection).unwrap();
 
     let client = create_tsig_ready_client(conn);
 

--- a/tests/compatibility-tests/tests/zone_transfer.rs
+++ b/tests/compatibility-tests/tests/zone_transfer.rs
@@ -40,8 +40,7 @@ macro_rules! assert_serial {
 fn test_zone_transfer() {
     let (process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn =
-        TcpClientConnection::new(socket, trust_dns_client::proto::tcp::TokioTcpConnector).unwrap();
+    let conn = TcpClientConnection::new(socket, trust_dns_client::proto::TokioRuntime).unwrap();
     let client = SyncClient::new(conn);
 
     let name = Name::from_str("example.net.").unwrap();

--- a/tests/compatibility-tests/tests/zone_transfer.rs
+++ b/tests/compatibility-tests/tests/zone_transfer.rs
@@ -40,7 +40,8 @@ macro_rules! assert_serial {
 fn test_zone_transfer() {
     let (process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
-    let conn = TcpClientConnection::new(socket).unwrap();
+    let conn =
+        TcpClientConnection::new(socket, trust_dns_client::proto::tcp::TokioTcpConnector).unwrap();
     let client = SyncClient::new(conn);
 
     let name = Name::from_str("example.net.").unwrap();

--- a/tests/integration-tests/src/tls_client_connection.rs
+++ b/tests/integration-tests/src/tls_client_connection.rs
@@ -19,8 +19,8 @@ use trust_dns_client::client::ClientConnection;
 use trust_dns_client::client::Signer;
 use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::rustls::{tls_client_connect, TlsClientStream};
-use trust_dns_proto::tcp::TcpConnector;
 use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect};
+use trust_dns_proto::RuntimeProvider;
 
 /// Tls client connection
 ///
@@ -49,11 +49,11 @@ impl<T> TlsClientConnection<T> {
 }
 
 #[allow(clippy::type_complexity)]
-impl<T: TcpConnector> ClientConnection for TlsClientConnection<T> {
-    type Sender = DnsMultiplexer<TlsClientStream<T::Socket>, Signer>;
+impl<T: RuntimeProvider> ClientConnection for TlsClientConnection<T> {
+    type Sender = DnsMultiplexer<TlsClientStream<T::TcpConnection>, Signer>;
     type SenderFuture = DnsMultiplexerConnect<
-        Pin<Box<dyn Future<Output = Result<TlsClientStream<T::Socket>, ProtoError>> + Send>>,
-        TlsClientStream<T::Socket>,
+        Pin<Box<dyn Future<Output = Result<TlsClientStream<T::TcpConnection>, ProtoError>> + Send>>,
+        TlsClientStream<T::TcpConnection>,
         Signer,
     >;
 

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -5,17 +5,15 @@ use std::{
 };
 
 use futures::{Future, FutureExt, TryFutureExt};
-#[cfg(feature = "dnssec")]
+#[cfg(all(feature = "dnssec", feature = "sqlite"))]
 use time::Duration;
-use tokio::{
-    net::{TcpStream as TokioTcpStream, UdpSocket as TokioUdpSocket},
-    runtime::Runtime,
-};
+use tokio::runtime::Runtime;
 
 #[cfg(all(feature = "dnssec", feature = "sqlite"))]
-use trust_dns_client::client::Signer;
-#[cfg(feature = "dnssec")]
-use trust_dns_client::rr::{dnssec::SigSigner, Record};
+use trust_dns_client::{
+    client::Signer,
+    rr::{dnssec::SigSigner, Record},
+};
 use trust_dns_client::{
     client::{AsyncClient, ClientHandle},
     error::ClientErrorKind,
@@ -27,11 +25,11 @@ use trust_dns_client::{
     tcp::TcpClientStream,
     udp::UdpClientStream,
 };
-#[cfg(feature = "dnssec")]
+#[cfg(all(feature = "dnssec", feature = "sqlite"))]
 use trust_dns_proto::xfer::{DnsExchangeBackground, DnsMultiplexer};
 #[cfg(all(feature = "dnssec", feature = "sqlite"))]
 use trust_dns_proto::TokioTime;
-use trust_dns_proto::{iocompat::AsyncIoTokioAsStd, xfer::FirstAnswer, DnsHandle};
+use trust_dns_proto::{tcp::TokioTcpConnector, udp::TokioUdpBinder, xfer::FirstAnswer, DnsHandle};
 
 use trust_dns_server::authority::{Authority, Catalog};
 
@@ -61,7 +59,7 @@ fn test_query_nonet() {
 fn test_query_udp_ipv4() {
     let io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let stream = UdpClientStream::<TokioUdpSocket>::new(addr);
+    let stream = UdpClientStream::<TokioUdpBinder>::new(addr, TokioUdpBinder);
     let client = AsyncClient::connect(stream);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -81,7 +79,7 @@ fn test_query_udp_ipv6() {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::<TokioUdpSocket>::new(addr);
+    let stream = UdpClientStream::new(addr, TokioUdpBinder);
     let client = AsyncClient::connect(stream);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -96,7 +94,7 @@ fn test_query_udp_ipv6() {
 fn test_query_tcp_ipv4() {
     let io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
+    let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
     let client = AsyncClient::new(stream, sender, None);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -115,7 +113,7 @@ fn test_query_tcp_ipv6() {
         .unwrap()
         .next()
         .unwrap();
-    let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
+    let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
     let client = AsyncClient::new(stream, sender, None);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -155,11 +153,9 @@ fn test_query_https() {
         .with_no_client_auth();
     client_config.alpn_protocols.push(ALPN_H2.to_vec());
 
-    let https_builder = HttpsClientStreamBuilder::with_client_config(Arc::new(client_config));
-    let client = AsyncClient::connect(
-        https_builder
-            .build::<AsyncIoTokioAsStd<TokioTcpStream>>(addr, "cloudflare-dns.com".to_string()),
-    );
+    let https_builder =
+        HttpsClientStreamBuilder::with_client_config(TokioTcpConnector, Arc::new(client_config));
+    let client = AsyncClient::connect(https_builder.build(addr, "cloudflare-dns.com".to_string()));
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
 
@@ -980,7 +976,7 @@ fn test_timeout_query_udp() {
         .unwrap();
 
     let stream =
-        UdpClientStream::<TokioUdpSocket>::with_timeout(addr, std::time::Duration::from_millis(1));
+        UdpClientStream::with_timeout(addr, std::time::Duration::from_millis(1), TokioUdpBinder);
     let client = AsyncClient::connect(stream);
     let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -1000,10 +996,8 @@ fn test_timeout_query_tcp() {
         .next()
         .unwrap();
 
-    let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::with_timeout(
-        addr,
-        std::time::Duration::from_millis(1),
-    );
+    let (stream, sender) =
+        TcpClientStream::with_timeout(addr, std::time::Duration::from_millis(1), TokioTcpConnector);
     let client = AsyncClient::with_timeout(
         Box::new(stream),
         sender,

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -26,9 +26,8 @@ use trust_dns_integration::authority::create_example;
 use trust_dns_integration::{NeverReturnsClientConnection, TestClientStream};
 use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::op::*;
-use trust_dns_proto::tcp::TokioTcpConnector;
-use trust_dns_proto::udp::TokioUdpBinder;
 use trust_dns_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect};
+use trust_dns_proto::TokioRuntime;
 use trust_dns_server::authority::{Authority, Catalog};
 
 pub struct TestClientConnection {
@@ -76,7 +75,7 @@ fn test_query_nonet() {
 #[allow(deprecated)]
 fn test_query_udp() {
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let conn = UdpClientConnection::new(addr, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(addr, TokioRuntime).unwrap();
     let client = SyncClient::new(conn);
 
     test_query(client);
@@ -86,7 +85,7 @@ fn test_query_udp() {
 #[allow(deprecated)]
 fn test_query_udp_edns() {
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let conn = UdpClientConnection::new(addr, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(addr, TokioRuntime).unwrap();
     let client = SyncClient::new(conn);
 
     test_query_edns(client);
@@ -97,7 +96,7 @@ fn test_query_udp_edns() {
 #[allow(deprecated)]
 fn test_query_tcp() {
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let conn = TcpClientConnection::new(addr, TokioTcpConnector).unwrap();
+    let conn = TcpClientConnection::new(addr, TokioRuntime).unwrap();
     let client = SyncClient::new(conn);
 
     test_query(client);
@@ -197,7 +196,7 @@ fn test_secure_query_example_udp() {
     // env_logger::init();
 
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let conn = UdpClientConnection::new(addr, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(addr, TokioRuntime).unwrap();
     let client = SyncDnssecClient::new(conn).build();
 
     test_secure_query_example(client);
@@ -210,7 +209,7 @@ fn test_secure_query_example_tcp() {
     // env_logger::init();
 
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let conn = TcpClientConnection::new(addr, TokioTcpConnector).unwrap();
+    let conn = TcpClientConnection::new(addr, TokioRuntime).unwrap();
     let client = SyncDnssecClient::new(conn).build();
 
     test_secure_query_example(client);
@@ -278,7 +277,7 @@ fn test_timeout_query_udp() {
         .unwrap();
 
     // TODO: need to add timeout length to SyncClient
-    let client = SyncClient::new(UdpClientConnection::new(addr, TokioUdpBinder).unwrap());
+    let client = SyncClient::new(UdpClientConnection::new(addr, TokioRuntime).unwrap());
     test_timeout_query(client);
 }
 
@@ -294,8 +293,7 @@ fn test_timeout_query_tcp() {
 
     // TODO: need to add timeout length to SyncClient
     let client = SyncClient::new(
-        TcpClientConnection::with_timeout(addr, Duration::from_millis(1), TokioTcpConnector)
-            .unwrap(),
+        TcpClientConnection::with_timeout(addr, Duration::from_millis(1), TokioRuntime).unwrap(),
     );
     test_timeout_query(client);
 }
@@ -348,9 +346,9 @@ fn test_timeout_query_tcp() {
 #[cfg(feature = "dnssec")]
 fn test_nsec_query_example_udp() {
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let conn = UdpClientConnection::new(addr, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(addr, TokioRuntime).unwrap();
     let client = SyncDnssecClient::new(conn).build();
-    test_nsec_query_example::<UdpClientConnection<TokioUdpBinder>>(client);
+    test_nsec_query_example::<UdpClientConnection<TokioRuntime>>(client);
 }
 
 #[test]
@@ -359,9 +357,9 @@ fn test_nsec_query_example_udp() {
 #[cfg(feature = "dnssec")]
 fn test_nsec_query_example_tcp() {
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let conn = TcpClientConnection::new(addr, TokioTcpConnector).unwrap();
+    let conn = TcpClientConnection::new(addr, TokioRuntime).unwrap();
     let client = SyncDnssecClient::new(conn).build();
-    test_nsec_query_example::<TcpClientConnection<TokioTcpConnector>>(client);
+    test_nsec_query_example::<TcpClientConnection<TokioRuntime>>(client);
 }
 
 #[cfg(feature = "dnssec")]
@@ -385,7 +383,7 @@ fn test_nsec_query_type() {
     let name = Name::from_str("www.example.com").unwrap();
 
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let conn = TcpClientConnection::new(addr, TokioTcpConnector).unwrap();
+    let conn = TcpClientConnection::new(addr, TokioRuntime).unwrap();
     let client = SyncDnssecClient::new(conn).build();
 
     let response = client

--- a/tests/integration-tests/tests/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/dnssec_client_handle_tests.rs
@@ -14,9 +14,9 @@ use trust_dns_client::rr::Name;
 use trust_dns_client::rr::{DNSClass, RData, RecordType};
 use trust_dns_client::tcp::TcpClientStream;
 
-use trust_dns_proto::tcp::TokioTcpConnector;
-use trust_dns_proto::udp::{TokioUdpBinder, UdpClientStream};
+use trust_dns_proto::udp::UdpClientStream;
 use trust_dns_proto::DnssecDnsHandle;
+use trust_dns_proto::TokioRuntime;
 use trust_dns_server::authority::{Authority, Catalog};
 
 use trust_dns_integration::authority::create_secure_example;
@@ -268,7 +268,7 @@ where
 
     let io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let stream = UdpClientStream::new(addr, TokioUdpBinder);
+    let stream = UdpClientStream::new(addr, TokioRuntime);
     let client = AsyncClient::connect(stream);
     let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
@@ -305,7 +305,7 @@ where
 
     let io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let (stream, sender) = TcpClientStream::new(addr, TokioTcpConnector);
+    let (stream, sender) = TcpClientStream::new(addr, TokioRuntime);
     let client = AsyncClient::new(Box::new(stream), sender, None);
     let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -16,9 +16,8 @@ use trust_dns_client::rr::*;
 use trust_dns_client::tcp::TcpClientConnection;
 use trust_dns_client::udp::UdpClientConnection;
 use trust_dns_proto::error::ProtoError;
-use trust_dns_proto::tcp::TokioTcpConnector;
-use trust_dns_proto::udp::TokioUdpBinder;
 use trust_dns_proto::xfer::DnsRequestSender;
+use trust_dns_proto::TokioRuntime;
 
 use trust_dns_server::authority::{Authority, Catalog};
 use trust_dns_server::ServerFuture;
@@ -102,7 +101,7 @@ fn test_server_unknown_type() {
         .spawn(move || server_thread_udp(runtime, udp_socket, server_continue2))
         .unwrap();
 
-    let conn = UdpClientConnection::new(ipaddr, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(ipaddr, TokioRuntime).unwrap();
     let client = SyncClient::new(conn);
     let client_result = client
         .query(
@@ -149,7 +148,7 @@ fn test_server_form_error_on_multiple_queries() {
         .spawn(move || server_thread_udp(runtime, udp_socket, server_continue2))
         .unwrap();
 
-    let conn = UdpClientConnection::new(ipaddr, TokioUdpBinder).unwrap();
+    let conn = UdpClientConnection::new(ipaddr, TokioRuntime).unwrap();
     let client = SyncClient::new(conn);
 
     // build the message
@@ -254,12 +253,12 @@ fn test_server_www_tls() {
     server_thread.join().unwrap();
 }
 
-fn lazy_udp_client(ipaddr: SocketAddr) -> UdpClientConnection<TokioUdpBinder> {
-    UdpClientConnection::new(ipaddr, TokioUdpBinder).unwrap()
+fn lazy_udp_client(ipaddr: SocketAddr) -> UdpClientConnection<TokioRuntime> {
+    UdpClientConnection::new(ipaddr, TokioRuntime).unwrap()
 }
 
-fn lazy_tcp_client(ipaddr: SocketAddr) -> TcpClientConnection<TokioTcpConnector> {
-    TcpClientConnection::new(ipaddr, TokioTcpConnector).unwrap()
+fn lazy_tcp_client(ipaddr: SocketAddr) -> TcpClientConnection<TokioRuntime> {
+    TcpClientConnection::new(ipaddr, TokioRuntime).unwrap()
 }
 
 #[cfg(feature = "dns-over-rustls")]
@@ -267,7 +266,7 @@ fn lazy_tls_client(
     ipaddr: SocketAddr,
     dns_name: String,
     cert_chain: Vec<rustls::Certificate>,
-) -> TlsClientConnection<TokioTcpConnector> {
+) -> TlsClientConnection<TokioRuntime> {
     use rustls::ClientConfig;
 
     let mut root_store = RootCertStore::empty();
@@ -286,7 +285,7 @@ fn lazy_tls_client(
         .with_root_certificates(root_store)
         .with_no_client_auth();
 
-    TlsClientConnection::new(ipaddr, dns_name, Arc::new(config), TokioTcpConnector)
+    TlsClientConnection::new(ipaddr, dns_name, Arc::new(config), TokioRuntime)
 }
 
 fn client_thread_www<C: ClientConnection>(conn: C)


### PR DESCRIPTION
I've changed the transport traits to use instance methods when creating the underlying sockets. This is useful to not rely on static variables if creating sockets relies on configuration that can change at runtime. The changes themselves are somewhat banal, with most of it being changes to the testing code, whereas the server implementation code itself has had no changes at all. There are also some changes that just some imports for testing.

For now, the `RuntimeProvider::Handle` type is expected to implement `TcpConnector` and `UdpSocketBinder` traits, but this gets a bit messy. I'm unsure if the `Handle` should have a trait of it's own that then depends on `TcpConnector`, `Spawn` and `UdpSocketBinder`, or just have 3 separate handle structs.