### PR TITLE
Remove unused field on NameServerPool

### DIFF
--- a/crates/resolver/src/error.rs
+++ b/crates/resolver/src/error.rs
@@ -17,7 +17,7 @@ use crate::proto::op::{Query, ResponseCode};
 use crate::proto::rr::rdata::SOA;
 use crate::proto::xfer::retry_dns_handle::RetryableError;
 use crate::proto::xfer::DnsResponse;
-#[cfg(feature = "with-backtrace")]
+#[cfg(feature = "backtrace")]
 use crate::proto::{trace, ExtBacktrace};
 
 /// An alias for results returned by functions of this crate
@@ -98,7 +98,7 @@ impl Clone for ResolveErrorKind {
 #[derive(Debug, Clone, Error)]
 pub struct ResolveError {
     pub(crate) kind: ResolveErrorKind,
-    #[cfg(feature = "with-backtrace")]
+    #[cfg(feature = "backtrace")]
     backtrack: Option<ExtBacktrace>,
 }
 
@@ -249,7 +249,7 @@ impl RetryableError for ResolveError {
 impl fmt::Display for ResolveError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "with-backtrace")] {
+            if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {
                     fmt::Display::fmt(&self.kind, f)?;
                     fmt::Debug::fmt(backtrace, f)
@@ -267,7 +267,7 @@ impl From<ResolveErrorKind> for ResolveError {
     fn from(kind: ResolveErrorKind) -> ResolveError {
         ResolveError {
             kind,
-            #[cfg(feature = "with-backtrace")]
+            #[cfg(feature = "backtrace")]
             backtrack: trace!(),
         }
     }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -41,7 +41,6 @@ pub struct NameServerPool<
     #[cfg(feature = "mdns")]
     mdns_conns: NameServer<C, P>, /* All NameServers must be the same type */
     options: ResolverOpts,
-    conn_provider: P,
 }
 
 #[cfg(test)]
@@ -108,7 +107,6 @@ where
             #[cfg(feature = "mdns")]
             mdns_conns: name_server::mdns_nameserver(*options, conn_provider.clone(), false),
             options: *options,
-            conn_provider,
         }
     }
 
@@ -118,13 +116,11 @@ where
         options: &ResolverOpts,
         datagram_conns: Vec<NameServer<C, P>>,
         stream_conns: Vec<NameServer<C, P>>,
-        conn_provider: P,
     ) -> Self {
         NameServerPool {
             datagram_conns: Arc::from(datagram_conns),
             stream_conns: Arc::from(stream_conns),
             options: *options,
-            conn_provider,
         }
     }
 
@@ -135,14 +131,12 @@ where
         datagram_conns: Vec<NameServer<C, P>>,
         stream_conns: Vec<NameServer<C, P>>,
         mdns_conns: NameServer<C, P>,
-        conn_provider: P,
     ) -> Self {
         NameServerPool {
             datagram_conns: Arc::from(datagram_conns),
             stream_conns: Arc::from(stream_conns),
             mdns_conns,
             options: *options,
-            conn_provider,
         }
     }
 
@@ -153,13 +147,11 @@ where
         options: &ResolverOpts,
         datagram_conns: Arc<[NameServer<C, P>]>,
         stream_conns: Arc<[NameServer<C, P>]>,
-        conn_provider: P,
     ) -> Self {
         NameServerPool {
             datagram_conns,
             stream_conns,
             options: *options,
-            conn_provider,
         }
     }
 
@@ -170,7 +162,6 @@ where
         datagram_conns: Arc<[NameServer<C, P>]>,
         stream_conns: Arc<[NameServer<C, P>]>,
         mdns_conns: NameServer<C, P>,
-        conn_provider: P,
     ) -> Self {
         NameServerPool {
             datagram_conns,
@@ -536,7 +527,7 @@ mod tests {
             ..Default::default()
         };
         let ns_config = { tcp };
-        let name_server = NameServer::new_with_provider(ns_config, opts, conn_provider.clone());
+        let name_server = NameServer::new_with_provider(ns_config, opts, conn_provider);
         let name_servers: Arc<[_]> = Arc::from([name_server]);
 
         let mut pool = NameServerPool::from_nameservers_test(
@@ -544,8 +535,7 @@ mod tests {
             Arc::from([]),
             Arc::clone(&name_servers),
             #[cfg(feature = "mdns")]
-            name_server::mdns_nameserver(opts, conn_provider.clone()),
-            conn_provider,
+            name_server::mdns_nameserver(opts, TokioConnectionProvider::new(TokioHandle)),
         );
 
         let name = Name::from_str("www.example.com.").unwrap();

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -6,7 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::{
-    authority::{message_request::QueriesEmitAndCount, Queries},
+    authority::{
+        message_request::{MessageRequest, QueriesEmitAndCount},
+        Queries,
+    },
     proto::{
         error::*,
         op::{
@@ -121,7 +124,7 @@ pub struct MessageResponseBuilder<'q> {
 }
 
 impl<'q> MessageResponseBuilder<'q> {
-    /// Constructs a new Response
+    /// Constructs a new response builder
     ///
     /// # Arguments
     ///
@@ -132,6 +135,15 @@ impl<'q> MessageResponseBuilder<'q> {
             sig0: None,
             edns: None,
         }
+    }
+
+    /// Constructs a new response builder
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - original request message to associate with the response
+    pub fn from_message_request(message: &'q MessageRequest) -> Self {
+        Self::new(Some(message.raw_query()))
     }
 
     /// Associate EDNS with the Response

--- a/crates/server/src/error/config_error.rs
+++ b/crates/server/src/error/config_error.rs
@@ -47,7 +47,7 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "with-backtrace")] {
+            if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {
                     fmt::Display::fmt(&self.kind, f)?;
                     fmt::Debug::fmt(backtrace, f)

--- a/crates/server/src/error/persistence_error.rs
+++ b/crates/server/src/error/persistence_error.rs
@@ -67,7 +67,7 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "with-backtrace")] {
+            if #[cfg(feature = "backtrace")] {
                 if let Some(ref backtrace) = self.backtrack {
                     fmt::Display::fmt(&self.kind, f)?;
                     fmt::Debug::fmt(backtrace, f)


### PR DESCRIPTION
The `NameServerPool` doesn't ever need to use a connection provider, it is however used by it's members (`datagram_conns` and `stream_conns`). As such, I've removed the field itself and fixed the tests where there was an extra parameter passed around to populate the field on `NameServerPool`. 