### PR TITLE
deprecate edns methods, add extensions

### DIFF
--- a/bin/tests/server_harness/mut_message_client.rs
+++ b/bin/tests/server_harness/mut_message_client.rs
@@ -1,7 +1,7 @@
 use trust_dns_client::client::*;
 use trust_dns_client::proto::xfer::{DnsHandle, DnsRequest};
 #[cfg(feature = "dnssec")]
-use trust_dns_client::rr::rdata::opt::EdnsOption;
+use trust_dns_client::{op::Edns, rr::rdata::opt::EdnsOption};
 use trust_dns_server::authority::LookupOptions;
 
 #[derive(Clone)]
@@ -35,7 +35,7 @@ impl<C: ClientHandle + Unpin> DnsHandle for MutMessageHandle<C> {
         #[cfg(feature = "dnssec")]
         {
             // mutable block
-            let edns = request.edns_mut();
+            let edns = request.extensions_mut().get_or_insert_with(Edns::new);
             edns.set_dnssec_ok(true);
             edns.options_mut()
                 .insert(EdnsOption::DAU(self.lookup_options.supported_algorithms()));

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -15,6 +15,7 @@ use futures_util::ready;
 use futures_util::stream::{Stream, StreamExt};
 use log::debug;
 use rand;
+use trust_dns_proto::op::Edns;
 
 use crate::client::Signer;
 use crate::error::*;
@@ -268,9 +269,10 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
 
         // Extended dns
         if self.is_using_edns() {
-            let edns = message.edns_mut();
-            edns.set_max_payload(MAX_PAYLOAD_LEN);
-            edns.set_version(0);
+            message
+                .set_edns(Edns::new())
+                .edns_mut()
+                .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
         }
 
         // add the query

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -270,9 +270,10 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
         // Extended dns
         if self.is_using_edns() {
             message
-                .set_edns(Edns::new())
-                .edns_mut()
-                .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+                .extensions_mut()
+                .get_or_insert_with(Edns::new)
+                .set_max_payload(MAX_PAYLOAD_LEN)
+                .set_version(0);
         }
 
         // add the query

--- a/crates/client/src/op/update_message.rs
+++ b/crates/client/src/op/update_message.rs
@@ -188,9 +188,10 @@ pub fn create(rrset: RecordSet, zone_origin: Name, use_edns: bool) -> Message {
     // Extended dns
     if use_edns {
         message
-            .set_edns(Edns::new())
-            .edns_mut()
-            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+            .extensions_mut()
+            .get_or_insert_with(Edns::new)
+            .set_max_payload(MAX_PAYLOAD_LEN)
+            .set_version(0);
     }
 
     message
@@ -259,9 +260,10 @@ pub fn append(rrset: RecordSet, zone_origin: Name, must_exist: bool, use_edns: b
     // Extended dns
     if use_edns {
         message
-            .set_edns(Edns::new())
-            .edns_mut()
-            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+            .extensions_mut()
+            .get_or_insert_with(Edns::new)
+            .set_max_payload(MAX_PAYLOAD_LEN)
+            .set_version(0);
     }
 
     message
@@ -351,9 +353,10 @@ pub fn compare_and_swap(
     // Extended dns
     if use_edns {
         message
-            .set_edns(Edns::new())
-            .edns_mut()
-            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+            .extensions_mut()
+            .get_or_insert_with(Edns::new)
+            .set_max_payload(MAX_PAYLOAD_LEN)
+            .set_version(0);
     }
 
     message
@@ -422,9 +425,10 @@ pub fn delete_by_rdata(mut rrset: RecordSet, zone_origin: Name, use_edns: bool) 
     // Extended dns
     if use_edns {
         message
-            .set_edns(Edns::new())
-            .edns_mut()
-            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+            .extensions_mut()
+            .get_or_insert(Edns::new())
+            .set_max_payload(MAX_PAYLOAD_LEN)
+            .set_version(0);
     }
 
     message
@@ -493,9 +497,10 @@ pub fn delete_rrset(mut record: Record, zone_origin: Name, use_edns: bool) -> Me
     // Extended dns
     if use_edns {
         message
-            .set_edns(Edns::new())
-            .edns_mut()
-            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+            .extensions_mut()
+            .get_or_insert_with(Edns::new)
+            .set_max_payload(MAX_PAYLOAD_LEN)
+            .set_version(0);
     }
 
     message
@@ -561,9 +566,10 @@ pub fn delete_all(
     // Extended dns
     if use_edns {
         message
-            .set_edns(Edns::new())
-            .edns_mut()
-            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+            .extensions_mut()
+            .get_or_insert_with(Edns::new)
+            .set_max_payload(MAX_PAYLOAD_LEN)
+            .set_version(0);
     }
 
     message
@@ -607,9 +613,10 @@ pub fn zone_transfer(zone_origin: Name, last_soa: Option<SOA>) -> Message {
     // Extended dns
     {
         message
-            .set_edns(Edns::new())
-            .edns_mut()
-            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+            .extensions_mut()
+            .get_or_insert_with(Edns::new)
+            .set_max_payload(MAX_PAYLOAD_LEN)
+            .set_version(0);
     }
 
     message

--- a/crates/client/src/op/update_message.rs
+++ b/crates/client/src/op/update_message.rs
@@ -9,6 +9,8 @@
 
 use std::fmt::Debug;
 
+use trust_dns_proto::op::Edns;
+
 use crate::client::async_client::MAX_PAYLOAD_LEN;
 use crate::op::{Message, MessageType, OpCode, Query};
 use crate::rr::rdata::{NULL, SOA};
@@ -185,9 +187,10 @@ pub fn create(rrset: RecordSet, zone_origin: Name, use_edns: bool) -> Message {
 
     // Extended dns
     if use_edns {
-        let edns = message.edns_mut();
-        edns.set_max_payload(MAX_PAYLOAD_LEN);
-        edns.set_version(0);
+        message
+            .set_edns(Edns::new())
+            .edns_mut()
+            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
     }
 
     message
@@ -255,9 +258,10 @@ pub fn append(rrset: RecordSet, zone_origin: Name, must_exist: bool, use_edns: b
 
     // Extended dns
     if use_edns {
-        let edns = message.edns_mut();
-        edns.set_max_payload(MAX_PAYLOAD_LEN);
-        edns.set_version(0);
+        message
+            .set_edns(Edns::new())
+            .edns_mut()
+            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
     }
 
     message
@@ -346,9 +350,10 @@ pub fn compare_and_swap(
 
     // Extended dns
     if use_edns {
-        let edns = message.edns_mut();
-        edns.set_max_payload(MAX_PAYLOAD_LEN);
-        edns.set_version(0);
+        message
+            .set_edns(Edns::new())
+            .edns_mut()
+            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
     }
 
     message
@@ -416,9 +421,10 @@ pub fn delete_by_rdata(mut rrset: RecordSet, zone_origin: Name, use_edns: bool) 
 
     // Extended dns
     if use_edns {
-        let edns = message.edns_mut();
-        edns.set_max_payload(MAX_PAYLOAD_LEN);
-        edns.set_version(0);
+        message
+            .set_edns(Edns::new())
+            .edns_mut()
+            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
     }
 
     message
@@ -486,9 +492,10 @@ pub fn delete_rrset(mut record: Record, zone_origin: Name, use_edns: bool) -> Me
 
     // Extended dns
     if use_edns {
-        let edns = message.edns_mut();
-        edns.set_max_payload(MAX_PAYLOAD_LEN);
-        edns.set_version(0);
+        message
+            .set_edns(Edns::new())
+            .edns_mut()
+            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
     }
 
     message
@@ -553,9 +560,10 @@ pub fn delete_all(
 
     // Extended dns
     if use_edns {
-        let edns = message.edns_mut();
-        edns.set_max_payload(MAX_PAYLOAD_LEN);
-        edns.set_version(0);
+        message
+            .set_edns(Edns::new())
+            .edns_mut()
+            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
     }
 
     message
@@ -598,9 +606,10 @@ pub fn zone_transfer(zone_origin: Name, last_soa: Option<SOA>) -> Message {
 
     // Extended dns
     {
-        let edns = message.edns_mut();
-        edns.set_max_payload(MAX_PAYLOAD_LEN);
-        edns.set_version(0);
+        message
+            .set_edns(Edns::new())
+            .edns_mut()
+            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
     }
 
     message

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -298,6 +298,19 @@ impl Message {
         self
     }
 
+    /// Add all the records from the iterator to the additionals section of the Message
+    pub fn add_additionals<R, I>(&mut self, records: R) -> &mut Self
+    where
+        R: IntoIterator<Item = Record, IntoIter = I>,
+        I: Iterator<Item = Record>,
+    {
+        for record in records {
+            self.add_additional(record);
+        }
+
+        self
+    }
+
     /// Sets the additional to the specified set of Records.
     ///
     /// # Panics
@@ -501,18 +514,14 @@ impl Message {
     /// ```
     /// # Return value
     ///
-    /// Returns the EDNS record if it was found in the additional section.
+    /// Optionally returns a reference to EDNS section
     pub fn edns(&self) -> Option<&Edns> {
         self.edns.as_ref()
     }
 
-    /// If edns is_none, this will create a new default Edns.
-    pub fn edns_mut(&mut self) -> &mut Edns {
-        if self.edns.is_none() {
-            self.edns = Some(Edns::new());
-        }
-
-        self.edns.as_mut().unwrap()
+    /// Optionally returns mutable reference to EDNS section
+    pub fn edns_mut(&mut self) -> Option<&mut Edns> {
+        self.edns.as_mut()
     }
 
     /// # Return value
@@ -770,6 +779,29 @@ impl From<Message> for MessageParts {
             name_servers,
             additionals,
             sig0: signature,
+            edns,
+        }
+    }
+}
+
+impl From<MessageParts> for Message {
+    fn from(msg: MessageParts) -> Self {
+        let MessageParts {
+            header,
+            queries,
+            answers,
+            name_servers,
+            additionals,
+            sig0,
+            edns,
+        } = msg;
+        Self {
+            header,
+            queries,
+            answers,
+            name_servers,
+            additionals,
+            signature: sig0,
             edns,
         }
     }

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -85,9 +85,10 @@ fn build_message(query: Query, options: DnsRequestOptions) -> Message {
     // Extended dns
     if options.use_edns {
         message
-            .set_edns(Edns::new())
-            .edns_mut()
-            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
+            .extensions_mut()
+            .get_or_insert_with(Edns::new)
+            .set_max_payload(MAX_PAYLOAD_LEN)
+            .set_version(0);
     }
     message
 }

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -12,9 +12,9 @@ use futures_util::stream::Stream;
 use log::debug;
 use rand;
 
-use crate::error::*;
 use crate::op::{Message, MessageType, OpCode, Query};
 use crate::xfer::{DnsRequest, DnsRequestOptions, DnsResponse, SerialMessage};
+use crate::{error::*, op::Edns};
 
 // TODO: this should be configurable
 // > An EDNS buffer size of 1232 bytes will avoid fragmentation on nearly all current networks.
@@ -85,9 +85,9 @@ fn build_message(query: Query, options: DnsRequestOptions) -> Message {
     // Extended dns
     if options.use_edns {
         message
+            .set_edns(Edns::new())
             .edns_mut()
-            .set_max_payload(MAX_PAYLOAD_LEN)
-            .set_version(0);
+            .map(|edns| edns.set_max_payload(MAX_PAYLOAD_LEN).set_version(0));
     }
     message
 }

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -144,7 +144,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> NameSe
                     ResolveError::from_response(response, self.config.trust_nx_responses)?;
 
                 // TODO: consider making message::take_edns...
-                let remote_edns = response.edns().cloned();
+                let remote_edns = response.extensions().clone();
 
                 // take the remote edns options and store them
                 self.state.establish(remote_edns);

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -220,8 +220,7 @@ fn test_query_edns(client: &mut AsyncClient) -> impl Future<Output = ()> {
     .set_recursion_desired(true)
     .set_edns(edns)
     .edns_mut()
-    .set_max_payload(1232)
-    .set_version(0);
+    .map(|edns| edns.set_max_payload(1232).set_version(0));
 
     client
         .send(msg)

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -157,8 +157,7 @@ where
     .set_recursion_desired(true)
     .set_edns(edns)
     .edns_mut()
-    .set_max_payload(1232)
-    .set_version(0);
+    .map(|edns| edns.set_max_payload(1232).set_version(0));
 
     let response = client.send(msg).remove(0).expect("Query failed");
 

--- a/tests/integration-tests/tests/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/dnssec_client_handle_tests.rs
@@ -50,7 +50,11 @@ where
         .expect("query failed");
 
     println!("response records: {:?}", response);
-    assert!(response.edns().expect("edns not here").dnssec_ok());
+    assert!(response
+        .extensions()
+        .as_ref()
+        .expect("edns not here")
+        .dnssec_ok());
 
     assert!(!response.answers().is_empty());
     let record = &response.answers()[0];


### PR DESCRIPTION
Assuming we're still good to go ahead with this modification, for reference the workaround for not being able to remove EDNS, as best I can work out is:

```
fn remove_edns(msg: Message) -> Message {
    let rcode = msg.response_code();
    let MessageParts {
        header,
        queries,
        answers,
        name_servers,
        additionals,
        sig0,
        edns,
    } = msg.into_parts();

    let mut ret = Message::new();
    ret.set_id(header.id())
        .set_message_type(header.message_type())
        .set_op_code(header.op_code())
        .set_authoritative(header.authoritative())
        .set_truncated(header.truncated())
        .set_recursion_desired(header.recursion_desired())
        .set_recursion_available(header.recursion_available())
        .set_authentic_data(header.authentic_data())
        .set_checking_disabled(header.checking_disabled())
        .set_response_code(rcode)
        .add_queries(queries)
        .add_answers(answers)
        .add_name_servers(name_servers);
    ret.insert_additionals(additionals);

    for sig in sig0 {
        ret.add_sig0(sig);
    }
    ret
}
```

Looking at all this, a `MessageBuilder` could probably help make constructing new Messages lot nicer, happy to sketch that out on an issue or something if you like. Let me know if you want to remove the MessageParts -> Message bit from this also... I included it here but if we pursue a builder maybe it's not as necessary.