### PR TITLE
Fix AsyncClient::clone always setting use_edns

### DIFF
--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -43,6 +43,7 @@ pub type ClientFuture = AsyncClient;
 ///
 /// This Client is generic and capable of wrapping UDP, TCP, and other underlying DNS protocol
 ///  implementations.
+#[derive(Clone)]
 pub struct AsyncClient {
     exchange: DnsExchange,
     use_edns: bool,
@@ -136,15 +137,6 @@ impl AsyncClient {
     /// Disable usage of EDNS for outgoing messages
     pub fn disable_edns(&mut self) {
         self.use_edns = false;
-    }
-}
-
-impl Clone for AsyncClient {
-    fn clone(&self) -> Self {
-        AsyncClient {
-            exchange: self.exchange.clone(),
-            use_edns: true,
-        }
     }
 }
 


### PR DESCRIPTION
In looking at diffs while investigating the root cause of #1597, I saw this clone implementation, and it looked suspicious. From my reading of the surrounding code and the changelog entry, it seems like the flag should be preserved, not overwritten.

Apologies if I misunderstood and this was intended!