### PR TITLE
crates/server, InMemoryStore: Use a RwLock instead of a Mutex to manage inner storage

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -89,7 +89,7 @@ rustls = { version = "0.20", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.20"
 time = "0.3"
-tokio = { version = "1.0", features = ["net"] }
+tokio = { version = "1.0", features = ["net", "sync"] }
 tokio-openssl = { version = "0.6.0", optional = true }
 tokio-rustls = { version = "0.23.0", optional = true }
 toml = "0.5"

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -10,7 +10,7 @@
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, HashSet},
-    ops::{Deref, DerefMut},
+    ops::DerefMut,
     sync::Arc,
 };
 
@@ -42,6 +42,8 @@ use crate::{
     },
     server::RequestInfo,
 };
+#[cfg(all(feature = "dnssec", feature = "testing"))]
+use std::ops::Deref;
 
 /// InMemoryAuthority is responsible for storing the resource records for a particular zone.
 ///
@@ -149,8 +151,9 @@ impl InMemoryAuthority {
     }
 
     /// Get all the records
-    pub async fn records(&self) -> impl Deref<Target = BTreeMap<RrKey, Arc<RecordSet>>> + '_ {
-        RwLockReadGuard::map(self.inner.read().await, |i| &i.records)
+    pub async fn records(&self) -> BTreeMap<RrKey, Arc<RecordSet>> {
+        let records = RwLockReadGuard::map(self.inner.read().await, |i| &i.records);
+        records.clone()
     }
 
     /// Get a mutable reference to the records


### PR DESCRIPTION
This was causing unexpected deadlocks during usage.

Signed-off-by: Erik Hollensbe <git@hollensbe.org>