### PR TITLE
Fix minimal dependency versions

### DIFF
--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -65,7 +65,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-std = { version = "1.6", features = ["unstable"] }
-async-trait = "0.1.42"
+async-trait = "0.1.43"
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 pin-utils = "0.1.0"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -71,7 +71,7 @@ cfg-if = "1"
 data-encoding = "2.2.0"
 futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
-lazy_static = "1.0"
+lazy_static = "1.2.0"
 log = "0.4"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 radix_trie = "0.2.0"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -68,7 +68,7 @@ name = "trust_dns_proto"
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1.42"
+async-trait = "0.1.43"
 backtrace = { version = "0.3.50", optional = true }
 bytes = { version = "1", optional = true }
 cfg-if = "1"
@@ -82,7 +82,7 @@ http = { version = "0.2", optional = true }
 idna = "0.2.3"
 ipnet = "2.3.0"
 js-sys = { version = "0.3.44", optional = true }
-lazy_static = "1.0"
+lazy_static = "1.2.0"
 log = "0.4"
 native-tls = { version = "0.2", optional = true }
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/lib.rs"
 [dependencies]
 cfg-if = "1.0.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
-lazy_static = "1.0"
+lazy_static = "1.2.0"
 log = "0.4"
 lru-cache = "0.1.2"
 parking_lot = "0.12"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -73,7 +73,7 @@ name = "trust_dns_server"
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1.42"
+async-trait = "0.1.43"
 bytes = "1"
 cfg-if = "1"
 enum-as-inner = "0.3"

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -69,9 +69,9 @@ dns-over-tls = []
 sqlite = ["rusqlite", "trust-dns-server/sqlite"]
 
 [dependencies]
-async-trait = "0.1.42"
+async-trait = "0.1.43"
 env_logger = "0.9"
-lazy_static = "1.0"
+lazy_static = "1.2.0"
 log = "0.4"
 futures = "0.3.5"
 openssl = { version = "0.10", features = ["v102", "v110"] }


### PR DESCRIPTION
This is a small improvement that helps dependents build with minimal versions.

* async-trait `0.1.42` → `0.1.43` (compile error in trust-dns-server with 0.1.42)
* lazy_static `1.0` → `1.2.0` (compile error in trust-dns-proto with 1.0.0)

To find these version updates, I generated an app with `cargo new` and added a dependency one by one on each of the Trust-DNS packages, each time running `cargo +nightly update -Z minimal-versions`, followed by `cargo check`.

In the future, checking minimal dependency versions (if desired at all) could be done in CI. I cannot look into this for now, so tested this change manually. More could be done, but this seems like a sensible first step.

Note that there is also #919 for this, but there hasn’t been any activity there for a while.