### PR TITLE
Replace references to the 'with-backtrace' feature with 'backtrace'

### DIFF
--- a/crates/resolver/src/error.rs
+++ b/crates/resolver/src/error.rs
@@ -17,7 +17,7 @@ use crate::proto::op::{Query, ResponseCode};
 use crate::proto::rr::rdata::SOA;
 use crate::proto::xfer::retry_dns_handle::RetryableError;
 use crate::proto::xfer::DnsResponse;
-#[cfg(feature = "with-backtrace")]
+#[cfg(feature = "backtrace")]
 use crate::proto::{trace, ExtBacktrace};
 
 /// An alias for results returned by functions of this crate
@@ -98,7 +98,7 @@ impl Clone for ResolveErrorKind {
 #[derive(Debug, Clone, Error)]
 pub struct ResolveError {
     pub(crate) kind: ResolveErrorKind,
-    #[cfg(feature = "with-backtrace")]
+    #[cfg(feature = "backtrace")]
     backtrack: Option<ExtBacktrace>,
 }
 
@@ -249,7 +249,7 @@ impl RetryableError for ResolveError {
 impl fmt::Display for ResolveError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "with-backtrace")] {
+            if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {
                     fmt::Display::fmt(&self.kind, f)?;
                     fmt::Debug::fmt(backtrace, f)
@@ -267,7 +267,7 @@ impl From<ResolveErrorKind> for ResolveError {
     fn from(kind: ResolveErrorKind) -> ResolveError {
         ResolveError {
             kind,
-            #[cfg(feature = "with-backtrace")]
+            #[cfg(feature = "backtrace")]
             backtrack: trace!(),
         }
     }

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -6,7 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::{
-    authority::{message_request::QueriesEmitAndCount, Queries},
+    authority::{
+        message_request::{MessageRequest, QueriesEmitAndCount},
+        Queries,
+    },
     proto::{
         error::*,
         op::{
@@ -121,7 +124,7 @@ pub struct MessageResponseBuilder<'q> {
 }
 
 impl<'q> MessageResponseBuilder<'q> {
-    /// Constructs a new Response
+    /// Constructs a new response builder
     ///
     /// # Arguments
     ///
@@ -132,6 +135,15 @@ impl<'q> MessageResponseBuilder<'q> {
             sig0: None,
             edns: None,
         }
+    }
+
+    /// Constructs a new response builder
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - original request message to associate with the response
+    pub fn from_message_request(message: &'q MessageRequest) -> Self {
+        Self::new(Some(message.raw_query()))
     }
 
     /// Associate EDNS with the Response

--- a/crates/server/src/error/config_error.rs
+++ b/crates/server/src/error/config_error.rs
@@ -47,7 +47,7 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "with-backtrace")] {
+            if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {
                     fmt::Display::fmt(&self.kind, f)?;
                     fmt::Debug::fmt(backtrace, f)

--- a/crates/server/src/error/persistence_error.rs
+++ b/crates/server/src/error/persistence_error.rs
@@ -67,7 +67,7 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "with-backtrace")] {
+            if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {
                     fmt::Display::fmt(&self.kind, f)?;
                     fmt::Debug::fmt(backtrace, f)


### PR DESCRIPTION
It seems like some of the code is compiled only if `with-backtrace` feature is enabled, but I can't find any place where this feature would be declared. It seems to me that it's confused with the `backtrace` feature, and this confusion is producing some compiler warnings. As such, I've gone and replaced the references to `with-backtrace` with `backtrace`. Feel free to disregard these changes if there is some context that I'm missing as to why the feature is used in the code.