### PR TITLE
Fix SvcParamKey::Unknown parsing

### DIFF
--- a/crates/client/src/serialize/txt/rdata_parsers/svcb.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/svcb.rs
@@ -290,12 +290,9 @@ fn parse_ipv6_hint(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
 ///   SvcParams in presentation format MAY appear in any order, but keys
 ///   MUST NOT be repeated.
 /// ```
-#[allow(clippy::unnecessary_wraps)]
 fn parse_unknown(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
-    let unknown: Vec<Vec<u8>> = if let Some(value) = value {
-        let unknown = parse_list::<String>(value).expect("infallible");
-
-        unknown.into_iter().map(|s| s.as_bytes().to_vec()).collect()
+    let unknown: Vec<u8> = if let Some(value) = value {
+        value.as_bytes().to_vec()
     } else {
         Vec::new()
     };


### PR DESCRIPTION
Addresses https://github.com/bluejekyll/trust-dns/issues/1677

Unfortunately it looks like this might break Key(_) parsing if they're collections, but I'm not sure what the spec says about those necessarily being collections versus arbitrary data. If so, a separate `fn parse_keys` should be added to `svcb.rs`.