### PR TITLE
force forwarder to preserve_intermediates

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -808,7 +808,10 @@ impl Default for ResolverOpts {
             positive_max_ttl: None,
             negative_max_ttl: None,
             num_concurrent_reqs: 2,
-            preserve_intermediates: false,
+
+            // Defaults to `true` to match the behavior of dig and nslookup.
+            preserve_intermediates: true,
+
             try_tcp_on_error: false,
         }
     }


### PR DESCRIPTION
According to RFC 1034, Section 4.3.2 step 3/a:

    If the data at the node is a CNAME, and QTYPE doesn't
    match CNAME, copy the CNAME RR into the answer section
    of the response, change QNAME to the canonical name in
    the CNAME RR, and go back to step 1.

This paragraph is describing the required behavior for name servers,
which includes TrustDNS's forwarder implementation. The behavior of
the forwarder in this context is controlled by a parameter
`preserve_intermediates`, which determines whether or not the TrustDNS
client implementation will collapse CNAMEs (the "intermediates") into
just the final non-CNAME record (if any), or if the client will resolve
to all found records including CNAMEs.

Because the forwarder uses the client implementation internally, we need
to ensure that `preserve_intermediates` is set to `true` when the
forwarder configures its DNS client. Before this commit, the value
defaulted to `false` unless otherwise specified in a config file.

With this commit, the forwarder will unconditionally set
`preserve_intermediates` to true, and will warn the user if they have
configured `preserve_intermediates` to false.

RFC 1034: https://www.rfc-editor.org/rfc/rfc1034.html