### PR TITLE
Add resolver.clear_cache() sync and async

### DIFF
--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -188,7 +188,7 @@ impl<R: RuntimeProvider> AsyncResolver<GenericConnection, GenericConnectionProvi
         Self::from_system_conf_with_provider(GenericConnectionProvider::<R>::new(runtime))
     }
 
-    /// Removes all entries from the cache
+    /// Flushes/Removes all entries from the cache
     pub async fn clear_cache(&mut self) {
         self.client_cache.clear_cache();
     }

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -187,6 +187,11 @@ impl<R: RuntimeProvider> AsyncResolver<GenericConnection, GenericConnectionProvi
     pub fn from_system_conf(runtime: R::Handle) -> Result<Self, ResolveError> {
         Self::from_system_conf_with_provider(GenericConnectionProvider::<R>::new(runtime))
     }
+
+    /// Removes all entries from the cache
+    pub async fn clear_cache(&mut self) {
+        self.client_cache.clear_cache();
+    }
 }
 
 impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncResolver<C, P> {

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -473,6 +473,11 @@ where
             Err(err) => Err(self.lru.negative(query, err, Instant::now())),
         }
     }
+
+    /// Clear all cached records
+    pub fn clear_cache(&mut self) {
+        self.lru.clear();
+    }
 }
 
 enum Records {

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -474,7 +474,7 @@ where
         }
     }
 
-    /// Clear all cached records
+    /// Flushes/Removes all entries from the cache
     pub fn clear_cache(&mut self) {
         self.lru.clear();
     }

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -146,6 +146,7 @@ impl DnsLru {
                 .unwrap_or_else(|| Duration::from_secs(u64::from(MAX_TTL))),
         }
     }
+
     pub(crate) fn clear(&self) {
         self.cache.lock().clear();
     }

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -146,6 +146,9 @@ impl DnsLru {
                 .unwrap_or_else(|| Duration::from_secs(u64::from(MAX_TTL))),
         }
     }
+    pub(crate) fn clear(&self) {
+        self.cache.lock().clear();
+    }
 
     pub(crate) fn insert(
         &self,

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -114,7 +114,7 @@ impl Resolver {
         Self::new(config, options)
     }
 
-    /// Removes all entries from the cache
+    /// Flushes/Removes all entries from the cache
     pub fn clear_cache(&mut self) -> ResolveResult<()> {
         let clearing = self.async_resolver.clear_cache();
         self.runtime.lock()?.block_on(clearing);

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -114,6 +114,13 @@ impl Resolver {
         Self::new(config, options)
     }
 
+    /// Removes all entries from the cache
+    pub fn clear_cache(&mut self) -> ResolveResult<()> {
+        let clearing = self.async_resolver.clear_cache();
+        self.runtime.lock()?.block_on(clearing);
+        Ok(())
+    }
+
     /// Generic lookup for any RecordType
     ///
     /// *WARNING* This interface may change in the future, please use [`Self::lookup_ip`] or another variant for more stable interfaces.


### PR DESCRIPTION
Hi all

This is the first PR to address the network change issue #1608

I am currently not sure what is smarter:
a. dropping the resolver in the consuming application on a network change or
b. reloading the settings in this crate

Cheers,
Stefan