### PR TITLE
Allow constructing responses for library users

### DIFF
--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -6,7 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::{
-    authority::{message_request::QueriesEmitAndCount, Queries},
+    authority::{
+        message_request::{MessageRequest, QueriesEmitAndCount},
+        Queries,
+    },
     proto::{
         error::*,
         op::{
@@ -121,7 +124,7 @@ pub struct MessageResponseBuilder<'q> {
 }
 
 impl<'q> MessageResponseBuilder<'q> {
-    /// Constructs a new Response
+    /// Constructs a new response builder
     ///
     /// # Arguments
     ///
@@ -132,6 +135,15 @@ impl<'q> MessageResponseBuilder<'q> {
             sig0: None,
             edns: None,
         }
+    }
+
+    /// Constructs a new response builder
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - original request message to associate with the response
+    pub fn from_message_request(message: &'q MessageRequest) -> Self {
+        Self::new(Some(message.raw_query()))
     }
 
     /// Associate EDNS with the Response


### PR DESCRIPTION
With the current code in `main`, it's not possible for library users to construct a `MessageResponse`, since creating a `MessageResponseBuilder` doesn't have any (public) methods that would construct it for legitimate reasons - the only [`new()`](https://github.com/bluejekyll/trust-dns/blob/63fdb8433346e8bb1c22a0f0aa0b3a1acf688ff6/crates/server/src/authority/message_response.rs#L129) method takes a private type as an argument. I've added a `from_message_request` method that _is_ public and allows users of `trust-dns-server` to construct `MessageResponse` instances that correspond to specific requests. 