### PR TITLE
Add CSYNC record from RFC7477

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 
 ### Update operations
 - [RFC 2136](https://tools.ietf.org/html/rfc2136): Dynamic Update
+- [RFC 7477](https://tools.ietf.org/html/rfc7477): Child-to-Parent Synchronization in DNS
 
 ### Secure DNS operations
 - [RFC 3007](https://tools.ietf.org/html/rfc3007): Secure Dynamic Update

--- a/crates/client/src/serialize/txt/rdata_parsers/csync.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/csync.rs
@@ -1,0 +1,62 @@
+// Copyright 2015-2021 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! CSYNC record for synchronizing information to the parent zone
+
+use std::str::FromStr;
+
+use crate::error::*;
+use crate::rr::rdata::CSYNC;
+use crate::rr::RecordType;
+
+/// Parse the RData from a set of Tokens
+///
+/// ```text
+/// IN CSYNC 1 3 A NS AAAA
+/// IN CSYNC 66 0 MX
+/// ```
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<CSYNC> {
+    let soa_serial: u32 = tokens
+        .next()
+        .ok_or_else(|| ParseError::from(ParseErrorKind::MissingToken("soa_serial".to_string())))
+        .and_then(|s| s.parse().map_err(Into::into))?;
+
+    let flags: u16 = tokens
+        .next()
+        .ok_or_else(|| ParseError::from(ParseErrorKind::MissingToken("flags".to_string())))
+        .and_then(|s| s.parse().map_err(Into::into))?;
+
+    let immediate: bool = flags & 0b0000_0001 == 0b0000_0001;
+    let soa_minimum: bool = flags & 0b0000_0010 == 0b0000_0010;
+
+    let mut record_types: Vec<RecordType> = Vec::new();
+
+    for token in tokens {
+        let record_type: RecordType = RecordType::from_str(token).unwrap();
+        record_types.push(record_type);
+    }
+
+    Ok(CSYNC::new(soa_serial, immediate, soa_minimum, record_types))
+}
+
+#[test]
+fn test_parsing() {
+    // IN CSYNC 123 3 NS
+
+    assert_eq!(
+        parse(vec!["123", "3", "NS"].into_iter()).expect("failed to parse CSYNC"),
+        CSYNC::new(123, true, true, vec![RecordType::NS]),
+    );
+}
+
+#[test]
+fn test_parsing_fails() {
+    // IN CSYNC NS
+
+    assert!(parse(vec!["NS"].into_iter()).is_err());
+    assert!(parse(vec![].into_iter()).is_err());
+}

--- a/crates/client/src/serialize/txt/rdata_parsers/mod.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/mod.rs
@@ -22,6 +22,7 @@
 pub(crate) mod a;
 pub(crate) mod aaaa;
 pub(crate) mod caa;
+pub(crate) mod csync;
 pub(crate) mod hinfo;
 pub(crate) mod mx;
 pub(crate) mod name;

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -208,6 +208,10 @@ pub enum ProtoErrorKind {
     #[error("nsec3 flags should be 0b0000000*: {0:b}")]
     UnrecognizedNsec3Flags(u8),
 
+    /// Unrecognized csync flags were found
+    #[error("csync flags should be 0b000000**: {0:b}")]
+    UnrecognizedCsyncFlags(u16),
+
     // foreign
     /// An error got returned from IO
     #[error("io error: {0}")]
@@ -489,6 +493,7 @@ impl Clone for ProtoErrorKind {
             UnknownRecordTypeValue(value) => UnknownRecordTypeValue(value),
             UnrecognizedLabelCode(value) => UnrecognizedLabelCode(value),
             UnrecognizedNsec3Flags(flags) => UnrecognizedNsec3Flags(flags),
+            UnrecognizedCsyncFlags(flags) => UnrecognizedCsyncFlags(flags),
 
             // foreign
             Io(ref e) => Io(if let Some(raw) = e.raw_os_error() {

--- a/crates/proto/src/rr/dnssec/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/nsec3.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+//! NSEC3 related record types
+
 #[cfg(feature = "serde-config")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec.rs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-//! negative cache proof for non-existence
+//! NSEC record types
 use std::fmt;
 
 #[cfg(feature = "serde-config")]
 use serde::{Deserialize, Serialize};
 
-use super::nsec3;
 use crate::error::*;
+use crate::rr::type_bit_map::{decode_type_bit_maps, encode_type_bit_maps};
 use crate::rr::{Name, RecordType};
 use crate::serialize::binary::*;
 
@@ -143,7 +143,7 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
         .map(|u| u as usize)
         .checked_sub(decoder.index() - start_idx)
         .map_err(|_| ProtoError::from("invalid rdata length in NSEC"))?;
-    let record_types = nsec3::decode_type_bit_maps(decoder, bit_map_len)?;
+    let record_types = decode_type_bit_maps(decoder, bit_map_len)?;
 
     Ok(NSEC::new(next_domain_name, record_types))
 }
@@ -161,7 +161,7 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
 pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &NSEC) -> ProtoResult<()> {
     encoder.with_canonical_names(|encoder| {
         rdata.next_domain_name().emit(encoder)?;
-        nsec3::encode_bit_maps(encoder, rdata.type_bit_maps())
+        encode_type_bit_maps(encoder, rdata.type_bit_maps())
     })
 }
 

--- a/crates/proto/src/rr/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-//! hashed negative cache proof for non-existence
-use std::collections::BTreeMap;
+//! NSEC record types
+
 use std::fmt;
 
 #[cfg(feature = "serde-config")]
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::*;
 use crate::rr::dnssec::Nsec3HashAlgorithm;
+use crate::rr::type_bit_map::*;
 use crate::rr::RecordType;
 use crate::serialize::binary::*;
 
@@ -311,135 +312,6 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
     ))
 }
 
-/// Decodes the array of RecordTypes covered by this NSEC record
-///
-/// # Arguments
-///
-/// * `decoder` - decoder to read from
-/// * `bit_map_len` - the number bytes in the bit map
-///
-/// # Returns
-///
-/// The Array of covered types
-pub(crate) fn decode_type_bit_maps(
-    decoder: &mut BinDecoder<'_>,
-    bit_map_len: Restrict<usize>,
-) -> ProtoResult<Vec<RecordType>> {
-    // 3.2.1.  Type Bit Maps Encoding
-    //
-    //  The encoding of the Type Bit Maps field is the same as that used by
-    //  the NSEC RR, described in [RFC4034].  It is explained and clarified
-    //  here for clarity.
-    //
-    //  The RR type space is split into 256 window blocks, each representing
-    //  the low-order 8 bits of the 16-bit RR type space.  Each block that
-    //  has at least one active RR type is encoded using a single octet
-    //  window number (from 0 to 255), a single octet bitmap length (from 1
-    //  to 32) indicating the number of octets used for the bitmap of the
-    //  window block, and up to 32 octets (256 bits) of bitmap.
-    //
-    //  Blocks are present in the NSEC3 RR RDATA in increasing numerical
-    //  order.
-    //
-    //     Type Bit Maps Field = ( Window Block # | Bitmap Length | Bitmap )+
-    //
-    //     where "|" denotes concatenation.
-    //
-    //  Each bitmap encodes the low-order 8 bits of RR types within the
-    //  window block, in network bit order.  The first bit is bit 0.  For
-    //  window block 0, bit 1 corresponds to RR type 1 (A), bit 2 corresponds
-    //  to RR type 2 (NS), and so forth.  For window block 1, bit 1
-    //  corresponds to RR type 257, bit 2 to RR type 258.  If a bit is set to
-    //  1, it indicates that an RRSet of that type is present for the
-    //  original owner name of the NSEC3 RR.  If a bit is set to 0, it
-    //  indicates that no RRSet of that type is present for the original
-    //  owner name of the NSEC3 RR.
-    //
-    //  Since bit 0 in window block 0 refers to the non-existing RR type 0,
-    //  it MUST be set to 0.  After verification, the validator MUST ignore
-    //  the value of bit 0 in window block 0.
-    //
-    //  Bits representing Meta-TYPEs or QTYPEs as specified in Section 3.1 of
-    //  [RFC2929] or within the range reserved for assignment only to QTYPEs
-    //  and Meta-TYPEs MUST be set to 0, since they do not appear in zone
-    //  data.  If encountered, they must be ignored upon reading.
-    //
-    //  Blocks with no types present MUST NOT be included.  Trailing zero
-    //  octets in the bitmap MUST be omitted.  The length of the bitmap of
-    //  each block is determined by the type code with the largest numerical
-    //  value, within that block, among the set of RR types present at the
-    //  original owner name of the NSEC3 RR.  Trailing octets not specified
-    //  MUST be interpreted as zero octets.
-    let mut record_types: Vec<RecordType> = Vec::new();
-    let mut state: BitMapReadState = BitMapReadState::Window;
-
-    // loop through all the bytes in the bitmap
-    for _ in 0..bit_map_len.unverified(/*bounded over any length of u16*/) {
-        let current_byte = decoder.read_u8()?;
-
-        state = match state {
-            BitMapReadState::Window => BitMapReadState::Len {
-                window: current_byte.unverified(/*window is any valid u8,*/),
-            },
-            BitMapReadState::Len { window } => BitMapReadState::RecordType {
-                window,
-                len: current_byte,
-                left: current_byte,
-            },
-            BitMapReadState::RecordType { window, len, left } => {
-                // window is the Window Block # from above
-                // len is the Bitmap Length
-                // current_byte is the Bitmap
-                let mut bit_map = current_byte.unverified(/*validated and restricted in usage in following usage*/);
-
-                // for all the bits in the current_byte
-                for i in 0..8 {
-                    // if the current_bytes most significant bit is set
-                    if bit_map & 0b1000_0000 == 0b1000_0000 {
-                        // len - left is the block in the bitmap, times 8 for the bits, + the bit in the current_byte
-                        let low_byte: u8 = len
-                            .checked_sub(left.unverified(/*will fail as param in this call if invalid*/))
-                            .checked_mul(8)
-                            .checked_add(i)
-                            .map_err(|_| "block len or left out of bounds in NSEC(3)")?
-                            .unverified(/*any u8 is valid at this point*/);
-                        let rr_type: u16 = (u16::from(window) << 8) | u16::from(low_byte);
-                        record_types.push(RecordType::from(rr_type));
-                    }
-                    // shift left and look at the next bit
-                    bit_map <<= 1;
-                }
-
-                // move to the next section of the bit_map
-                let left = left
-                    .checked_sub(1)
-                    .map_err(|_| ProtoError::from("block left out of bounds in NSEC(3)"))?;
-                if left.unverified(/*comparison is safe*/) == 0 {
-                    // we've exhausted this Window, move to the next
-                    BitMapReadState::Window
-                } else {
-                    // continue reading this Window
-                    BitMapReadState::RecordType { window, len, left }
-                }
-            }
-        };
-    }
-
-    Ok(record_types)
-}
-
-enum BitMapReadState {
-    Window,
-    Len {
-        window: u8,
-    },
-    RecordType {
-        window: u8,
-        len: Restrict<u8>,
-        left: Restrict<u8>,
-    },
-}
-
 /// Write the RData from the given Decoder
 pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &NSEC3) -> ProtoResult<()> {
     encoder.emit(rdata.hash_algorithm().into())?;
@@ -449,53 +321,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &NSEC3) -> ProtoResult<()> {
     encoder.emit_vec(rdata.salt())?;
     encoder.emit(rdata.next_hashed_owner_name().len() as u8)?;
     encoder.emit_vec(rdata.next_hashed_owner_name())?;
-    encode_bit_maps(encoder, rdata.type_bit_maps())?;
-
-    Ok(())
-}
-
-/// Encode the bit map
-///
-/// # Arguments
-///
-/// * `encoder` - the encoder to write to
-/// * `type_bit_maps` - types to encode into the bitmap
-pub(crate) fn encode_bit_maps(
-    encoder: &mut BinEncoder<'_>,
-    type_bit_maps: &[RecordType],
-) -> ProtoResult<()> {
-    let mut hash: BTreeMap<u8, Vec<u8>> = BTreeMap::new();
-    let mut type_bit_maps = type_bit_maps.to_vec();
-    type_bit_maps.sort();
-
-    // collect the bitmaps
-    for rr_type in type_bit_maps {
-        let code: u16 = (rr_type).into();
-        let window: u8 = (code >> 8) as u8;
-        let low: u8 = (code & 0x00FF) as u8;
-
-        let bit_map: &mut Vec<u8> = hash.entry(window).or_insert_with(Vec::new);
-        // len + left is the block in the bitmap, divided by 8 for the bits, + the bit in the current_byte
-        let index: u8 = low / 8;
-        let bit: u8 = 0b1000_0000 >> (low % 8);
-
-        // adding necessary space to the vector
-        if bit_map.len() < (index as usize + 1) {
-            bit_map.resize(index as usize + 1, 0_u8);
-        }
-
-        bit_map[index as usize] |= bit;
-    }
-
-    // output bitmaps
-    for (window, bitmap) in hash {
-        encoder.emit(window)?;
-        // the hashset should never be larger that 255 based on above logic.
-        encoder.emit(bitmap.len() as u8)?;
-        for bits in bitmap {
-            encoder.emit(bits)?;
-        }
-    }
+    encode_type_bit_maps(encoder, rdata.type_bit_maps())?;
 
     Ok(())
 }

--- a/crates/proto/src/rr/mod.rs
+++ b/crates/proto/src/rr/mod.rs
@@ -27,6 +27,7 @@ pub mod record_data;
 pub mod record_type;
 pub mod resource;
 mod rr_set;
+pub mod type_bit_map;
 
 pub use self::dns_class::DNSClass;
 pub use self::domain::{IntoName, Name, TryParseIp};

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -1,0 +1,200 @@
+// Copyright 2015-2021 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! CSYNC record for synchronizing data from a child zone to the parent
+
+use std::fmt;
+
+#[cfg(feature = "serde-config")]
+use serde::{Deserialize, Serialize};
+
+use crate::error::*;
+use crate::rr::type_bit_map::{decode_type_bit_maps, encode_type_bit_maps};
+use crate::rr::RecordType;
+use crate::serialize::binary::*;
+
+/// [RFC 7477, Child-to-Parent Synchronization in DNS, March 2015][rfc7477]
+///
+/// ```text
+/// 2.1.1.  The CSYNC Resource Record Wire Format
+///
+/// The CSYNC RDATA consists of the following fields:
+///
+///                       1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+///   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///  |                          SOA Serial                           |
+///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///  |       Flags                   |            Type Bit Map       /
+///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///  /                     Type Bit Map (continued)                  /
+///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// ```
+///
+/// [rfc7477]: https://tools.ietf.org/html/rfc7477
+#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct CSYNC {
+    soa_serial: u32,
+    immediate: bool,
+    soa_minimum: bool,
+    type_bit_maps: Vec<RecordType>,
+}
+
+impl CSYNC {
+    /// Creates a new CSYNC record data.
+    ///
+    /// # Arguments
+    ///
+    /// * `soa_serial` - A serial number for the zone
+    /// * `immediate` - A flag signalling if the change should happen immediately
+    /// * `soa_minimum` - A flag to used to signal if the soa_serial should be validated
+    /// * `type_bit_maps` - a bit map of the types to synchronize
+    ///
+    /// # Return value
+    ///
+    /// The new CSYNC record data.
+    pub fn new(
+        soa_serial: u32,
+        immediate: bool,
+        soa_minimum: bool,
+        type_bit_maps: Vec<RecordType>,
+    ) -> CSYNC {
+        CSYNC {
+            soa_serial,
+            immediate,
+            soa_minimum,
+            type_bit_maps,
+        }
+    }
+
+    /// [RFC 7477](https://tools.ietf.org/html/rfc7477#section-2.1.1.2.1), Child-to-Parent Synchronization in DNS, March 2015
+    ///
+    /// ```text
+    /// 2.1.1.2.1.  The Type Bit Map Field
+    ///
+    ///    The Type Bit Map field indicates the record types to be processed by
+    ///    the parental agent, according to the procedures in Section 3.  The
+    ///    Type Bit Map field is encoded in the same way as the Type Bit Map
+    ///    field of the NSEC record, described in [RFC4034], Section 4.1.2.  If
+    ///    a bit has been set that a parental agent implementation does not
+    ///    understand, the parental agent MUST NOT act upon the record.
+    ///    Specifically, a parental agent must not simply copy the data, and it
+    ///    must understand the semantics associated with a bit in the Type Bit
+    ///    Map field that has been set to 1.
+    /// ```
+    pub fn type_bit_maps(&self) -> &[RecordType] {
+        &self.type_bit_maps
+    }
+
+    /// [RFC 7477](https://tools.ietf.org/html/rfc7477#section-2.1.1.2), Child-to-Parent Synchronization in DNS, March 2015
+    ///
+    /// ```text
+    /// 2.1.1.2.  The Flags Field
+    ///
+    ///    The Flags field contains 16 bits of boolean flags that define
+    ///    operations that affect the processing of the CSYNC record.  The flags
+    ///    defined in this document are as follows:
+    ///
+    ///       0x00 0x01: "immediate"
+    ///
+    ///       0x00 0x02: "soaminimum"
+    ///
+    ///    The definitions for how the flags are to be used can be found in
+    ///    Section 3.
+    ///
+    ///    The remaining flags are reserved for use by future specifications.
+    ///    Undefined flags MUST be set to 0 by CSYNC publishers.  Parental
+    ///    agents MUST NOT process a CSYNC record if it contains a 1 value for a
+    ///    flag that is unknown to or unsupported by the parental agent.
+    /// ```
+    pub fn flags(&self) -> u16 {
+        let mut flags: u16 = 0;
+        if self.immediate {
+            flags |= 0b0000_0001
+        };
+        if self.soa_minimum {
+            flags |= 0b0000_0010
+        };
+        flags
+    }
+}
+
+/// Read the RData from the given Decoder
+pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoResult<CSYNC> {
+    let start_idx = decoder.index();
+
+    let soa_serial = decoder.read_u32()?.unverified();
+
+    let flags: u16 = decoder
+        .read_u16()?
+        .verify_unwrap(|flags| flags & 0b1111_1100 == 0)
+        .map_err(|flags| ProtoError::from(ProtoErrorKind::UnrecognizedCsyncFlags(flags)))?;
+
+    let immediate: bool = flags & 0b0000_0001 == 0b0000_0001;
+    let soa_minimum: bool = flags & 0b0000_0010 == 0b0000_0010;
+
+    let bit_map_len = rdata_length
+        .map(|u| u as usize)
+        .checked_sub(decoder.index() - start_idx)
+        .map_err(|_| ProtoError::from("invalid rdata length in CSYNC"))?;
+    let record_types = decode_type_bit_maps(decoder, bit_map_len)?;
+
+    Ok(CSYNC::new(soa_serial, immediate, soa_minimum, record_types))
+}
+
+/// Write the RData from the given Decoder
+pub fn emit(encoder: &mut BinEncoder<'_>, csync: &CSYNC) -> ProtoResult<()> {
+    encoder.emit_u32(csync.soa_serial)?;
+    encoder.emit_u16(csync.flags())?;
+    encode_type_bit_maps(encoder, csync.type_bit_maps())?;
+
+    Ok(())
+}
+
+impl fmt::Display for CSYNC {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{soa_serial} {flags}",
+            soa_serial = &self.soa_serial,
+            flags = &self.flags(),
+        )?;
+
+        for ty in &self.type_bit_maps {
+            write!(f, " {}", ty)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use super::*;
+
+    #[test]
+    fn test() {
+        let types = vec![RecordType::A, RecordType::NS, RecordType::AAAA];
+
+        let rdata = CSYNC::new(123, true, true, types);
+
+        let mut bytes = Vec::new();
+        let mut encoder: BinEncoder<'_> = BinEncoder::new(&mut bytes);
+        assert!(emit(&mut encoder, &rdata).is_ok());
+        let bytes = encoder.into_bytes();
+
+        println!("bytes: {:?}", bytes);
+
+        let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
+        let restrict = Restrict::new(bytes.len() as u16);
+        let read_rdata = read(&mut decoder, restrict).expect("Decoding error");
+        assert_eq!(rdata, read_rdata);
+    }
+}

--- a/crates/proto/src/rr/rdata/mod.rs
+++ b/crates/proto/src/rr/rdata/mod.rs
@@ -22,6 +22,7 @@
 pub mod a;
 pub mod aaaa;
 pub mod caa;
+pub mod csync;
 pub mod hinfo;
 pub mod mx;
 pub mod name;
@@ -37,6 +38,7 @@ pub mod tlsa;
 pub mod txt;
 
 pub use self::caa::CAA;
+pub use self::csync::CSYNC;
 pub use self::hinfo::HINFO;
 pub use self::mx::MX;
 pub use self::naptr::NAPTR;

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -53,6 +53,8 @@ pub enum RecordType {
     //  DHCID,      // 49 RFC 4701 DHCP identifier
     //  DLV,        //	32769	RFC 4431	DNSSEC Lookaside Validation record
     //  DNAME,      // 39 RFC 2672 Delegation Name
+    /// [RFC 7477](https://tools.ietf.org/html/rfc4034) Child-to-parent synchronization record
+    CSYNC,
     /// [RFC 4034](https://tools.ietf.org/html/rfc4034) DNS Key record: RSASHA256 and RSASHA512, RFC5702
     DNSKEY,
     /// [RFC 4034](https://tools.ietf.org/html/rfc4034) Delegation signer: RSASHA256 and RSASHA512, RFC5702
@@ -194,6 +196,7 @@ impl FromStr for RecordType {
             "AXFR" => Ok(RecordType::AXFR),
             "CAA" => Ok(RecordType::CAA),
             "CNAME" => Ok(RecordType::CNAME),
+            "CSYNC" => Ok(RecordType::CSYNC),
             "DNSKEY" => Ok(RecordType::DNSKEY),
             "DS" => Ok(RecordType::DS),
             "HINFO" => Ok(RecordType::HINFO),
@@ -243,6 +246,7 @@ impl From<u16> for RecordType {
             252 => RecordType::AXFR,
             257 => RecordType::CAA,
             5 => RecordType::CNAME,
+            62 => RecordType::CSYNC,
             48 => RecordType::DNSKEY,
             43 => RecordType::DS,
             13 => RecordType::HINFO,
@@ -315,6 +319,7 @@ impl From<RecordType> for &'static str {
             RecordType::AXFR => "AXFR",
             RecordType::CAA => "CAA",
             RecordType::CNAME => "CNAME",
+            RecordType::CSYNC => "CSYNC",
             RecordType::DNSKEY => "DNSKEY",
             RecordType::DS => "DS",
             RecordType::HINFO => "HINFO",
@@ -366,6 +371,7 @@ impl From<RecordType> for u16 {
             RecordType::AXFR => 252,
             RecordType::CAA => 257,
             RecordType::CNAME => 5,
+            RecordType::CSYNC => 62,
             RecordType::DNSKEY => 48,
             RecordType::DS => 43,
             RecordType::HINFO => 13,
@@ -437,6 +443,7 @@ mod tests {
             RecordType::TXT,
             RecordType::AAAA,
             RecordType::SRV,
+            RecordType::CSYNC,
             RecordType::AXFR,
             RecordType::ANY,
         ];
@@ -455,6 +462,7 @@ mod tests {
             RecordType::TXT,
             RecordType::AAAA,
             RecordType::HINFO,
+            RecordType::CSYNC,
         ];
 
         unordered.sort();
@@ -476,6 +484,7 @@ mod tests {
             "ANAME",
             "CAA",
             "CNAME",
+            "CSYNC",
             "HINFO",
             "NULL",
             "MX",

--- a/crates/proto/src/rr/type_bit_map.rs
+++ b/crates/proto/src/rr/type_bit_map.rs
@@ -1,0 +1,210 @@
+// Copyright 2015-2021 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! type bit map helper definitions
+
+use crate::error::*;
+use crate::rr::RecordType;
+use crate::serialize::binary::*;
+use std::collections::BTreeMap;
+
+enum BitMapReadState {
+    Window,
+    Len {
+        window: u8,
+    },
+    RecordType {
+        window: u8,
+        len: Restrict<u8>,
+        left: Restrict<u8>,
+    },
+}
+
+/// Encode the bit map
+///
+/// # Arguments
+///
+/// * `encoder` - the encoder to write to
+/// * `type_bit_maps` - types to encode into the bitmap
+pub(crate) fn encode_type_bit_maps(
+    encoder: &mut BinEncoder<'_>,
+    type_bit_maps: &[RecordType],
+) -> ProtoResult<()> {
+    let mut hash: BTreeMap<u8, Vec<u8>> = BTreeMap::new();
+    let mut type_bit_maps = type_bit_maps.to_vec();
+    type_bit_maps.sort();
+
+    // collect the bitmaps
+    for rr_type in type_bit_maps {
+        let code: u16 = (rr_type).into();
+        let window: u8 = (code >> 8) as u8;
+        let low: u8 = (code & 0x00FF) as u8;
+
+        let bit_map: &mut Vec<u8> = hash.entry(window).or_insert_with(Vec::new);
+        // len + left is the block in the bitmap, divided by 8 for the bits, + the bit in the current_byte
+        let index: u8 = low / 8;
+        let bit: u8 = 0b1000_0000 >> (low % 8);
+
+        // adding necessary space to the vector
+        if bit_map.len() < (index as usize + 1) {
+            bit_map.resize(index as usize + 1, 0_u8);
+        }
+
+        bit_map[index as usize] |= bit;
+    }
+
+    // output bitmaps
+    for (window, bitmap) in hash {
+        encoder.emit(window)?;
+        // the hashset should never be larger that 255 based on above logic.
+        encoder.emit(bitmap.len() as u8)?;
+        for bits in bitmap {
+            encoder.emit(bits)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Decodes the array of RecordTypes covered by this NSEC record
+///
+/// # Arguments
+///
+/// * `decoder` - decoder to read from
+/// * `bit_map_len` - the number bytes in the bit map
+///
+/// # Returns
+///
+/// The Array of covered types
+pub(crate) fn decode_type_bit_maps(
+    decoder: &mut BinDecoder<'_>,
+    bit_map_len: Restrict<usize>,
+) -> ProtoResult<Vec<RecordType>> {
+    // 3.2.1.  Type Bit Maps Encoding
+    //
+    //  The encoding of the Type Bit Maps field is the same as that used by
+    //  the NSEC RR, described in [RFC4034].  It is explained and clarified
+    //  here for clarity.
+    //
+    //  The RR type space is split into 256 window blocks, each representing
+    //  the low-order 8 bits of the 16-bit RR type space.  Each block that
+    //  has at least one active RR type is encoded using a single octet
+    //  window number (from 0 to 255), a single octet bitmap length (from 1
+    //  to 32) indicating the number of octets used for the bitmap of the
+    //  window block, and up to 32 octets (256 bits) of bitmap.
+    //
+    //  Blocks are present in the NSEC3 RR RDATA in increasing numerical
+    //  order.
+    //
+    //     Type Bit Maps Field = ( Window Block # | Bitmap Length | Bitmap )+
+    //
+    //     where "|" denotes concatenation.
+    //
+    //  Each bitmap encodes the low-order 8 bits of RR types within the
+    //  window block, in network bit order.  The first bit is bit 0.  For
+    //  window block 0, bit 1 corresponds to RR type 1 (A), bit 2 corresponds
+    //  to RR type 2 (NS), and so forth.  For window block 1, bit 1
+    //  corresponds to RR type 257, bit 2 to RR type 258.  If a bit is set to
+    //  1, it indicates that an RRSet of that type is present for the
+    //  original owner name of the NSEC3 RR.  If a bit is set to 0, it
+    //  indicates that no RRSet of that type is present for the original
+    //  owner name of the NSEC3 RR.
+    //
+    //  Since bit 0 in window block 0 refers to the non-existing RR type 0,
+    //  it MUST be set to 0.  After verification, the validator MUST ignore
+    //  the value of bit 0 in window block 0.
+    //
+    //  Bits representing Meta-TYPEs or QTYPEs as specified in Section 3.1 of
+    //  [RFC2929] or within the range reserved for assignment only to QTYPEs
+    //  and Meta-TYPEs MUST be set to 0, since they do not appear in zone
+    //  data.  If encountered, they must be ignored upon reading.
+    //
+    //  Blocks with no types present MUST NOT be included.  Trailing zero
+    //  octets in the bitmap MUST be omitted.  The length of the bitmap of
+    //  each block is determined by the type code with the largest numerical
+    //  value, within that block, among the set of RR types present at the
+    //  original owner name of the NSEC3 RR.  Trailing octets not specified
+    //  MUST be interpreted as zero octets.
+    let mut record_types: Vec<RecordType> = Vec::new();
+    let mut state: BitMapReadState = BitMapReadState::Window;
+
+    // loop through all the bytes in the bitmap
+    for _ in 0..bit_map_len.unverified(/*bounded over any length of u16*/) {
+        let current_byte = decoder.read_u8()?;
+
+        state = match state {
+            BitMapReadState::Window => BitMapReadState::Len {
+                window: current_byte.unverified(/*window is any valid u8,*/),
+            },
+            BitMapReadState::Len { window } => BitMapReadState::RecordType {
+                window,
+                len: current_byte,
+                left: current_byte,
+            },
+            BitMapReadState::RecordType { window, len, left } => {
+                // window is the Window Block # from above
+                // len is the Bitmap Length
+                // current_byte is the Bitmap
+                let mut bit_map = current_byte.unverified(/*validated and restricted in usage in following usage*/);
+
+                // for all the bits in the current_byte
+                for i in 0..8 {
+                    // if the current_bytes most significant bit is set
+                    if bit_map & 0b1000_0000 == 0b1000_0000 {
+                        // len - left is the block in the bitmap, times 8 for the bits, + the bit in the current_byte
+                        let low_byte: u8 = len
+                            .checked_sub(left.unverified(/*will fail as param in this call if invalid*/))
+                            .checked_mul(8)
+                            .checked_add(i)
+                            .map_err(|_| "block len or left out of bounds in NSEC(3)")?
+                            .unverified(/*any u8 is valid at this point*/);
+                        let rr_type: u16 = (u16::from(window) << 8) | u16::from(low_byte);
+                        record_types.push(RecordType::from(rr_type));
+                    }
+                    // shift left and look at the next bit
+                    bit_map <<= 1;
+                }
+
+                // move to the next section of the bit_map
+                let left = left
+                    .checked_sub(1)
+                    .map_err(|_| ProtoError::from("block left out of bounds in NSEC(3)"))?;
+                if left.unverified(/*comparison is safe*/) == 0 {
+                    // we've exhausted this Window, move to the next
+                    BitMapReadState::Window
+                } else {
+                    // continue reading this Window
+                    BitMapReadState::RecordType { window, len, left }
+                }
+            }
+        };
+    }
+
+    Ok(record_types)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use super::*;
+
+    #[test]
+    fn test_encode_decode() {
+        let types = vec![RecordType::A, RecordType::NS];
+
+        let mut bytes = Vec::new();
+        let mut encoder: BinEncoder<'_> = BinEncoder::new(&mut bytes);
+        assert!(encode_type_bit_maps(&mut encoder, &types).is_ok());
+        let bytes = encoder.into_bytes();
+
+        let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
+        let restrict = Restrict::new(bytes.len());
+        let read_bit_map = decode_type_bit_maps(&mut decoder, restrict).expect("Decoding error");
+        assert_eq!(types, read_bit_map);
+    }
+}


### PR DESCRIPTION
The CSYNC record is used to synchronize records (mostly NS and glue) to the parent zone.

Had to move nsec3::encode_type_bit_maps and decode_type_bit_maps in order to make it work with/without the dnssec-feature.

Tested with the following zone: 

```
@   IN          SOA     trust-dns.org. root.trust-dns.org. (
                                199609203       ; Serial
                                28800   ; Refresh
                                7200    ; Retry
                                604800  ; Expire
                                86400)  ; Minimum TTL

                CSYNC   66  3   A NS MX
```
And get the following output using resolve util:

```
$ ./target/release/resolve -n 127.0.0.1:24141 -t CSYNC example.com
Querying for example.com CSYNC from tcp:127.0.0.1:24141, udp:127.0.0.1:24141
Success for query name: example.com type: CSYNC class: IN mdns_unicast_response: false
        example.com. 86400 IN CSYNC 66 3 A NS MX
```