### PR TITLE
server: keep MessageResponse iterators generic

### DIFF
--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -12,6 +12,7 @@ use std::{borrow::Borrow, collections::HashMap, future::Future, io};
 
 use cfg_if::cfg_if;
 use log::{debug, error, info, trace, warn};
+use trust_dns_proto::rr::Record;
 
 #[cfg(feature = "dnssec")]
 use crate::client::rr::{
@@ -37,9 +38,16 @@ pub struct Catalog {
 }
 
 #[allow(unused_mut, unused_variables)]
-async fn send_response<R: ResponseHandler>(
+async fn send_response<'a, R: ResponseHandler>(
     response_edns: Option<Edns>,
-    mut response: MessageResponse<'_, '_>,
+    mut response: MessageResponse<
+        '_,
+        'a,
+        impl Iterator<Item = &'a Record> + Send + 'a,
+        impl Iterator<Item = &'a Record> + Send + 'a,
+        impl Iterator<Item = &'a Record> + Send + 'a,
+        impl Iterator<Item = &'a Record> + Send + 'a,
+    >,
     mut response_handle: R,
 ) -> io::Result<ResponseInfo> {
     #[cfg(feature = "dnssec")]

--- a/crates/server/src/server/https_handler.rs
+++ b/crates/server/src/server/https_handler.rs
@@ -12,6 +12,7 @@ use futures_util::lock::Mutex;
 use h2::server;
 use log::{debug, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
+use trust_dns_proto::rr::Record;
 
 use crate::{
     authority::MessageResponse,
@@ -83,9 +84,16 @@ struct HttpsResponseHandle(Arc<Mutex<::h2::server::SendResponse<Bytes>>>);
 
 #[async_trait::async_trait]
 impl ResponseHandler for HttpsResponseHandle {
-    async fn send_response(
+    async fn send_response<'a>(
         &mut self,
-        response: MessageResponse<'_, '_>,
+        response: MessageResponse<
+            '_,
+            'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+        >,
     ) -> io::Result<ResponseInfo> {
         use crate::proto::https::response;
         use crate::proto::https::HttpsError;

--- a/crates/server/src/server/response_handler.rs
+++ b/crates/server/src/server/response_handler.rs
@@ -8,6 +8,7 @@
 use std::{io, net::SocketAddr};
 
 use log::debug;
+use trust_dns_proto::rr::Record;
 
 use crate::{
     authority::MessageResponse,
@@ -25,9 +26,16 @@ pub trait ResponseHandler: Clone + Send + Sync + Unpin + 'static {
     /// Serializes and sends a message to to the wrapped handle
     ///
     /// self is consumed as only one message should ever be sent in response to a Request
-    async fn send_response(
+    async fn send_response<'a>(
         &mut self,
-        response: MessageResponse<'_, '_>,
+        response: MessageResponse<
+            '_,
+            'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+        >,
     ) -> io::Result<ResponseInfo>;
 }
 
@@ -51,9 +59,16 @@ impl ResponseHandler for ResponseHandle {
     /// Serializes and sends a message to to the wrapped handle
     ///
     /// self is consumed as only one message should ever be sent in response to a Request
-    async fn send_response(
+    async fn send_response<'a>(
         &mut self,
-        response: MessageResponse<'_, '_>,
+        response: MessageResponse<
+            '_,
+            'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+        >,
     ) -> io::Result<ResponseInfo> {
         debug!(
             "response: {} response_code: {}",

--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -11,6 +11,7 @@ use log::{debug, info, warn};
 #[cfg(feature = "dns-over-rustls")]
 use rustls::{Certificate, PrivateKey};
 use tokio::{net, task::JoinHandle};
+use trust_dns_proto::rr::Record;
 
 #[cfg(all(feature = "dns-over-openssl", not(feature = "dns-over-rustls")))]
 use crate::proto::openssl::tls_server::*;
@@ -609,9 +610,16 @@ struct ReportingResponseHandler<R: ResponseHandler> {
 
 #[async_trait::async_trait]
 impl<R: ResponseHandler> ResponseHandler for ReportingResponseHandler<R> {
-    async fn send_response(
+    async fn send_response<'a>(
         &mut self,
-        response: crate::authority::MessageResponse<'_, '_>,
+        response: crate::authority::MessageResponse<
+            '_,
+            'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+        >,
     ) -> io::Result<super::ResponseInfo> {
         let response_info = self.handler.send_response(response).await?;
 

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -27,6 +27,7 @@ use trust_dns_client::{
 };
 use trust_dns_proto::{
     error::ProtoError,
+    rr::Record,
     xfer::{DnsClientStream, DnsMultiplexer, DnsMultiplexerConnect, SerialMessage, StreamReceiver},
     BufDnsStreamHandle, TokioTime,
 };
@@ -105,9 +106,16 @@ impl TestResponseHandler {
 
 #[async_trait::async_trait]
 impl ResponseHandler for TestResponseHandler {
-    async fn send_response(
+    async fn send_response<'a>(
         &mut self,
-        response: MessageResponse<'_, '_>,
+        response: MessageResponse<
+            '_,
+            'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+        >,
     ) -> io::Result<ResponseInfo> {
         let buf = &mut self.buf.lock().unwrap();
         buf.clear();


### PR DESCRIPTION
`ResponseHandler`, due to not specifying the default type arguments for `MessageResponse`, only allowed boxed up iterators. Remove the default types and propagate the type constraints everywhere.

In the limit, this could cause quite a bit of monomorphized code to be generated.