### PR TITLE
Add CDS/CDNSKEY records from RFC7344

### DIFF
--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -65,8 +65,12 @@ impl RDataParser for RData {
             RecordType::DNSKEY => {
                 return Err(ParseError::from("DNSKEY should be dynamically generated"))
             }
+            RecordType::CDNSKEY => {
+                return Err(ParseError::from("CDNSKEY should be dynamically generated"))
+            }
             RecordType::KEY => return Err(ParseError::from("KEY should be dynamically generated")),
             RecordType::DS => return Err(ParseError::from("DS should be dynamically generated")),
+            RecordType::CDS => return Err(ParseError::from("CDS should be dynamically generated")),
             RecordType::NSEC => {
                 return Err(ParseError::from("NSEC should be dynamically generated"))
             }
@@ -159,5 +163,29 @@ mod tests {
         );
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dynamically_generated() {
+        let dynamically_generated = vec![
+            RecordType::DS,
+            RecordType::CDS,
+            RecordType::DNSKEY,
+            RecordType::CDNSKEY,
+            RecordType::KEY,
+            RecordType::NSEC,
+            RecordType::NSEC3,
+            RecordType::NSEC3PARAM,
+            RecordType::RRSIG,
+        ];
+
+        let tokens = vec!["test"];
+
+        let name = Name::from_str("example.com.").unwrap();
+
+        for record_type in dynamically_generated {
+            let result = RData::parse(record_type, tokens.iter().map(AsRef::as_ref), Some(&name));
+            assert!(result.is_err());
+        }
     }
 }

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -45,8 +45,10 @@ pub enum RecordType {
     AXFR,
     /// [RFC 6844](https://tools.ietf.org/html/rfc6844) Certification Authority Authorization
     CAA,
-    //  CDS,        //	59	RFC 7344	Child DS
-    //  CDNSKEY,    //	60	RFC 7344	Child DNSKEY
+    /// [RFC 7344](https://tools.ietf.org/html/rfc7344) Child DS
+    CDS,
+    /// [RFC 7344](https://tools.ietf.org/html/rfc7344) Child DNSKEY
+    CDNSKEY,
     //  CERT,       // 37 RFC 4398 Certificate record
     /// [RFC 1035](https://tools.ietf.org/html/rfc1035) Canonical name record
     CNAME,
@@ -162,6 +164,8 @@ impl RecordType {
         matches!(
             self,
             RecordType::DNSKEY
+                | RecordType::CDNSKEY
+                | RecordType::CDS
                 | RecordType::DS
                 | RecordType::KEY
                 | RecordType::NSEC
@@ -195,6 +199,8 @@ impl FromStr for RecordType {
             "ANAME" => Ok(RecordType::ANAME),
             "AXFR" => Ok(RecordType::AXFR),
             "CAA" => Ok(RecordType::CAA),
+            "CDNSKEY" => Ok(RecordType::CDNSKEY),
+            "CDS" => Ok(RecordType::CDS),
             "CNAME" => Ok(RecordType::CNAME),
             "CSYNC" => Ok(RecordType::CSYNC),
             "DNSKEY" => Ok(RecordType::DNSKEY),
@@ -245,6 +251,8 @@ impl From<u16> for RecordType {
             251 => RecordType::IXFR,
             252 => RecordType::AXFR,
             257 => RecordType::CAA,
+            59 => RecordType::CDS,
+            60 => RecordType::CDNSKEY,
             5 => RecordType::CNAME,
             62 => RecordType::CSYNC,
             48 => RecordType::DNSKEY,
@@ -318,6 +326,8 @@ impl From<RecordType> for &'static str {
             RecordType::ANY => "ANY",
             RecordType::AXFR => "AXFR",
             RecordType::CAA => "CAA",
+            RecordType::CDNSKEY => "CDNSKEY",
+            RecordType::CDS => "CDS",
             RecordType::CNAME => "CNAME",
             RecordType::CSYNC => "CSYNC",
             RecordType::DNSKEY => "DNSKEY",
@@ -370,6 +380,8 @@ impl From<RecordType> for u16 {
             RecordType::ANY => 255,
             RecordType::AXFR => 252,
             RecordType::CAA => 257,
+            RecordType::CDNSKEY => 60,
+            RecordType::CDS => 59,
             RecordType::CNAME => 5,
             RecordType::CSYNC => 62,
             RecordType::DNSKEY => 48,
@@ -503,6 +515,8 @@ mod tests {
 
         #[cfg(feature = "dnssec")]
         let dnssec_record_names = &[
+            "CDNSKEY",
+            "CDS",
             "DNSKEY",
             "DS",
             "KEY",


### PR DESCRIPTION
This PR is for adding CDS/CDNSKEY support to proto and client.

Tested using the resolve tool:
```
$ ./target/release/resolve -t CDS multisigner.se                                                                                                                             20:57:52
Querying for multisigner.se CDS from udp:8.8.8.8:53, tcp:8.8.8.8:53, udp:8.8.4.4:53, tcp:8.8.4.4:53, udp:[2001:4860:4860::8888]:53, tcp:[2001:4860:4860::8888]:53, udp:[2001:4860:4860::8844]:53, tcp:[2001:4860:4860::8844]:53
Success for query name: multisigner.se type: CDS class: IN mdns_unicast_response: false
        multisigner.se. 0 IN CDS 54989 8 2 74290553BD934989BD2011906EFFABECD0A1CADDA285737CFCD82CBA5AEDC14B
```