### PR TITLE
deprecate outdated dnssec algorithms

### DIFF
--- a/bin/tests/named_test_rsa_dnssec.rs
+++ b/bin/tests/named_test_rsa_dnssec.rs
@@ -187,6 +187,7 @@ fn test_ed25519() {
 
 #[test]
 #[should_panic]
+#[allow(deprecated)]
 fn test_rsa_sha1_fails() {
     generic_test(
         confg_toml(),

--- a/crates/client/src/rr/dnssec/key_format.rs
+++ b/crates/client/src/rr/dnssec/key_format.rs
@@ -36,6 +36,7 @@ impl KeyFormat {
         let password = password.unwrap_or("");
         let password = password.as_bytes();
 
+        #[allow(deprecated)]
         match algorithm {
             Algorithm::Unknown(v) => Err(format!("unknown algorithm: {}", v).into()),
             #[cfg(feature = "openssl")]
@@ -135,7 +136,7 @@ impl KeyFormat {
             .next();
 
         // generate the key
-        #[allow(unused)]
+        #[allow(unused, deprecated)]
         let key_pair: KeyPair<Private> = match algorithm {
             Algorithm::Unknown(v) => return Err(format!("unknown algorithm: {}", v).into()),
             #[cfg(feature = "openssl")]

--- a/crates/client/src/rr/dnssec/keypair.rs
+++ b/crates/client/src/rr/dnssec/keypair.rs
@@ -452,6 +452,7 @@ impl KeyPair<Private> {
     ///
     /// RSA keys are hardcoded to 2048bits at the moment. Other keys have predefined sizes.
     pub fn generate(algorithm: Algorithm) -> DnsSecResult<Self> {
+        #[allow(deprecated)]
         match algorithm {
             Algorithm::Unknown(_) => Err(DnsSecErrorKind::Message("unknown algorithm").into()),
             #[cfg(feature = "openssl")]
@@ -487,6 +488,7 @@ impl KeyPair<Private> {
     #[cfg(feature = "ring")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ring")))]
     pub fn generate_pkcs8(algorithm: Algorithm) -> DnsSecResult<Vec<u8>> {
+        #[allow(deprecated)]
         match algorithm {
             Algorithm::Unknown(_) => Err(DnsSecErrorKind::Message("unknown algorithm").into()),
             #[cfg(feature = "openssl")]

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -160,6 +160,7 @@ mod tests {
 
     #[cfg(feature = "dnssec")]
     #[test]
+    #[allow(deprecated)]
     fn test_ds() {
         let tokens = [
             "60485",

--- a/crates/client/src/serialize/txt/rdata_parsers/ds.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/ds.rs
@@ -24,6 +24,7 @@ use crate::proto::rr::dnssec::{Algorithm, DigestType};
 ///    hexadecimal digits.  Whitespace is allowed within the hexadecimal
 ///    text.
 /// ```
+#[allow(deprecated)]
 pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResult<DS> {
     let tag_str: &str = tokens
         .next()
@@ -75,6 +76,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn test_parsing() {
         assert_eq!(
             parse("60485 5 1 2BB183AF5F22588179A53B0A 98631FAD1A292118".split(' ')).unwrap(),

--- a/crates/proto/src/rr/dnssec/algorithm.rs
+++ b/crates/proto/src/rr/dnssec/algorithm.rs
@@ -1,9 +1,13 @@
-// Copyright 2015-2019 Benjamin Fry <benjaminfry@me.com>
+// Copyright 2015-2022 Benjamin Fry <benjaminfry@me.com>
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
+
+// needed for the derive statements on algorithm
+//   this issue in rustc would help narrow the statement: https://github.com/rust-lang/rust/issues/62398
+#![allow(deprecated)]
 
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -100,12 +104,24 @@ use crate::serialize::binary::*;
 #[non_exhaustive]
 pub enum Algorithm {
     /// DO NOT USE, MD5 is a compromised hashing function, it is here for backward compatibility
+    #[deprecated(
+        note = "this is a compromised hashing function, it is here for backward compatibility"
+    )]
     RSAMD5,
-    /// DO NOT USE, SHA1 is a compromised hashing function, it is here for backward compatibility
+    /// DO NOT USE, DSA is a compromised hashing function, it is here for backward compatibility
+    #[deprecated(
+        note = "this is a compromised hashing function, it is here for backward compatibility"
+    )]
     DSA,
     /// DO NOT USE, SHA1 is a compromised hashing function, it is here for backward compatibility
+    #[deprecated(
+        note = "this is a compromised hashing function, it is here for backward compatibility"
+    )]
     RSASHA1,
     /// DO NOT USE, SHA1 is a compromised hashing function, it is here for backward compatibility
+    #[deprecated(
+        note = "this is a compromised hashing function, it is here for backward compatibility"
+    )]
     RSASHA1NSEC3SHA1,
     /// RSA public key with SHA256 hash
     RSASHA256,
@@ -124,6 +140,7 @@ pub enum Algorithm {
 impl Algorithm {
     /// <http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml>
     pub fn from_u8(value: u8) -> Self {
+        #[allow(deprecated)]
         match value {
             1 => Self::RSAMD5,
             3 => Self::DSA,

--- a/crates/proto/src/rr/dnssec/digest_type.rs
+++ b/crates/proto/src/rr/dnssec/digest_type.rs
@@ -151,6 +151,7 @@ impl DigestType {
 
 impl From<Algorithm> for DigestType {
     fn from(a: Algorithm) -> Self {
+        #[allow(deprecated)]
         match a {
             Algorithm::RSAMD5
             | Algorithm::DSA

--- a/crates/proto/src/rr/dnssec/public_key.rs
+++ b/crates/proto/src/rr/dnssec/public_key.rs
@@ -403,6 +403,7 @@ impl<'k> PublicKey for Rsa<'k> {
 
     #[cfg(feature = "ring")]
     fn verify(&self, algorithm: Algorithm, message: &[u8], signature: &[u8]) -> ProtoResult<()> {
+        #[allow(deprecated)]
         let alg = match algorithm {
             Algorithm::RSASHA256 => &signature::RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
             Algorithm::RSASHA512 => &signature::RSA_PKCS1_1024_8192_SHA512_FOR_LEGACY_USE_ONLY,
@@ -451,6 +452,7 @@ impl<'k> PublicKeyEnum<'k> {
     /// Converts the bytes into a PulbicKey of the specified algorithm
     #[allow(unused_variables, clippy::match_single_binding)]
     pub fn from_public_bytes(public_key: &'k [u8], algorithm: Algorithm) -> ProtoResult<Self> {
+        #[allow(deprecated)]
         match algorithm {
             #[cfg(any(feature = "openssl", feature = "ring"))]
             Algorithm::ECDSAP256SHA256 | Algorithm::ECDSAP384SHA384 => Ok(PublicKeyEnum::Ec(

--- a/crates/proto/src/rr/dnssec/supported_algorithm.rs
+++ b/crates/proto/src/rr/dnssec/supported_algorithm.rs
@@ -63,6 +63,7 @@ impl SupportedAlgorithms {
 
     fn pos(algorithm: Algorithm) -> Option<u8> {
         // not using the values from the RFC's to keep the bit_map space condensed
+        #[allow(deprecated)]
         let bit_pos: Option<u8> = match algorithm {
             Algorithm::RSASHA1 => Some(0),
             Algorithm::RSASHA256 => Some(1),
@@ -79,6 +80,7 @@ impl SupportedAlgorithms {
 
     fn from_pos(pos: u8) -> Option<Algorithm> {
         // TODO: should build a code generator or possibly a macro for deriving these inversions
+        #[allow(deprecated)]
         match pos {
             0 => Some(Algorithm::RSASHA1),
             1 => Some(Algorithm::RSASHA256),
@@ -218,6 +220,7 @@ impl BinEncodable for SupportedAlgorithms {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_has() {
     let mut supported = SupportedAlgorithms::new();
 
@@ -235,6 +238,8 @@ fn test_has() {
 }
 
 #[test]
+#[allow(deprecated)]
+
 fn test_iterator() {
     let supported = SupportedAlgorithms::all();
     assert_eq!(supported.iter().count(), 7);
@@ -260,6 +265,7 @@ fn test_iterator() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_vec() {
     let supported = SupportedAlgorithms::all();
     let array: Vec<u8> = (&supported).into();

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -570,6 +570,7 @@ impl<'r> Iterator for RrsigsByAlgorithms<'r> {
                     if let Some(RData::DNSSEC(DNSSECRData::SIG(ref rrsig))) = record.data() {
                         rrsig.algorithm()
                     } else {
+                        #[allow(deprecated)]
                         Algorithm::RSASHA1
                     }
                 })

--- a/crates/proto/tests/dnssec_presentation_format_tests.rs
+++ b/crates/proto/tests/dnssec_presentation_format_tests.rs
@@ -5,6 +5,7 @@ use trust_dns_proto::rr::dnssec::{Algorithm, DigestType};
 use trust_dns_proto::rr::Name;
 
 #[test]
+#[allow(deprecated)]
 fn test_dnskey_display() {
     let dnskey = DNSKEY::new(
         true,
@@ -30,6 +31,7 @@ fn test_dnskey_display() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_ds_display() {
     let dnskey = DNSKEY::new(
         true,

--- a/crates/server/src/config/dnssec.rs
+++ b/crates/server/src/config/dnssec.rs
@@ -111,6 +111,7 @@ impl KeyConfig {
     /// algorithm for for the key, see `Algorithm` for supported algorithms.
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
+    #[allow(deprecated)]
     pub fn algorithm(&self) -> ParseResult<Algorithm> {
         match self.algorithm.as_str() {
             "RSASHA1" => Ok(Algorithm::RSASHA1),

--- a/util/src/get_root_ksks.rs
+++ b/util/src/get_root_ksks.rs
@@ -49,6 +49,7 @@ pub fn main() {
         .expect("query failed");
 
     for r in lookup.iter() {
+        #[allow(deprecated)]
         match r {
             RData::DNSSEC(DNSSECRData::DNSKEY(dnskey)) => {
                 if !(dnskey.secure_entry_point() && dnskey.zone_key()) {


### PR DESCRIPTION
after reviewing #1635, I noticed that that we have comments to not use, but felt it ideal that we deprecate specific algorithm types such that a compiler error will occur if used.