### PR TITLE
Configuration of bind address for resolver.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83137067e3a2a6a06d67168e49e68a0957d215410473a740cea95a2425c0b7c6"
+dependencies = [
+ "async-io",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
 name = "async-std"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +162,7 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "async-lock",
+ "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -171,6 +189,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "pin-utils",
+ "socket2",
  "trust-dns-resolver",
 ]
 
@@ -1314,6 +1333,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,9 +1365,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -64,12 +64,13 @@ name = "async_std_resolver"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = "1.6"
+async-std = { version = "1.6", features = ["unstable"] }
 async-trait = "0.1.42"
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 pin-utils = "0.1.0"
 trust-dns-resolver = { version = "0.21.0-alpha.4", path = "../resolver", default-features = false }
+socket2 = "0.4.2"
 
 [dev-dependencies]
 async-std = { version = "1.6", features = ["attributes"] }

--- a/crates/proto/src/native_tls/tls_client_stream.rs
+++ b/crates/proto/src/native_tls/tls_client_stream.rs
@@ -52,6 +52,11 @@ impl<S: Connect> TlsClientStreamBuilder<S> {
         self.0.identity(pkcs12);
     }
 
+    /// Sets the address to connect from.
+    pub fn bind_addr(&mut self, bind_addr: SocketAddr) {
+        self.0.bind_addr(bind_addr);
+    }
+
     /// Creates a new TlsStream to the specified name_server
     ///
     /// # Arguments

--- a/crates/proto/src/openssl/tls_client_stream.rs
+++ b/crates/proto/src/openssl/tls_client_stream.rs
@@ -60,11 +60,17 @@ impl<S: Connect> TlsClientStreamBuilder<S> {
         self.0.identity(pkcs12);
     }
 
+    /// Sets the address to connect from.
+    pub fn bind_addr(&mut self, bind_addr: SocketAddr) {
+        self.0.bind_addr(bind_addr);
+    }
+
     /// Creates a new TlsStream to the specified name_server
     ///
     /// # Arguments
     ///
     /// * `name_server` - IP and Port for the remote DNS resolver
+    /// * `bind_addr` - IP and port to connect from
     /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
     #[allow(clippy::type_complexity)]
     pub fn build(

--- a/crates/proto/src/rustls/mod.rs
+++ b/crates/proto/src/rustls/mod.rs
@@ -11,8 +11,10 @@ pub mod tls_client_stream;
 pub mod tls_server;
 pub mod tls_stream;
 
-pub use self::tls_client_stream::{tls_client_connect, TlsClientStream};
-pub use self::tls_stream::{tls_connect, tls_from_stream, TlsStream};
+pub use self::tls_client_stream::{
+    tls_client_connect, tls_client_connect_with_bind_addr, TlsClientStream,
+};
+pub use self::tls_stream::{tls_connect, tls_connect_with_bind_addr, tls_from_stream, TlsStream};
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -61,7 +61,24 @@ impl<S: Connect> TcpClientStream<S> {
         name_server: SocketAddr,
         timeout: Duration,
     ) -> (TcpClientConnect<S>, BufDnsStreamHandle) {
-        let (stream_future, sender) = TcpStream::<S>::with_timeout(name_server, timeout);
+        Self::with_bind_addr_and_timeout(name_server, None, timeout)
+    }
+
+    /// Constructs a new TcpStream for a client to the specified SocketAddr.
+    ///
+    /// # Arguments
+    ///
+    /// * `name_server` - the IP and Port of the DNS server to connect to
+    /// * `bind_addr` - the IP and port to connect from
+    /// * `timeout` - connection timeout
+    #[allow(clippy::new_ret_no_self)]
+    pub fn with_bind_addr_and_timeout(
+        name_server: SocketAddr,
+        bind_addr: Option<SocketAddr>,
+        timeout: Duration,
+    ) -> (TcpClientConnect<S>, BufDnsStreamHandle) {
+        let (stream_future, sender) =
+            TcpStream::<S>::with_bind_addr_and_timeout(name_server, bind_addr, timeout);
 
         let new_future = Box::pin(
             stream_future
@@ -139,8 +156,13 @@ where
 #[cfg(feature = "tokio-runtime")]
 #[async_trait]
 impl Connect for AsyncIoTokioAsStd<TokioTcpStream> {
-    async fn connect(addr: SocketAddr) -> io::Result<Self> {
-        super::tokio::connect(&addr).await.map(AsyncIoTokioAsStd)
+    async fn connect_with_bind(
+        addr: SocketAddr,
+        bind_addr: Option<SocketAddr>,
+    ) -> io::Result<Self> {
+        super::tokio::connect_with_bind(&addr, &bind_addr)
+            .await
+            .map(AsyncIoTokioAsStd)
     }
 }
 

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -35,7 +35,13 @@ pub trait DnsTcpStream: AsyncRead + AsyncWrite + Unpin + Send + Sync + Sized + '
 #[async_trait]
 pub trait Connect: DnsTcpStream {
     /// connect to tcp
-    async fn connect(addr: SocketAddr) -> io::Result<Self>;
+    async fn connect(addr: SocketAddr) -> io::Result<Self> {
+        Self::connect_with_bind(addr, None).await
+    }
+
+    /// connect to tcp with address to connect from
+    async fn connect_with_bind(addr: SocketAddr, bind_addr: Option<SocketAddr>)
+        -> io::Result<Self>;
 }
 
 /// Current state while writing to the remote of the TCP connection
@@ -127,17 +133,40 @@ impl<S: Connect> TcpStream<S> {
 
         // This set of futures collapses the next tcp socket into a stream which can be used for
         //  sending and receiving tcp packets.
-        let stream_fut = Self::connect(name_server, timeout, outbound_messages);
+        let stream_fut = Self::connect(name_server, None, timeout, outbound_messages);
+
+        (stream_fut, message_sender)
+    }
+
+    /// Creates a new future of the eventually establish a IO stream connection or fail trying
+    ///
+    /// # Arguments
+    ///
+    /// * `name_server` - the IP and Port of the DNS server to connect to
+    /// * `bind_addr` - the IP and port to connect from
+    /// * `timeout` - connection timeout
+    #[allow(clippy::type_complexity)]
+    pub fn with_bind_addr_and_timeout(
+        name_server: SocketAddr,
+        bind_addr: Option<SocketAddr>,
+        timeout: Duration,
+    ) -> (
+        impl Future<Output = Result<TcpStream<S>, io::Error>> + Send,
+        BufDnsStreamHandle,
+    ) {
+        let (message_sender, outbound_messages) = BufDnsStreamHandle::new(name_server);
+        let stream_fut = Self::connect(name_server, bind_addr, timeout, outbound_messages);
 
         (stream_fut, message_sender)
     }
 
     async fn connect(
         name_server: SocketAddr,
+        bind_addr: Option<SocketAddr>,
         timeout: Duration,
         outbound_messages: StreamReceiver,
     ) -> Result<TcpStream<S>, io::Error> {
-        let tcp = S::connect(name_server);
+        let tcp = S::connect_with_bind(name_server, bind_addr);
         S::Time::timeout(timeout, tcp)
             .map(move |tcp_stream: Result<Result<S, io::Error>, _>| {
                 tcp_stream

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -10,8 +10,10 @@ use crate::{Executor, Time};
 
 /// Test next random udpsocket.
 pub fn next_random_socket_test<S: UdpSocket + Send + 'static, E: Executor>(mut exec: E) {
-    let (stream, _) =
-        UdpStream::<S>::new(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 52));
+    let (stream, _) = UdpStream::<S>::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 52),
+        None,
+    );
     drop(
         exec.block_on(stream)
             .expect("failed to get next socket address"),

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -402,6 +402,8 @@ pub struct NameServerConfig {
     #[cfg_attr(feature = "serde-config", serde(skip))]
     /// optional configuration for the tls client
     pub tls_config: Option<TlsClientConfig>,
+    /// The client address (IP and port) to use for connecting to the server.
+    pub bind_addr: Option<SocketAddr>,
 }
 
 impl fmt::Display for NameServerConfig {
@@ -478,6 +480,7 @@ impl NameServerConfigGroup {
                 trust_nx_responses,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
+                bind_addr: None,
             };
             let tcp = NameServerConfig {
                 socket_addr: SocketAddr::new(*ip, port),
@@ -486,6 +489,7 @@ impl NameServerConfigGroup {
                 trust_nx_responses,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
+                bind_addr: None,
             };
 
             name_servers.push(udp);
@@ -515,6 +519,7 @@ impl NameServerConfigGroup {
                 trust_nx_responses,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
+                bind_addr: None,
             };
 
             name_servers.push(config);
@@ -647,6 +652,14 @@ impl NameServerConfigGroup {
     #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-rustls")))]
     pub fn with_client_config(self, client_config: Arc<ClientConfig>) -> Self {
         Self(self.0, Some(TlsClientConfig(client_config)))
+    }
+
+    /// Sets the client address (IP and port) to connect from on all name servers.
+    pub fn with_bind_addr(mut self, bind_addr: Option<SocketAddr>) -> Self {
+        for server in &mut self.0 {
+            server.bind_addr = bind_addr;
+        }
+        self
     }
 }
 

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -12,6 +12,7 @@ use crate::config::TlsClientConfig;
 #[allow(clippy::type_complexity)]
 pub(crate) fn new_https_stream<R>(
     socket_addr: SocketAddr,
+    bind_addr: Option<SocketAddr>,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
 ) -> DnsExchangeConnect<HttpsClientConnect<R::Tcp>, HttpsClientStream, TokioTime>
@@ -23,7 +24,10 @@ where
         |TlsClientConfig(client_config)| client_config,
     );
 
-    let https_builder = HttpsClientStreamBuilder::with_client_config(client_config);
+    let mut https_builder = HttpsClientStreamBuilder::with_client_config(client_config);
+    if let Some(bind_addr) = bind_addr {
+        https_builder.bind_addr(bind_addr);
+    }
     DnsExchange::connect(https_builder.build::<R::Tcp>(socket_addr, dns_name))
 }
 

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -253,6 +253,7 @@ where
         trust_nx_responses,
         #[cfg(feature = "dns-over-rustls")]
         tls_config: None,
+        bind_addr: None,
     };
     NameServer::new_with_provider(config, options, conn_provider)
 }
@@ -284,6 +285,7 @@ mod tests {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         };
         let io_loop = Runtime::new().unwrap();
         let runtime_handle = TokioHandle;
@@ -322,6 +324,7 @@ mod tests {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         };
         let io_loop = Runtime::new().unwrap();
         let runtime_handle = TokioHandle;

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -446,6 +446,7 @@ mod tests {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         };
 
         let config2 = NameServerConfig {
@@ -455,6 +456,7 @@ mod tests {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         };
 
         let mut resolver_config = ResolverConfig::new();
@@ -518,6 +520,7 @@ mod tests {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         };
 
         let opts = ResolverOpts {

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -67,6 +67,7 @@ fn into_resolver_config(
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         });
         nameservers.push(NameServerConfig {
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
@@ -75,6 +76,7 @@ fn into_resolver_config(
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         });
     }
     if nameservers.is_empty() {
@@ -126,6 +128,7 @@ mod tests {
                 trust_nx_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
+                bind_addr: None,
             },
             NameServerConfig {
                 socket_addr: addr,
@@ -134,6 +137,7 @@ mod tests {
                 trust_nx_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
+                bind_addr: None,
             },
         ]
     }

--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -35,6 +35,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         });
         name_servers.push(NameServerConfig {
             socket_addr,
@@ -43,6 +44,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: None,
         });
     }
     Ok(name_servers)

--- a/crates/resolver/src/tls/dns_over_native_tls.rs
+++ b/crates/resolver/src/tls/dns_over_native_tls.rs
@@ -22,11 +22,15 @@ use crate::name_server::RuntimeProvider;
 #[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
+    bind_addr: Option<SocketAddr>,
     dns_name: String,
 ) -> (
     Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
-    let tls_builder = TlsClientStreamBuilder::new();
+    let mut tls_builder = TlsClientStreamBuilder::new();
+    if let Some(bind_addr) = bind_addr {
+        tls_builder.bind_addr(bind_addr);
+    }
     tls_builder.build(socket_addr, dns_name)
 }

--- a/crates/resolver/src/tls/dns_over_openssl.rs
+++ b/crates/resolver/src/tls/dns_over_openssl.rs
@@ -22,11 +22,15 @@ use crate::name_server::RuntimeProvider;
 #[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
+    bind_addr: Option<SocketAddr>,
     dns_name: String,
 ) -> (
     Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
-    let tls_builder = TlsClientStreamBuilder::new();
+    let mut tls_builder = TlsClientStreamBuilder::new();
+    if let Some(bind_addr) = bind_addr {
+        tls_builder.bind_addr(bind_addr);
+    }
     tls_builder.build(socket_addr, dns_name)
 }

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -16,7 +16,7 @@ use futures_util::future::Future;
 use rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
 
 use proto::error::ProtoError;
-use proto::rustls::{tls_client_connect, TlsClientStream};
+use proto::rustls::{tls_client_connect_with_bind_addr, TlsClientStream};
 use proto::BufDnsStreamHandle;
 
 use crate::config::TlsClientConfig;
@@ -53,6 +53,7 @@ lazy_static! {
 #[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream<R: RuntimeProvider>(
     socket_addr: SocketAddr,
+    bind_addr: Option<SocketAddr>,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
 ) -> (
@@ -63,6 +64,7 @@ pub(crate) fn new_tls_stream<R: RuntimeProvider>(
         || CLIENT_CONFIG.clone(),
         |TlsClientConfig(client_config)| client_config,
     );
-    let (stream, handle) = tls_client_connect(socket_addr, dns_name, client_config);
+    let (stream, handle) =
+        tls_client_connect_with_bind_addr(socket_addr, bind_addr, dns_name, client_config);
     (Box::pin(stream), handle)
 }

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -95,6 +95,7 @@ fn mock_nameserver_on_send_nx<O: OnSend + Unpin>(
             trust_nx_responses,
             #[cfg(any(feature = "dns-over-rustls", feature = "dns-over-https-rustls"))]
             tls_config: None,
+            bind_addr: None,
         },
         options,
         client,

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -284,7 +284,7 @@ fn lazy_tls_client(
         .with_root_certificates(root_store)
         .with_no_client_auth();
 
-    TlsClientConnection::new(ipaddr, dns_name, Arc::new(config))
+    TlsClientConnection::new(ipaddr, None, dns_name, Arc::new(config))
 }
 
 fn client_thread_www<C: ClientConnection>(conn: C)

--- a/util/src/resolve.rs
+++ b/util/src/resolve.rs
@@ -19,7 +19,7 @@
     unreachable_pub
 )]
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use console::style;
 use structopt::StructOpt;
@@ -71,6 +71,10 @@ struct Opts {
     /// Specify a nameserver to use, ip and port e.g. 8.8.8.8:53 or \[2001:4860:4860::8888\]:53 (port required)
     #[structopt(short = "n", long, require_delimiter = true)]
     nameserver: Vec<SocketAddr>,
+
+    /// Specify the IP address to connect from.
+    #[structopt(long)]
+    bind: Option<IpAddr>,
 
     /// Use ipv4 addresses only, default is both ipv4 and ipv6
     #[structopt(long)]
@@ -152,6 +156,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: opts.bind.map(|ip| SocketAddr::new(ip, 0)),
         });
 
         name_servers.push(NameServerConfig {
@@ -161,6 +166,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             trust_nx_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
+            bind_addr: opts.bind.map(|ip| SocketAddr::new(ip, 0)),
         });
     }
 


### PR DESCRIPTION
Allows configuration of the local address that is used by the resolver.
This is useful if the system has multiple active network connections
and it is desirable to specify which interface is used for name
resolution.

Fixes: #1005