### PR TITLE
Stop searching for additional records when encountering a name already seen. Fixes #1283

### DIFF
--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -1034,7 +1034,7 @@ impl Authority for InMemoryAuthority {
                         .and_then(|(search_name, search_type)| {
                             inner
                                 .additional_search(
-                                    name.into(),
+                                    name,
                                     query_type,
                                     search_name,
                                     search_type,

--- a/crates/server/tests/in_memory.rs
+++ b/crates/server/tests/in_memory.rs
@@ -1,0 +1,149 @@
+use std::str::FromStr;
+
+use tokio::runtime::Runtime;
+use trust_dns_client::rr::{Name, RData, Record, RecordType};
+use trust_dns_server::{
+    authority::{Authority, ZoneType},
+    store::in_memory::InMemoryAuthority,
+};
+
+#[test]
+fn test_cname_loop() {
+    let runtime = Runtime::new().expect("failed to create Tokio Runtime");
+    let mut auth = InMemoryAuthority::empty(
+        Name::from_str("example.com.").unwrap(),
+        ZoneType::Primary,
+        false,
+    );
+
+    auth.upsert_mut(
+        Record::from_rdata(
+            Name::from_str("foo.example.com.").unwrap(),
+            300,
+            RData::CNAME(Name::from_str("foo.example.com.").unwrap()),
+        ),
+        0,
+    );
+
+    auth.upsert_mut(
+        Record::from_rdata(
+            Name::from_str("bar.example.com.").unwrap(),
+            300,
+            RData::CNAME(Name::from_str("foo.example.com.").unwrap()),
+        ),
+        0,
+    );
+
+    auth.upsert_mut(
+        Record::from_rdata(
+            Name::from_str("baz.example.com.").unwrap(),
+            300,
+            RData::CNAME(Name::from_str("boz.example.com.").unwrap()),
+        ),
+        0,
+    );
+
+    auth.upsert_mut(
+        Record::from_rdata(
+            Name::from_str("boz.example.com.").unwrap(),
+            300,
+            RData::CNAME(Name::from_str("biz.example.com.").unwrap()),
+        ),
+        0,
+    );
+
+    auth.upsert_mut(
+        Record::from_rdata(
+            Name::from_str("biz.example.com.").unwrap(),
+            300,
+            RData::CNAME(Name::from_str("baz.example.com.").unwrap()),
+        ),
+        0,
+    );
+
+    let mut lookup = runtime
+        .block_on(auth.lookup(
+            &Name::from_str("foo.example.com.").unwrap().into(),
+            RecordType::A,
+            Default::default(),
+        ))
+        .unwrap();
+
+    let records: Vec<&Record> = lookup.iter().collect();
+    assert_eq!(records.len(), 1);
+    let record = records[0];
+    assert_eq!(record.name(), &Name::from_str("foo.example.com.").unwrap());
+    assert_eq!(
+        record.data(),
+        Some(&RData::CNAME(Name::from_str("foo.example.com.").unwrap()))
+    );
+
+    assert!(
+        lookup.take_additionals().is_none(),
+        "Should be no additional records."
+    );
+
+    let mut lookup = runtime
+        .block_on(auth.lookup(
+            &Name::from_str("bar.example.com.").unwrap().into(),
+            RecordType::A,
+            Default::default(),
+        ))
+        .unwrap();
+
+    let records: Vec<&Record> = lookup.iter().collect();
+    assert_eq!(records.len(), 1);
+    let record = records[0];
+    assert_eq!(record.name(), &Name::from_str("bar.example.com.").unwrap());
+    assert_eq!(
+        record.data(),
+        Some(&RData::CNAME(Name::from_str("foo.example.com.").unwrap()))
+    );
+
+    let additionals = lookup
+        .take_additionals()
+        .expect("Should be additional records");
+    let additionals: Vec<&Record> = additionals.iter().collect();
+    assert_eq!(additionals.len(), 1);
+    let record = additionals[0];
+    assert_eq!(record.name(), &Name::from_str("foo.example.com.").unwrap());
+    assert_eq!(
+        record.data(),
+        Some(&RData::CNAME(Name::from_str("foo.example.com.").unwrap()))
+    );
+
+    let mut lookup = runtime
+        .block_on(auth.lookup(
+            &Name::from_str("baz.example.com.").unwrap().into(),
+            RecordType::A,
+            Default::default(),
+        ))
+        .unwrap();
+
+    let records: Vec<&Record> = lookup.iter().collect();
+    assert_eq!(records.len(), 1);
+    let record = records[0];
+    assert_eq!(record.name(), &Name::from_str("baz.example.com.").unwrap());
+    assert_eq!(
+        record.data(),
+        Some(&RData::CNAME(Name::from_str("boz.example.com.").unwrap()))
+    );
+
+    let additionals = lookup
+        .take_additionals()
+        .expect("Should be additional records");
+    let additionals: Vec<&Record> = additionals.iter().collect();
+    assert_eq!(additionals.len(), 2);
+    let record = additionals[0];
+    assert_eq!(record.name(), &Name::from_str("boz.example.com.").unwrap());
+    assert_eq!(
+        record.data(),
+        Some(&RData::CNAME(Name::from_str("biz.example.com.").unwrap()))
+    );
+    let record = additionals[1];
+    assert_eq!(record.name(), &Name::from_str("biz.example.com.").unwrap());
+    assert_eq!(
+        record.data(),
+        Some(&RData::CNAME(Name::from_str("baz.example.com.").unwrap()))
+    );
+}


### PR DESCRIPTION
I've assumed that including the original record in additionals is incorrect so I had to pass in the original name to stop that from happening. Also seems that the `continue_name` variable is unnecessary.

fixes: #1283