### PR TITLE
Parse DS records

### DIFF
--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -74,7 +74,7 @@ impl RDataParser for RData {
             #[cfg(feature = "dnssec")]
             RecordType::DS => RData::DNSSEC(DNSSECRData::DS(ds::parse(tokens)?)),
             #[cfg(not(feature = "dnssec"))]
-            RecordType::CDS => return Err(ParseError::from("DS should be dynamically generated")),
+            RecordType::DS => return Err(ParseError::from("DS should be dynamically generated")),
             RecordType::CDS => return Err(ParseError::from("CDS should be dynamically generated")),
             RecordType::NSEC => {
                 return Err(ParseError::from("NSEC should be dynamically generated"))

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -19,6 +19,7 @@
 use crate::error::*;
 use crate::rr::{Name, RData, RecordType};
 use crate::serialize::txt::rdata_parsers::*;
+use crate::proto::rr::dnssec::rdata::DNSSECRData;
 
 pub(crate) trait RDataParser: Sized {
     fn parse<'i, I: Iterator<Item = &'i str>>(
@@ -69,7 +70,7 @@ impl RDataParser for RData {
                 return Err(ParseError::from("CDNSKEY should be dynamically generated"))
             }
             RecordType::KEY => return Err(ParseError::from("KEY should be dynamically generated")),
-            RecordType::DS => return Err(ParseError::from("DS should be dynamically generated")),
+            RecordType::DS => RData::DNSSEC(DNSSECRData::DS(ds::parse(tokens)?)),
             RecordType::CDS => return Err(ParseError::from("CDS should be dynamically generated")),
             RecordType::NSEC => {
                 return Err(ParseError::from("NSEC should be dynamically generated"))
@@ -150,6 +151,32 @@ mod tests {
                 false,
                 vec![RecordType::A, RecordType::NS]
             ))
+        );
+    }
+
+    #[test]
+    fn test_ds() {
+        let tokens = ["60485", "5", "1", "2BB183AF5F22588179A53B0A", "98631FAD1A292118"];
+        let name = Name::from_str("dskey.example.com.").unwrap();
+        let record = RData::parse(
+            RecordType::DS,
+            tokens.iter().map(AsRef::as_ref),
+            Some(&name)
+        )
+        .unwrap();
+
+        assert_eq!(
+            record,
+            RData::DNSSEC(DNSSECRData::DS(DS::new(
+                60485,
+                crate::proto::rr::dnssec::Algorithm::RSASHA1,
+                crate::proto::rr::dnssec::DigestType::SHA1,
+                vec![
+                    0x2B, 0xB1, 0x83, 0xAF, 0x5F, 0x22, 0x58, 0x81,
+                    0x79, 0xA5, 0x3B, 0x0A, 0x98, 0x63, 0x1F, 0xAD,
+                    0x1A, 0x29, 0x21, 0x18
+                ]
+            )))
         );
     }
 

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -19,6 +19,7 @@
 use crate::error::*;
 use crate::rr::{Name, RData, RecordType};
 use crate::serialize::txt::rdata_parsers::*;
+#[cfg(feature = "dnssec")]
 use crate::proto::rr::dnssec::rdata::DNSSECRData;
 
 pub(crate) trait RDataParser: Sized {
@@ -70,7 +71,10 @@ impl RDataParser for RData {
                 return Err(ParseError::from("CDNSKEY should be dynamically generated"))
             }
             RecordType::KEY => return Err(ParseError::from("KEY should be dynamically generated")),
+            #[cfg(feature = "dnssec")]
             RecordType::DS => RData::DNSSEC(DNSSECRData::DS(ds::parse(tokens)?)),
+            #[cfg(not(feature = "dnssec"))]
+            RecordType::CDS => return Err(ParseError::from("DS should be dynamically generated")),
             RecordType::CDS => return Err(ParseError::from("CDS should be dynamically generated")),
             RecordType::NSEC => {
                 return Err(ParseError::from("NSEC should be dynamically generated"))
@@ -154,6 +158,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "dnssec")]
     #[test]
     fn test_ds() {
         let tokens = ["60485", "5", "1", "2BB183AF5F22588179A53B0A", "98631FAD1A292118"];

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -17,10 +17,10 @@
 //! record data enum variants
 
 use crate::error::*;
-use crate::rr::{Name, RData, RecordType};
-use crate::serialize::txt::rdata_parsers::*;
 #[cfg(feature = "dnssec")]
 use crate::proto::rr::dnssec::rdata::DNSSECRData;
+use crate::rr::{Name, RData, RecordType};
+use crate::serialize::txt::rdata_parsers::*;
 
 pub(crate) trait RDataParser: Sized {
     fn parse<'i, I: Iterator<Item = &'i str>>(
@@ -161,12 +161,18 @@ mod tests {
     #[cfg(feature = "dnssec")]
     #[test]
     fn test_ds() {
-        let tokens = ["60485", "5", "1", "2BB183AF5F22588179A53B0A", "98631FAD1A292118"];
+        let tokens = [
+            "60485",
+            "5",
+            "1",
+            "2BB183AF5F22588179A53B0A",
+            "98631FAD1A292118",
+        ];
         let name = Name::from_str("dskey.example.com.").unwrap();
         let record = RData::parse(
             RecordType::DS,
             tokens.iter().map(AsRef::as_ref),
-            Some(&name)
+            Some(&name),
         )
         .unwrap();
 
@@ -177,9 +183,8 @@ mod tests {
                 crate::proto::rr::dnssec::Algorithm::RSASHA1,
                 crate::proto::rr::dnssec::DigestType::SHA1,
                 vec![
-                    0x2B, 0xB1, 0x83, 0xAF, 0x5F, 0x22, 0x58, 0x81,
-                    0x79, 0xA5, 0x3B, 0x0A, 0x98, 0x63, 0x1F, 0xAD,
-                    0x1A, 0x29, 0x21, 0x18
+                    0x2B, 0xB1, 0x83, 0xAF, 0x5F, 0x22, 0x58, 0x81, 0x79, 0xA5, 0x3B, 0x0A, 0x98,
+                    0x63, 0x1F, 0xAD, 0x1A, 0x29, 0x21, 0x18
                 ]
             )))
         );

--- a/crates/client/src/serialize/txt/rdata_parsers/ds.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/ds.rs
@@ -1,8 +1,8 @@
 //! Parser for DS text form
 
 use crate::error::*;
-use crate::proto::rr::dnssec::{Algorithm, DigestType};
 use crate::proto::rr::dnssec::rdata::ds::DS;
+use crate::proto::rr::dnssec::{Algorithm, DigestType};
 
 /// Parse the RData from a set of Tokens
 ///
@@ -24,7 +24,7 @@ use crate::proto::rr::dnssec::rdata::ds::DS;
 ///    hexadecimal digits.  Whitespace is allowed within the hexadecimal
 ///    text.
 /// ```
-pub (crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<DS> {
+pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<DS> {
     let tag_str: &str = tokens
         .next()
         .ok_or_else(|| ParseError::from(ParseErrorKind::Message("key tag not present")))?;
@@ -45,18 +45,22 @@ pub (crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseRes
         "INDIRECT" => Algorithm::Unknown(252),
         "PRIVATEDNS" => Algorithm::Unknown(253),
         "PRIVATEOID" => Algorithm::Unknown(254),
-        _ => Algorithm::from_u8(algorithm_str.parse()?)
+        _ => Algorithm::from_u8(algorithm_str.parse()?),
     };
     let digest_type = DigestType::from_u8(digest_type_str.parse()?)?;
     let digest_str: String = tokens.collect();
     if digest_str.is_empty() {
-        return Err(ParseError::from(ParseErrorKind::Message("digest not present")));
+        return Err(ParseError::from(ParseErrorKind::Message(
+            "digest not present",
+        )));
     }
     let mut digest = Vec::with_capacity(digest_str.len() / 2);
     let mut s = digest_str.as_str();
     while s.len() >= 2 {
-        if ! s.is_char_boundary(2) {
-            return Err(ParseError::from(ParseErrorKind::Message("digest contains non hexadecimal text")));
+        if !s.is_char_boundary(2) {
+            return Err(ParseError::from(ParseErrorKind::Message(
+                "digest contains non hexadecimal text",
+            )));
         }
         let (byte_str, rest) = s.split_at(2);
         s = rest;
@@ -75,11 +79,12 @@ mod tests {
         assert_eq!(
             parse("60485 5 1 2BB183AF5F22588179A53B0A 98631FAD1A292118".split(' ')).unwrap(),
             DS::new(
-                60485, Algorithm::RSASHA1, DigestType::SHA1,
+                60485,
+                Algorithm::RSASHA1,
+                DigestType::SHA1,
                 vec![
-                    0x2B, 0xB1, 0x83, 0xAF, 0x5F, 0x22, 0x58, 0x81,
-                    0x79, 0xA5, 0x3B, 0x0A, 0x98, 0x63, 0x1F, 0xAD,
-                    0x1A, 0x29, 0x21, 0x18
+                    0x2B, 0xB1, 0x83, 0xAF, 0x5F, 0x22, 0x58, 0x81, 0x79, 0xA5, 0x3B, 0x0A, 0x98,
+                    0x63, 0x1F, 0xAD, 0x1A, 0x29, 0x21, 0x18
                 ]
             )
         );

--- a/crates/client/src/serialize/txt/rdata_parsers/ds.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/ds.rs
@@ -1,0 +1,87 @@
+//! Parser for DS text form
+
+use crate::error::*;
+use crate::proto::rr::dnssec::{Algorithm, DigestType};
+use crate::proto::rr::dnssec::rdata::ds::DS;
+
+/// Parse the RData from a set of Tokens
+///
+/// [RFC 4034, Resource Records for the DNS Security Extensions](https://datatracker.ietf.org/doc/html/rfc4034#section-5.3)
+/// ```text
+/// 5.3.  The DS RR Presentation Format
+///
+///    The presentation format of the RDATA portion is as follows:
+///
+///    The Key Tag field MUST be represented as an unsigned decimal integer.
+///
+///    The Algorithm field MUST be represented either as an unsigned decimal
+///    integer or as an algorithm mnemonic specified in Appendix A.1.
+///
+///    The Digest Type field MUST be represented as an unsigned decimal
+///    integer.
+///
+///    The Digest MUST be represented as a sequence of case-insensitive
+///    hexadecimal digits.  Whitespace is allowed within the hexadecimal
+///    text.
+/// ```
+pub (crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<DS> {
+    let tag_str: &str = tokens
+        .next()
+        .ok_or_else(|| ParseError::from(ParseErrorKind::Message("key tag not present")))?;
+    let algorithm_str: &str = tokens
+        .next()
+        .ok_or_else(|| ParseError::from(ParseErrorKind::Message("algorithm not present")))?;
+    let digest_type_str: &str = tokens
+        .next()
+        .ok_or_else(|| ParseError::from(ParseErrorKind::Message("digest type not present")))?;
+    let tag: u16 = tag_str.parse()?;
+    let algorithm = match algorithm_str {
+        // Mnemonics from Appendix A.1.
+        "RSAMD5" => Algorithm::Unknown(1),
+        "DH" => Algorithm::Unknown(2),
+        "DSA" => Algorithm::Unknown(3),
+        "ECC" => Algorithm::Unknown(4),
+        "RSASHA1" => Algorithm::RSASHA1,
+        "INDIRECT" => Algorithm::Unknown(252),
+        "PRIVATEDNS" => Algorithm::Unknown(253),
+        "PRIVATEOID" => Algorithm::Unknown(254),
+        _ => Algorithm::from_u8(algorithm_str.parse()?)
+    };
+    let digest_type = DigestType::from_u8(digest_type_str.parse()?)?;
+    let digest_str: String = tokens.collect();
+    if digest_str.is_empty() {
+        return Err(ParseError::from(ParseErrorKind::Message("digest not present")));
+    }
+    let mut digest = Vec::with_capacity(digest_str.len() / 2);
+    let mut s = digest_str.as_str();
+    while s.len() >= 2 {
+        if ! s.is_char_boundary(2) {
+            return Err(ParseError::from(ParseErrorKind::Message("digest contains non hexadecimal text")));
+        }
+        let (byte_str, rest) = s.split_at(2);
+        s = rest;
+        let byte = u8::from_str_radix(byte_str, 16)?;
+        digest.push(byte);
+    }
+    Ok(DS::new(tag, algorithm, digest_type, digest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parsing() {
+        assert_eq!(
+            parse("60485 5 1 2BB183AF5F22588179A53B0A 98631FAD1A292118".split(' ')).unwrap(),
+            DS::new(
+                60485, Algorithm::RSASHA1, DigestType::SHA1,
+                vec![
+                    0x2B, 0xB1, 0x83, 0xAF, 0x5F, 0x22, 0x58, 0x81,
+                    0x79, 0xA5, 0x3B, 0x0A, 0x98, 0x63, 0x1F, 0xAD,
+                    0x1A, 0x29, 0x21, 0x18
+                ]
+            )
+        );
+    }
+}

--- a/crates/client/src/serialize/txt/rdata_parsers/mod.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod a;
 pub(crate) mod aaaa;
 pub(crate) mod caa;
 pub(crate) mod csync;
+pub(crate) mod ds;
 pub(crate) mod hinfo;
 pub(crate) mod mx;
 pub(crate) mod name;

--- a/crates/client/src/serialize/txt/rdata_parsers/mod.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod a;
 pub(crate) mod aaaa;
 pub(crate) mod caa;
 pub(crate) mod csync;
+#[cfg(feature = "dnssec")]
 pub(crate) mod ds;
 pub(crate) mod hinfo;
 pub(crate) mod mx;

--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -387,7 +387,7 @@ impl Parser {
     /// use trust_dns_client::serialize::txt::Parser;
     ///
     /// assert_eq!(Parser::parse_time("0").unwrap(),  0);
-    /// assert_eq!(Parser::parse_time("s").unwrap(),  0);
+    /// assert!(Parser::parse_time("s").is_err());
     /// assert_eq!(Parser::parse_time("0s").unwrap(), 0);
     /// assert_eq!(Parser::parse_time("1").unwrap(),  1);
     /// assert_eq!(Parser::parse_time("1S").unwrap(), 1);
@@ -405,40 +405,40 @@ impl Parser {
     /// ```
     pub fn parse_time(ttl_str: &str) -> ParseResult<u32> {
         let mut value: u32 = 0;
-        let mut collect: u32 = 0;
+        let mut collect: Option<u32> = None;
 
         for c in ttl_str.chars() {
             match c {
                 // TODO, should these all be checked operations?
                 '0'..='9' => {
-                    collect *= 10;
-                    collect += c.to_digit(10).ok_or(ParseErrorKind::CharToInt(c))?;
+                    let digit = c.to_digit(10).ok_or(ParseErrorKind::CharToInt(c))?;
+                    collect = Some(collect.unwrap_or(0) * 10 + digit);
                 }
                 'S' | 's' => {
-                    value += collect;
-                    collect = 0;
+                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))?;
+                    collect = None;
                 }
                 'M' | 'm' => {
-                    value += collect * 60;
-                    collect = 0;
+                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))? * 60;
+                    collect = None;
                 }
                 'H' | 'h' => {
-                    value += collect * 3_600;
-                    collect = 0;
+                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))? * 3_600;
+                    collect = None;
                 }
                 'D' | 'd' => {
-                    value += collect * 86_400;
-                    collect = 0;
+                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))? * 86_400;
+                    collect = None;
                 }
                 'W' | 'w' => {
-                    value += collect * 604_800;
-                    collect = 0;
+                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))? * 604_800;
+                    collect = None;
                 }
                 _ => return Err(ParseErrorKind::ParseTime(ttl_str.to_string()).into()),
             }
         }
 
-        Ok(value + collect) // collects the initial num, or 0 if it was already collected
+        Ok(value + collect.unwrap_or(0)) // collects the initial num, or 0 if it was already collected
     }
 }
 

--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -414,16 +414,35 @@ impl Parser {
                     let digit = c.to_digit(10).ok_or(ParseErrorKind::CharToInt(c))?;
                     collect = Some(collect.unwrap_or(0) * 10 + digit);
                 }
-                'S' | 's' => value += collect.take()
-                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
-                'M' | 'm' => value += 60 * collect.take()
-                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
-                'H' | 'h' => value += 3_600 * collect.take()
-                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
-                'D' | 'd' => value += 86_400 * collect.take()
-                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
-                'W' | 'w' => value += 604_800 * collect.take()
-                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
+                'S' | 's' => {
+                    value += collect
+                        .take()
+                        .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?
+                }
+                'M' | 'm' => {
+                    value += 60
+                        * collect
+                            .take()
+                            .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?
+                }
+                'H' | 'h' => {
+                    value += 3_600
+                        * collect
+                            .take()
+                            .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?
+                }
+                'D' | 'd' => {
+                    value += 86_400
+                        * collect
+                            .take()
+                            .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?
+                }
+                'W' | 'w' => {
+                    value += 604_800
+                        * collect
+                            .take()
+                            .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?
+                }
                 _ => return Err(ParseErrorKind::ParseTime(ttl_str.to_string()).into()),
             }
         }

--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -414,26 +414,16 @@ impl Parser {
                     let digit = c.to_digit(10).ok_or(ParseErrorKind::CharToInt(c))?;
                     collect = Some(collect.unwrap_or(0) * 10 + digit);
                 }
-                'S' | 's' => {
-                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))?;
-                    collect = None;
-                }
-                'M' | 'm' => {
-                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))? * 60;
-                    collect = None;
-                }
-                'H' | 'h' => {
-                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))? * 3_600;
-                    collect = None;
-                }
-                'D' | 'd' => {
-                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))? * 86_400;
-                    collect = None;
-                }
-                'W' | 'w' => {
-                    value += collect.ok_or(ParseErrorKind::ParseTime(ttl_str.to_string()))? * 604_800;
-                    collect = None;
-                }
+                'S' | 's' => value += collect.take()
+                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
+                'M' | 'm' => value += 60 * collect.take()
+                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
+                'H' | 'h' => value += 3_600 * collect.take()
+                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
+                'D' | 'd' => value += 86_400 * collect.take()
+                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
+                'W' | 'w' => value += 604_800 * collect.take()
+                    .ok_or_else(|| ParseErrorKind::ParseTime(ttl_str.to_string()))?,
                 _ => return Err(ParseErrorKind::ParseTime(ttl_str.to_string()).into()),
             }
         }

--- a/crates/proto/src/rr/dnssec/algorithm.rs
+++ b/crates/proto/src/rr/dnssec/algorithm.rs
@@ -99,6 +99,10 @@ use crate::serialize::binary::*;
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[non_exhaustive]
 pub enum Algorithm {
+    /// DO NOT USE, MD5 is a compromised hashing function, it is here for backward compatibility
+    RSAMD5,
+    /// DO NOT USE, SHA1 is a compromised hashing function, it is here for backward compatibility
+    DSA,
     /// DO NOT USE, SHA1 is a compromised hashing function, it is here for backward compatibility
     RSASHA1,
     /// DO NOT USE, SHA1 is a compromised hashing function, it is here for backward compatibility
@@ -121,6 +125,8 @@ impl Algorithm {
     /// <http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml>
     pub fn from_u8(value: u8) -> Self {
         match value {
+            1 => Algorithm::RSAMD5,
+            3 => Algorithm::DSA,
             5 => Algorithm::RSASHA1,
             7 => Algorithm::RSASHA1NSEC3SHA1,
             8 => Algorithm::RSASHA256,
@@ -135,7 +141,8 @@ impl Algorithm {
     /// length in bytes that the hash portion of this function will produce
     pub fn hash_len(self) -> Option<usize> {
         match self {
-            Algorithm::RSASHA1 | Algorithm::RSASHA1NSEC3SHA1 => Some(20), // 160 bits
+            Algorithm::RSAMD5 => Some(16), // 128 bits
+            Algorithm::DSA | Algorithm::RSASHA1 | Algorithm::RSASHA1NSEC3SHA1 => Some(20), // 160 bits
             Algorithm::RSASHA256 | Algorithm::ECDSAP256SHA256 | Algorithm::ED25519 => Some(32), // 256 bits
             Algorithm::ECDSAP384SHA384 => Some(48),
             Algorithm::RSASHA512 => Some(64), // 512 bites
@@ -152,6 +159,8 @@ impl Algorithm {
     /// Convert to string form
     pub fn as_str(self) -> &'static str {
         match self {
+            Algorithm::RSAMD5 => "RSAMD5",
+            Algorithm::DSA => "DSA",
             Algorithm::RSASHA1 => "RSASHA1",
             Algorithm::RSASHA256 => "RSASHA256",
             Algorithm::RSASHA1NSEC3SHA1 => "RSASHA1-NSEC3-SHA1",
@@ -188,6 +197,8 @@ impl From<Algorithm> for &'static str {
 impl From<Algorithm> for u8 {
     fn from(a: Algorithm) -> u8 {
         match a {
+            Algorithm::RSAMD5 => 1,
+            Algorithm::DSA => 3,
             Algorithm::RSASHA1 => 5,
             Algorithm::RSASHA1NSEC3SHA1 => 7,
             Algorithm::RSASHA256 => 8,
@@ -209,6 +220,8 @@ impl Display for Algorithm {
 #[test]
 fn test_into() {
     for algorithm in &[
+        Algorithm::RSAMD5,
+        Algorithm::DSA,
         Algorithm::RSASHA1,
         Algorithm::RSASHA256,
         Algorithm::RSASHA1NSEC3SHA1,
@@ -224,6 +237,8 @@ fn test_into() {
 #[test]
 fn test_order() {
     let mut algorithms = [
+        Algorithm::RSAMD5,
+        Algorithm::DSA,
         Algorithm::RSASHA1,
         Algorithm::RSASHA256,
         Algorithm::RSASHA1NSEC3SHA1,
@@ -237,6 +252,8 @@ fn test_order() {
 
     for (got, expect) in algorithms.iter().zip(
         [
+            Algorithm::RSAMD5,
+            Algorithm::DSA,
             Algorithm::RSASHA1,
             Algorithm::RSASHA1NSEC3SHA1,
             Algorithm::RSASHA256,

--- a/crates/proto/src/rr/dnssec/digest_type.rs
+++ b/crates/proto/src/rr/dnssec/digest_type.rs
@@ -47,7 +47,8 @@ pub enum DigestType {
     SHA1,
     /// [RFC 4509](https://tools.ietf.org/html/rfc4509)
     SHA256,
-    // GOSTR34_11_94, // [RFC5933]
+    /// [RFC 5933](https://tools.ietf.org/html/rfc5933)
+    GOSTR34_11_94,
     /// [RFC 6605](https://tools.ietf.org/html/rfc6605)
     SHA384,
     /// Undefined
@@ -63,7 +64,7 @@ impl DigestType {
         match value {
             1 => Ok(DigestType::SHA1),
             2 => Ok(DigestType::SHA256),
-            //  3  => Ok(DigestType::GOSTR34_11_94),
+            3  => Ok(DigestType::GOSTR34_11_94),
             4 => Ok(DigestType::SHA384),
             5 => Ok(DigestType::ED25519),
             _ => Err(ProtoErrorKind::UnknownAlgorithmTypeValue(value).into()),
@@ -151,7 +152,7 @@ impl DigestType {
 impl From<Algorithm> for DigestType {
     fn from(a: Algorithm) -> DigestType {
         match a {
-            Algorithm::RSASHA1 | Algorithm::RSASHA1NSEC3SHA1 => DigestType::SHA1,
+            Algorithm::RSAMD5 | Algorithm::DSA | Algorithm::RSASHA1 | Algorithm::RSASHA1NSEC3SHA1 => DigestType::SHA1,
             Algorithm::RSASHA256 | Algorithm::ECDSAP256SHA256 => DigestType::SHA256,
             Algorithm::RSASHA512 => DigestType::SHA512,
             Algorithm::ECDSAP384SHA384 => DigestType::SHA384,
@@ -167,7 +168,7 @@ impl From<DigestType> for u8 {
         match a {
             DigestType::SHA1 => 1,
             DigestType::SHA256 => 2,
-            // DigestType::GOSTR34_11_94 => 3,
+            DigestType::GOSTR34_11_94 => 3,
             DigestType::SHA384 => 4,
             DigestType::ED25519 => 5,
             DigestType::SHA512 => 255,

--- a/crates/proto/src/rr/dnssec/digest_type.rs
+++ b/crates/proto/src/rr/dnssec/digest_type.rs
@@ -64,7 +64,7 @@ impl DigestType {
         match value {
             1 => Ok(DigestType::SHA1),
             2 => Ok(DigestType::SHA256),
-            3  => Ok(DigestType::GOSTR34_11_94),
+            3 => Ok(DigestType::GOSTR34_11_94),
             4 => Ok(DigestType::SHA384),
             5 => Ok(DigestType::ED25519),
             _ => Err(ProtoErrorKind::UnknownAlgorithmTypeValue(value).into()),
@@ -152,7 +152,10 @@ impl DigestType {
 impl From<Algorithm> for DigestType {
     fn from(a: Algorithm) -> DigestType {
         match a {
-            Algorithm::RSAMD5 | Algorithm::DSA | Algorithm::RSASHA1 | Algorithm::RSASHA1NSEC3SHA1 => DigestType::SHA1,
+            Algorithm::RSAMD5
+            | Algorithm::DSA
+            | Algorithm::RSASHA1
+            | Algorithm::RSASHA1NSEC3SHA1 => DigestType::SHA1,
             Algorithm::RSASHA256 | Algorithm::ECDSAP256SHA256 => DigestType::SHA256,
             Algorithm::RSASHA512 => DigestType::SHA512,
             Algorithm::ECDSAP384SHA384 => DigestType::SHA384,

--- a/crates/proto/src/rr/dnssec/supported_algorithm.rs
+++ b/crates/proto/src/rr/dnssec/supported_algorithm.rs
@@ -71,7 +71,7 @@ impl SupportedAlgorithms {
             Algorithm::ECDSAP256SHA256 => Some(4),
             Algorithm::ECDSAP384SHA384 => Some(5),
             Algorithm::ED25519 => Some(6),
-            Algorithm::Unknown(_) => None,
+            Algorithm::RSAMD5 | Algorithm::DSA | Algorithm::Unknown(_) => None,
         };
 
         bit_pos.map(|b| 1u8 << b)

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -370,7 +370,8 @@ mod tests {
     fn test_load_zone() {
         #[cfg(feature = "dnssec")]
         let config = FileConfig {
-            zone_file_path: "../../tests/test-data/named_test_configs/dnssec/example.com.zone".to_string(),
+            zone_file_path: "../../tests/test-data/named_test_configs/dnssec/example.com.zone"
+                .to_string(),
         };
         #[cfg(not(feature = "dnssec"))]
         let config = FileConfig {

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -368,6 +368,11 @@ mod tests {
 
     #[test]
     fn test_load_zone() {
+        #[cfg(feature = "dnssec")]
+        let config = FileConfig {
+            zone_file_path: "../../tests/test-data/named_test_configs/dnssec/example.com.zone".to_string(),
+        };
+        #[cfg(not(feature = "dnssec"))]
         let config = FileConfig {
             zone_file_path: "../../tests/test-data/named_test_configs/example.com.zone".to_string(),
         };

--- a/tests/test-data/named_test_configs/dnssec/example.com.zone
+++ b/tests/test-data/named_test_configs/dnssec/example.com.zone
@@ -30,4 +30,7 @@ server          SRV     1 1 443 alias
 
 no-service 86400 IN MX 0 .
 
+dskey           NS      www
+                DS      60485 5 1 2BB183AF5F22588179A53B0A 98631FAD1A292118
+
 $INCLUDE include.example.com.zone

--- a/tests/test-data/named_test_configs/dnssec/example.com.zone
+++ b/tests/test-data/named_test_configs/dnssec/example.com.zone
@@ -33,4 +33,4 @@ no-service 86400 IN MX 0 .
 dskey           NS      www
                 DS      60485 5 1 2BB183AF5F22588179A53B0A 98631FAD1A292118
 
-$INCLUDE include.example.com.zone
+$INCLUDE ../include.example.com.zone

--- a/tests/test-data/named_test_configs/example.com.zone
+++ b/tests/test-data/named_test_configs/example.com.zone
@@ -30,4 +30,7 @@ server          SRV     1 1 443 alias
 
 no-service 86400 IN MX 0 .
 
+dskey           NS      www
+                DS      60485 5 1 2BB183AF5F22588179A53B0A 98631FAD1A292118
+
 $INCLUDE include.example.com.zone


### PR DESCRIPTION
Adds support for parsing DS records from zone files.

This requires a "breaking" change: the TTL parser used to accept raw unit letters as valid values. Thus `DS` was parsed as a 0 second TTL. This PR makes that invalid,
