### PR TITLE
Remove forced Mutex from handler

### DIFF
--- a/crates/server/src/server/https_handler.rs
+++ b/crates/server/src/server/https_handler.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 pub(crate) async fn h2_handler<T, I>(
-    handler: Arc<Mutex<T>>,
+    handler: Arc<T>,
     io: I,
     src_addr: SocketAddr,
     dns_hostname: Arc<str>,
@@ -71,7 +71,7 @@ pub(crate) async fn h2_handler<T, I>(
 async fn handle_request<T>(
     bytes: BytesMut,
     src_addr: SocketAddr,
-    handler: Arc<Mutex<T>>,
+    handler: Arc<T>,
     responder: HttpsResponseHandle,
 ) where
     T: RequestHandler,

--- a/crates/server/src/server/quic_handler.rs
+++ b/crates/server/src/server/quic_handler.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 pub(crate) async fn quic_handler<T>(
-    handler: Arc<Mutex<T>>,
+    handler: Arc<T>,
     mut quic_streams: QuicStreams,
     src_addr: SocketAddr,
     _dns_hostname: Arc<str>,
@@ -75,7 +75,7 @@ where
 async fn handle_request<T>(
     bytes: BytesMut,
     src_addr: SocketAddr,
-    handler: Arc<Mutex<T>>,
+    handler: Arc<T>,
     responder: QuicResponseHandle,
 ) where
     T: RequestHandler,


### PR DESCRIPTION
The mutex here causes severe performance issues if you write e.g. a DNS proxy where some delegates take longer than others-- it forces serialization between invocations of `request_handler` but it's not required because there are no mutable borrows of self.