### PR TITLE
pass RequestInfo into Authority on search

### DIFF
--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -132,6 +132,14 @@ impl fmt::Display for Flags {
 
 impl Default for Header {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Header {
+    // TODO: we should make id, message_type and op_code all required and non-editable
+    /// A default Header, not very useful.
+    pub const fn new() -> Self {
         Header {
             id: 0,
             message_type: MessageType::Query,
@@ -142,20 +150,12 @@ impl Default for Header {
             recursion_available: false,
             authentic_data: false,
             checking_disabled: false,
-            response_code: ResponseCode::default(),
+            response_code: ResponseCode::NoError,
             query_count: 0,
             answer_count: 0,
             name_server_count: 0,
             additional_count: 0,
         }
-    }
-}
-
-impl Header {
-    // TODO: we should make id, message_type and op_code all required and non-editable
-    /// A default Header, not very useful.
-    pub fn new() -> Self {
-        Default::default()
     }
 
     /// Construct a new header based off the request header. This copies over the RD (recursion-desired)

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -17,11 +17,9 @@ use crate::client::{
 };
 use crate::{
     authority::{LookupError, MessageRequest, UpdateResult, ZoneType},
-    client::{
-        op::LowerQuery,
-        rr::{LowerName, RecordSet, RecordType},
-    },
+    client::rr::{LowerName, RecordSet, RecordType},
     proto::rr::RrsetRecords,
+    server::RequestInfo,
 };
 
 /// LookupOptions that specify different options from the client to include or exclude various records in the response.
@@ -148,7 +146,7 @@ pub trait Authority: Send + Sync {
     ///  `is_secure` is true, in the case of no records found then NSEC records will be returned.
     async fn search(
         &self,
-        query: &LowerQuery,
+        request: RequestInfo<'_>,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError>;
 

--- a/crates/server/src/authority/authority_object.rs
+++ b/crates/server/src/authority/authority_object.rs
@@ -13,10 +13,8 @@ use log::debug;
 
 use crate::{
     authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType},
-    client::{
-        op::LowerQuery,
-        rr::{LowerName, Record, RecordType},
-    },
+    client::rr::{LowerName, Record, RecordType},
+    server::RequestInfo,
 };
 
 /// An Object safe Authority
@@ -71,7 +69,7 @@ pub trait AuthorityObject: Send + Sync {
     ///  `is_secure` is true, in the case of no records found then NSEC records will be returned.
     async fn search(
         &self,
-        query: &LowerQuery,
+        request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
     ) -> Result<Box<dyn LookupObject>, LookupError>;
 
@@ -185,12 +183,12 @@ where
     ///  `is_secure` is true, in the case of no records found then NSEC records will be returned.
     async fn search(
         &self,
-        query: &LowerQuery,
+        request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
     ) -> Result<Box<dyn LookupObject>, LookupError> {
         let this = self.as_ref();
-        debug!("performing {} on {}", query, this.origin());
-        let lookup = Authority::search(&*this, query, lookup_options).await;
+        debug!("performing {} on {}", request_info.query, this.origin());
+        let lookup = Authority::search(&*this, request_info, lookup_options).await;
         lookup.map(|l| Box::new(l) as Box<dyn LookupObject>)
     }
 

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -414,6 +414,7 @@ async fn lookup<'a, R: ResponseHandler + Unpin>(
 
     let (response_header, sections) = build_response(
         &*authority,
+        request_info,
         request.id(),
         request.header(),
         query,
@@ -466,6 +467,7 @@ fn lookup_options_for_edns(edns: Option<&Edns>) -> LookupOptions {
 
 async fn build_response(
     authority: &dyn AuthorityObject,
+    request_info: RequestInfo<'_>,
     request_id: u16,
     request_header: &Header,
     query: &LowerQuery,
@@ -485,7 +487,7 @@ async fn build_response(
     response_header.set_authoritative(authority.zone_type().is_authoritative());
 
     debug!("performing {} on {}", query, authority.origin());
-    let future = authority.search(query, lookup_options);
+    let future = authority.search(request_info, lookup_options);
 
     #[allow(deprecated)]
     let sections = match authority.zone_type() {

--- a/crates/server/src/server/request_handler.rs
+++ b/crates/server/src/server/request_handler.rs
@@ -68,6 +68,7 @@ impl std::ops::Deref for Request {
     }
 }
 
+// TODO: add ProtocolInfo that would have TLS details or other additional things...
 /// A narrow view of the Request, specifically a verified single query for the request
 #[non_exhaustive]
 pub struct RequestInfo<'a> {
@@ -79,6 +80,30 @@ pub struct RequestInfo<'a> {
     pub header: &'a Header,
     /// The query from the request
     pub query: &'a LowerQuery,
+}
+
+impl<'a> RequestInfo<'a> {
+    /// Construct a new RequestInfo
+    ///
+    /// # Arguments
+    ///
+    /// * `src` - The source address from which the request came
+    /// * `protocol` - The protocol used for the request
+    /// * `header` - The header from the original request
+    /// * `query` - The query from the request, LowerQuery is intended to reduce complexity for lookups in authorities
+    pub fn new(
+        src: SocketAddr,
+        protocol: Protocol,
+        header: &'a Header,
+        query: &'a LowerQuery,
+    ) -> Self {
+        Self {
+            src,
+            protocol,
+            header,
+            query,
+        }
+    }
 }
 
 /// Information about the response sent for a request

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -28,10 +28,10 @@ use crate::{
 use crate::{
     authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType},
     client::{
-        op::LowerQuery,
         rr::{LowerName, Name, RecordSet, RecordType, RrKey},
         serialize::txt::{Lexer, Parser, Token},
     },
+    server::RequestInfo,
     store::{file::FileConfig, in_memory::InMemoryAuthority},
 };
 
@@ -295,10 +295,10 @@ impl Authority for FileAuthority {
     ///  `is_secure` is true, in the case of no records found then NSEC records will be returned.
     async fn search(
         &self,
-        query: &LowerQuery,
+        request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        self.0.search(query, lookup_options).await
+        self.0.search(request_info, lookup_options).await
     }
 
     /// Get the NS, NameServer, record for the zone

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -14,12 +14,13 @@ use crate::{
         Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
     },
     client::{
-        op::{LowerQuery, ResponseCode},
+        op::ResponseCode,
         rr::{LowerName, Name, Record, RecordType},
     },
     resolver::{
         config::ResolverConfig, lookup::Lookup as ResolverLookup, TokioAsyncResolver, TokioHandle,
     },
+    server::RequestInfo,
     store::forwarder::ForwardConfig,
 };
 
@@ -116,11 +117,15 @@ impl Authority for ForwardAuthority {
 
     async fn search(
         &self,
-        query: &LowerQuery,
+        request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        self.lookup(query.name(), query.query_type(), lookup_options)
-            .await
+        self.lookup(
+            request_info.query.name(),
+            request_info.query.query_type(),
+            lookup_options,
+        )
+        .await
     }
 
     async fn get_nsec_records(

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -35,12 +35,13 @@ use crate::{
         MessageRequest, UpdateResult, ZoneType,
     },
     client::{
-        op::{LowerQuery, ResponseCode},
+        op::ResponseCode,
         rr::{
             rdata::SOA,
             {DNSClass, LowerName, Name, RData, Record, RecordSet, RecordType, RrKey},
         },
     },
+    server::RequestInfo,
 };
 
 /// InMemoryAuthority is responsible for storing the resource records for a particular zone.
@@ -1141,13 +1142,13 @@ impl Authority for InMemoryAuthority {
 
     async fn search(
         &self,
-        query: &LowerQuery,
+        request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        debug!("searching InMemoryAuthority for: {}", query);
+        debug!("searching InMemoryAuthority for: {}", request_info.query);
 
-        let lookup_name = query.name();
-        let record_type: RecordType = query.query_type();
+        let lookup_name = request_info.query.name();
+        let record_type: RecordType = request_info.query.query_type();
 
         // if this is an AXFR zone transfer, verify that this is either the Secondary or Primary
         //  for AXFR the first and last record must be the SOA

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -18,15 +18,13 @@ use log::{error, info, warn};
 
 use crate::{
     authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType},
-    client::{
-        op::LowerQuery,
-        rr::{LowerName, RrKey},
-    },
+    client::rr::{LowerName, RrKey},
     error::{PersistenceErrorKind, PersistenceResult},
     proto::{
         op::ResponseCode,
         rr::{DNSClass, Name, RData, Record, RecordSet, RecordType},
     },
+    server::RequestInfo,
     store::{
         in_memory::InMemoryAuthority,
         sqlite::{Journal, SqliteConfig},
@@ -968,10 +966,10 @@ impl Authority for SqliteAuthority {
 
     async fn search(
         &self,
-        query: &LowerQuery,
+        request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        self.in_memory.search(query, lookup_options).await
+        self.in_memory.search(request_info, lookup_options).await
     }
 
     /// Return the NSEC records based on the given name


### PR DESCRIPTION
Fixes: #1613

@moschroe, It took me a while to come back around to this.

This is a first pass at adding the request details to the `Authority::search` method, but should suffice for the original issue. I do want to extend this for DoH, DoT, and eventually DoQ to allow for client cert validation (of some form), though the TLS protocol may actually require a different method that's not authority based. We'll see.