### PR TITLE
proto: add PartialEq+Hash derives

### DIFF
--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -47,7 +47,7 @@ use crate::{
 ///
 /// ```
 ///
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Hash)]
 pub struct Header {
     id: u16,
     message_type: MessageType,
@@ -81,7 +81,7 @@ impl fmt::Display for Header {
 }
 
 /// Message types are either Query (also Update) or Response
-#[derive(Debug, PartialEq, PartialOrd, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Copy, Clone, Hash)]
 pub enum MessageType {
     /// Queries are Client requests, these are either Queries or Updates
     Query,
@@ -101,7 +101,7 @@ impl fmt::Display for MessageType {
 }
 
 /// All the flags of the request/response header
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Flags {
     authoritative: bool,
     truncation: bool,

--- a/crates/proto/src/op/op_code.rs
+++ b/crates/proto/src/op/op_code.rs
@@ -28,7 +28,7 @@ use crate::error::*;
 ///
 ///                 3-15            reserved for future use
 /// ```
-#[derive(Debug, PartialEq, PartialOrd, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Copy, Clone, Hash)]
 #[allow(dead_code)]
 pub enum OpCode {
     /// Query request [RFC 1035](https://tools.ietf.org/html/rfc1035)

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -59,7 +59,7 @@ use std::fmt::{Display, Formatter};
 ///
 ///                 6-15            Reserved for future use.
 ///  ```
-#[derive(Debug, Eq, PartialEq, PartialOrd, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Copy, Clone, Hash)]
 #[allow(dead_code)]
 pub enum ResponseCode {
     /// No Error [RFC 1035](https://tools.ietf.org/html/rfc1035)

--- a/crates/proto/src/rr/dnssec/ec_public_key.rs
+++ b/crates/proto/src/rr/dnssec/ec_public_key.rs
@@ -9,7 +9,7 @@ use super::Algorithm;
 use crate::error::*;
 
 #[allow(unreachable_pub)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct ECPublicKey {
     buf: [u8; MAX_LEN],
     len: usize,

--- a/crates/proto/src/xfer/dns_request.rs
+++ b/crates/proto/src/xfer/dns_request.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, DerefMut};
 use crate::op::Message;
 
 /// A set of options for expressing options to how requests should be treated
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct DnsRequestOptions {
     /// When true, the underlying DNS protocols will not return on the first response received.
@@ -30,7 +30,7 @@ pub struct DnsRequestOptions {
 /// A DNS request object
 ///
 /// This wraps a DNS Message for requests. It also has request options associated for controlling certain features of the DNS protocol handlers.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct DnsRequest {
     message: Message,
     options: DnsRequestOptions,


### PR DESCRIPTION
Hello! I had needed a `PartialEq` and `Hash` impl on `Flags`. When I went through and added it to a couple more structs.

Acceptable? I saw `Eq` was not derived on some and wasn't sure if that was intentional either.