### PR TITLE
Trust dns client cli

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,7 @@
 codecov:
   require_ci_to_pass: yes
+  notify:
+    after_n_builds: 13
 
 coverage:
   precision: 2
@@ -18,3 +20,4 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
+  after_n_builds: 13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,11 +307,14 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
+ "atty",
  "bitflags",
  "clap_derive",
  "indexmap",
  "lazy_static",
  "os_str_bytes",
+ "strsim",
+ "termcolor",
  "textwrap",
 ]
 
@@ -1475,6 +1478,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,10 +1882,13 @@ dependencies = [
  "env_logger",
  "log",
  "openssl",
+ "rustls",
  "tokio",
  "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-resolver",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.1",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -340,6 +340,14 @@ $> cargo build --release --features dns-over-rustls
 Using Rust semantics it should be possible to develop a high performance and
 safe DNS Server that is more resilient to attacks.
 
+- What is the MSRV (minimum stable Rust version) policy?
+
+    Trust-DNS will work to support backward compatibility with three Rust versions.
+For example, if `1.50` is the current release, then the MSRV will be `1.47`. The
+version is only increased as necessary, so it's possible that the MSRV is older
+than this policy states. Additionally, the MSRV is only supported for the `no-default-features`
+build due to it being an intractable issue of trying to enforce this policy on dependencies.
+
 ## Community
 
 For live discussions beyond this repository, please see this [Discord](https://discord.gg/89nxE4n).

--- a/crates/client/src/serialize/txt/mod.rs
+++ b/crates/client/src/serialize/txt/mod.rs
@@ -21,6 +21,7 @@ mod rdata_parsers;
 mod zone;
 mod zone_lex;
 
+pub use self::parse_rdata::RDataParser;
 pub use self::zone::Parser;
 pub use self::zone_lex::Lexer;
 pub use self::zone_lex::Token;

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -47,7 +47,8 @@ pub trait RDataParser: Sized {
                 Token::EOL | Token::Blank => (),
                 _ => {
                     return Err(ParseError::from(format!(
-                        "unexpected token in record data: {token:?}"
+                        "unexpected token in record data: {:?}",
+                        token
                     )))
                 }
             }

--- a/crates/proto/src/https/https_client_stream.rs
+++ b/crates/proto/src/https/https_client_stream.rs
@@ -306,15 +306,17 @@ impl HttpsClientStreamBuilder {
     /// * `name_server` - IP and Port for the remote DNS resolver
     /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
     pub fn build<S: Connect>(
-        self,
+        mut self,
         name_server: SocketAddr,
         dns_name: String,
     ) -> HttpsClientConnect<S> {
-        assert!(self
-            .client_config
-            .alpn_protocols
-            .iter()
-            .any(|protocol| *protocol == ALPN_H2.to_vec()));
+        // ensure the ALPN protocol is set correctly
+        if self.client_config.alpn_protocols.is_empty() {
+            let mut client_config = (*self.client_config).clone();
+            client_config.alpn_protocols = vec![ALPN_H2.to_vec()];
+
+            self.client_config = Arc::new(client_config);
+        }
 
         let tls = TlsConfig {
             client_config: self.client_config,

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -16,6 +16,8 @@
 
 //! Extended DNS options
 
+use std::fmt;
+
 use crate::error::*;
 use crate::rr::rdata::opt::{self, EdnsCode, EdnsOption};
 use crate::rr::rdata::OPT;
@@ -212,6 +214,20 @@ impl BinEncodable for Edns {
 
         place.replace(encoder, len as u16)?;
         Ok(())
+    }
+}
+
+impl fmt::Display for Edns {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let version = self.version;
+        let dnssec_ok = self.dnssec_ok;
+        let max_payload = self.max_payload;
+
+        write!(
+            f,
+            "version: {version} dnssec_ok: {dnssec_ok} max_payload: {max_payload} opts: {}",
+            self.options().as_ref().len()
+        )
     }
 }
 

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -225,8 +225,11 @@ impl fmt::Display for Edns {
 
         write!(
             f,
-            "version: {version} dnssec_ok: {dnssec_ok} max_payload: {max_payload} opts: {}",
-            self.options().as_ref().len()
+            "version: {version} dnssec_ok: {dnssec_ok} max_payload: {max_payload} opts: {opts_len}",
+            version = version,
+            dnssec_ok = dnssec_ok,
+            max_payload = max_payload,
+            opts_len = self.options().as_ref().len()
         )
     }
 }

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -218,7 +218,7 @@ impl BinEncodable for Edns {
 }
 
 impl fmt::Display for Edns {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let version = self.version;
         let dnssec_ok = self.dnssec_ok;
         let max_payload = self.max_payload;

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -69,10 +69,11 @@ impl fmt::Display for Header {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{id}:{flags}:{code:?}:{answers}/{authorities}/{additionals}",
+            "{id}:{flags}:{code:?}:{op_code}:{answers}/{authorities}/{additionals}",
             id = self.id,
             flags = self.flags(),
             code = self.response_code,
+            op_code = self.op_code,
             answers = self.answer_count,
             authorities = self.name_server_count,
             additionals = self.additional_count,

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -1056,7 +1056,7 @@ impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let write_query = |slice, f: &mut fmt::Formatter<'_>| -> Result<(), fmt::Error> {
             for d in slice {
-                writeln!(f, ";; {d}")?;
+                writeln!(f, ";; {}", d)?;
             }
 
             Ok(())
@@ -1064,7 +1064,7 @@ impl fmt::Display for Message {
 
         let write_slice = |slice, f: &mut fmt::Formatter<'_>| -> Result<(), fmt::Error> {
             for d in slice {
-                writeln!(f, "{d}")?;
+                writeln!(f, "{}", d)?;
             }
 
             Ok(())

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -1072,7 +1072,7 @@ impl fmt::Display for Message {
 
         writeln!(f, "; header {header}", header = self.header())?;
 
-        if let Some(edns) = self.edns() {
+        if let Some(edns) = self.extensions() {
             writeln!(f, "; edns {}", edns)?;
         }
 

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -274,8 +274,10 @@ impl Display for Query {
         {
             write!(
                 f,
-                "name: {} type: {} class: {}",
-                self.name, self.query_type, self.query_class
+                "{name} {class} {ty}",
+                name = self.name,
+                class = self.query_class,
+                ty = self.query_type,
             )
         }
 
@@ -283,8 +285,11 @@ impl Display for Query {
         {
             write!(
                 f,
-                "name: {} type: {} class: {} mdns_unicast_response: {}",
-                self.name, self.query_type, self.query_class, self.mdns_unicast_response
+                "{name} {class} {ty}; mdns_unicast_response: {mdns}",
+                name = self.name,
+                class = self.query_class,
+                ty = self.query_type,
+                mdns = self.mdns_unicast_response
             )
         }
     }

--- a/crates/proto/src/quic/mod.rs
+++ b/crates/proto/src/quic/mod.rs
@@ -12,9 +12,9 @@ mod quic_server;
 mod quic_stream;
 
 pub use self::quic_client_stream::{
-    QuicClientConnect, QuicClientResponse, QuicClientStream, QuicClientStreamBuilder,
+    client_config_tls13_webpki_roots, QuicClientConnect, QuicClientResponse, QuicClientStream,
+    QuicClientStreamBuilder,
 };
-
 pub use self::quic_server::{QuicServer, QuicStreams};
 pub use self::quic_stream::{DoqErrorCode, QuicStream};
 

--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -212,7 +212,9 @@ impl QuicClientStreamBuilder {
 
         // ensure the ALPN protocol is set correctly
         let mut crypto_config = self.crypto_config;
-        crypto_config.alpn_protocols = vec![quic_stream::DOQ_ALPN.to_vec()];
+        if crypto_config.alpn_protocols.is_empty() {
+            crypto_config.alpn_protocols = vec![quic_stream::DOQ_ALPN.to_vec()];
+        }
 
         let client_config = ClientConfig::new(Arc::new(crypto_config));
         endpoint.set_default_client_config(client_config);
@@ -240,7 +242,8 @@ fn sanitize_transport_config(transport_config: &mut TransportConfig) {
     transport_config.max_concurrent_uni_streams(VarInt::from_u32(0));
 }
 
-fn client_config_tls13_webpki_roots() -> TlsClientConfig {
+/// Default crypto options for quic
+pub fn client_config_tls13_webpki_roots() -> TlsClientConfig {
     use rustls::{OwnedTrustAnchor, RootCertStore};
     let mut root_store = RootCertStore::empty();
     root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -187,6 +187,13 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> DnsRequestSender
         let message = SerialMessage::new(bytes, self.name_server);
         let bind_addr = self.bind_addr;
 
+        debug!(
+            "final message: {}",
+            message
+                .to_message()
+                .expect("bizarre we just made this message")
+        );
+
         S::Time::timeout::<Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>>(
             self.timeout,
             Box::pin(send_serial_message::<S>(

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -319,7 +319,9 @@ where
 
                 debug!(
                     "final message: {}",
-                    serial_message.to_message().expect("bizarre we just made this message")
+                    serial_message
+                        .to_message()
+                        .expect("bizarre we just made this message")
                 );
 
                 // add to the map -after- the client send b/c we don't want to put it in the map if

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -317,6 +317,11 @@ where
                 debug!("sending message id: {}", active_request.request_id());
                 let serial_message = SerialMessage::new(buffer, self.stream.name_server_addr());
 
+                debug!(
+                    "final message: {}",
+                    serial_message.to_message().expect("bizarre we just made this message")
+                );
+
                 // add to the map -after- the client send b/c we don't want to put it in the map if
                 //  we ended up returning an error from the send.
                 match self.stream_handle.send(serial_message) {

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -282,6 +282,11 @@ impl DnsResponse {
             _ => None,
         }
     }
+
+    /// Take the inner Message from the response
+    pub fn into_inner(self) -> Message {
+        self.0
+    }
 }
 
 impl Deref for DnsResponse {

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -163,7 +163,11 @@ impl DnsHandle for BufDnsRequestStreamHandle {
 
     fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {
         let request: DnsRequest = request.into();
-        debug!("enqueueing message: {:?}", request.queries());
+        debug!(
+            "enqueueing message:{}:{:?}",
+            request.op_code(),
+            request.queries()
+        );
 
         let (request, oneshot) = OneshotDnsRequest::oneshot(request);
         try_oneshot!(self.sender.try_send(request).map_err(|_| {

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -580,7 +580,7 @@ impl NameServerConfigGroup {
     #[cfg(feature = "dns-over-https")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
     pub fn google_https() -> Self {
-        Self::from_ips_https(GOOGLE_IPS, 53, "dns.google".to_string(), true)
+        Self::from_ips_https(GOOGLE_IPS, 443, "dns.google".to_string(), true)
     }
 
     /// Creates a default configuration, using `1.1.1.1`, `1.0.0.1` and `2606:4700:4700::1111`, `2606:4700:4700::1001` (thank you, Cloudflare).

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -49,7 +49,7 @@ dnssec-ring = ["dnssec", "trust-dns-client/dnssec-ring", "trust-dns-proto/dnssec
 [[bin]]
 name = "dns"
 path = "src/dns.rs"
-required-features = ["dns-over-rustls", "dns-over-https-rustls"]
+required-features = ["dns-over-rustls", "dns-over-https-rustls", "dns-over-quic"]
 
 [[bin]]
 name = "dnskey-to-pem"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -47,6 +47,10 @@ dnssec-openssl = ["dnssec", "openssl", "trust-dns-client/dnssec-openssl", "trust
 dnssec-ring = ["dnssec", "trust-dns-client/dnssec-ring", "trust-dns-proto/dnssec-ring", "trust-dns-resolver/dnssec-ring"]
 
 [[bin]]
+name = "dns"
+path = "src/dns.rs"
+
+[[bin]]
 name = "dnskey-to-pem"
 path = "src/bind_dnskey_to_pem.rs"
 required-features = ["dnssec-openssl"]

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -49,7 +49,6 @@ dnssec-ring = ["dnssec", "trust-dns-client/dnssec-ring", "trust-dns-proto/dnssec
 [[bin]]
 name = "dns"
 path = "src/dns.rs"
-required-features = ["dns-over-rustls", "dns-over-https-rustls", "dns-over-quic"]
 
 [[bin]]
 name = "dnskey-to-pem"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -36,7 +36,7 @@ codecov = { repository = "bluejekyll/trust-dns", branch = "main", service = "git
 maintenance = { status = "actively-developed" }
 
 [features]
-dns-over-rustls = ["trust-dns-proto/dns-over-rustls", "trust-dns-client/dns-over-rustls", "trust-dns-resolver/dns-over-rustls"]
+dns-over-rustls = ["rustls", "webpki", "webpki-roots", "trust-dns-proto/dns-over-rustls", "trust-dns-client/dns-over-rustls", "trust-dns-resolver/dns-over-rustls"]
 dns-over-https-rustls = ["dns-over-https", "dns-over-rustls", "trust-dns-proto/dns-over-https-rustls", "trust-dns-client/dns-over-https-rustls", "trust-dns-resolver/dns-over-https-rustls"]
 dns-over-https = ["trust-dns-proto/dns-over-https", "trust-dns-client/dns-over-https","trust-dns-resolver/dns-over-https"]
 
@@ -49,6 +49,7 @@ dnssec-ring = ["dnssec", "trust-dns-client/dnssec-ring", "trust-dns-proto/dnssec
 [[bin]]
 name = "dns"
 path = "src/dns.rs"
+required-features = ["dns-over-rustls", "dns-over-https-rustls"]
 
 [[bin]]
 name = "dnskey-to-pem"
@@ -74,9 +75,13 @@ clap = { version = "3.1", default-features = false, features = ["std", "cargo", 
 console = "0.15.0"
 data-encoding = "2.2.0"
 env_logger = { version = "0.9.0", features = ["termcolor", "humantime", "atty"] }
+log = "0.4"
+openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
+rustls = { version = "0.20.0", optional = true }
 trust-dns-client = { version = "0.21.1", path = "../crates/client" }
 trust-dns-proto = { version = "0.21.1", path = "../crates/proto" }
 trust-dns-resolver = { version = "0.21.1", path = "../crates/resolver" }
-log = "0.4"
-openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
+webpki = { version = "0.22.0", optional = true }
+webpki-roots = { version = "0.22.1", optional = true }
+

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -70,7 +70,7 @@ name = "resolve"
 path = "src/resolve.rs"
 
 [dependencies]
-clap = { version = "3.1", default-features = false, features = ["std", "cargo", "derive"] }
+clap = { version = "3.1", default-features = false, features = ["std", "cargo", "derive", "color", "suggestions"] }
 console = "0.15.0"
 data-encoding = "2.2.0"
 env_logger = { version = "0.9.0", features = ["termcolor", "humantime", "atty"] }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -77,7 +77,7 @@ data-encoding = "2.2.0"
 env_logger = { version = "0.9.0", features = ["termcolor", "humantime", "atty"] }
 log = "0.4"
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
-rustls = { version = "0.20.0", optional = true }
+rustls = { version = "0.20.0", features = ["dangerous_configuration"], optional = true }
 trust-dns-client = { version = "0.21.1", path = "../crates/client" }
 trust-dns-proto = { version = "0.21.1", path = "../crates/proto" }
 trust-dns-resolver = { version = "0.21.1", path = "../crates/resolver" }

--- a/util/src/dns.rs
+++ b/util/src/dns.rs
@@ -216,6 +216,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // TODO: need to cleanup all of ClientHandle and the Client in general to make it dynamically usable.
     match protocol {
         Protocol::Udp => {
+            println!("; using udp:{nameserver}");
             let stream = UdpClientStream::<UdpSocket>::new(nameserver);
             let (client, bg) = AsyncClient::connect(stream).await?;
             let handle = tokio::spawn(bg);
@@ -223,15 +224,25 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             drop(handle);
         }
         Protocol::Tcp => {
-            todo!()
+            println!("; using tcp:{nameserver}");
+            let (stream, sender) =
+                TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(nameserver);
+            let client = AsyncClient::new(stream, sender, None);
+            let (mut client, bg) = client.await?;
+            let handle = tokio::spawn(bg);
+            handle_request(class, zone, command, client).await?;
+            drop(handle);
         }
         Protocol::Tls => {
+            println!("; using tls:{nameserver}");
             todo!()
         }
         Protocol::Https => {
+            println!("; using https:{nameserver}");
             todo!()
         }
         Protocol::Quic => {
+            println!("; using quic:{nameserver}");
             todo!()
         }
     };

--- a/util/src/dns.rs
+++ b/util/src/dns.rs
@@ -1,0 +1,216 @@
+// Copyright 2015-2022 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! The dns client program
+
+// BINARY WARNINGS
+#![warn(
+    clippy::default_trait_access,
+    clippy::dbg_macro,
+    clippy::unimplemented,
+    missing_copy_implementations,
+    missing_docs,
+    non_snake_case,
+    non_upper_case_globals,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
+
+use clap::{ArgEnum, Args, Parser, Subcommand};
+use console::style;
+
+use trust_dns_client::rr::{DNSClass, RData, RecordType};
+use trust_dns_proto::{rr::Name, xfer::DnsRequestOptions};
+
+/// A CLI interface for the trust-dns-client.
+///
+/// This utility directly uses the trust-dns-client to perform actions with a single
+/// DNS server
+#[derive(Debug, Parser)]
+#[clap(name = "dns client")]
+struct Opts {
+    /// Specify a nameserver to use, ip and port e.g. 8.8.8.8:53 or \[2001:4860:4860::8888\]:53 (port required)
+    #[clap(short = 'n', long)]
+    nameserver: SocketAddr,
+
+    /// Specify the IP address to connect from.
+    #[clap(long)]
+    bind: Option<IpAddr>,
+
+    /// Protocol type to use for the communication
+    #[clap(short = 'p', long, default_value = "udp", arg_enum)]
+    protocol: Protocol,
+
+    // TODO: zone is required for all update operations...
+    /// Zone, required for dynamic DNS updates, e.g. example.com if updating www.example.com
+    #[clap(short = 'z', long)]
+    zone: Option<Name>,
+
+    /// The Class of the record
+    #[clap(long, default_value_t = DNSClass::IN)]
+    class: DNSClass,
+
+    /// Enable debug and all logging
+    #[clap(long)]
+    debug: bool,
+
+    /// Enable info + warning + error logging
+    #[clap(long)]
+    info: bool,
+
+    /// Enable warning + error logging
+    #[clap(long)]
+    warn: bool,
+
+    /// Enable error logging
+    #[clap(long)]
+    error: bool,
+
+    /// Command to execute
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Clone, Debug, ArgEnum)]
+enum Protocol {
+    Udp,
+    Tcp,
+    Https,
+    Quic,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    Query(QueryOpt),
+    Notify(NotifyOpt),
+    Create(CreateOpt),
+    Append(AppendOpt),
+    // CompareAndSwap(),
+    DeleteRecord(DeleteRecordOpt),
+    // DeleteRecordSet,
+    // DeleteAll,
+    // ZoneTransfer,
+    // Raw?
+}
+
+/// Query a name server for the record of the given type
+#[derive(Debug, Args)]
+struct QueryOpt {
+    /// Name of the record to query
+    name: Name,
+
+    /// Type of DNS record to notify
+    #[clap(name = "TYPE")]
+    ty: RecordType,
+}
+
+/// Notify a nameserver that a record has been updated
+#[derive(Debug, Args)]
+struct NotifyOpt {
+    /// Name associated to the record that is being notified
+    name: Name,
+
+    /// Type of DNS record to notify
+    #[clap(name = "TYPE")]
+    ty: RecordType,
+
+    /// Optional record data to associate
+    rdata: Vec<String>,
+}
+
+/// Create a new record in the target zone
+#[derive(Debug, Args)]
+struct CreateOpt {
+    /// Name associated to the record to create
+    name: Name,
+
+    /// Type of DNS record to create
+    #[clap(name = "TYPE")]
+    ty: RecordType,
+
+    /// Record data to associate
+    #[clap(required = true)]
+    rdata: Vec<String>,
+}
+
+/// Append record data to a record set
+#[derive(Debug, Args)]
+struct AppendOpt {
+    /// If true, then the record must exist for the append to succeed
+    #[clap(long)]
+    must_exist: bool,
+
+    /// Name associated to the record that is being updated
+    name: Name,
+
+    /// Type of DNS record to update
+    #[clap(name = "TYPE")]
+    ty: RecordType,
+
+    /// Record data to associate
+    #[clap(required = true)]
+    rdata: Vec<String>,
+}
+
+/// Delete a single record from a zone, the data must match the record
+#[derive(Debug, Args)]
+struct DeleteRecordOpt {
+    /// Name associated to the record that is being updated
+    name: Name,
+
+    /// Type of DNS record to update
+    #[clap(name = "TYPE")]
+    ty: RecordType,
+
+    /// Record data to associate
+    #[clap(required = true)]
+    rdata: Vec<String>,
+}
+
+/// Run the resolve program
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let opts: Opts = Opts::parse();
+
+    // enable logging early
+    let log_level = if opts.debug {
+        log::LevelFilter::Debug
+    } else if opts.info {
+        log::LevelFilter::Info
+    } else if opts.warn {
+        log::LevelFilter::Warn
+    } else if opts.error {
+        log::LevelFilter::Error
+    } else {
+        log::LevelFilter::Off
+    };
+
+    // Get query term
+    env_logger::builder()
+        .filter_module("trust_dns_resolver", log_level)
+        .filter_module("trust_dns_proto", log_level)
+        .filter_module("trust_dns_client", log_level)
+        .write_style(env_logger::WriteStyle::Auto)
+        .format_indent(Some(4))
+        .init();
+
+    // query parameters
+    let name = opts.zone.as_ref();
+
+    // execute query
+    println!("Sending DNS request");
+
+    // report response, TODO: better display of errors
+    println!("Got response");
+
+    Ok(())
+}

--- a/util/src/dns.rs
+++ b/util/src/dns.rs
@@ -199,7 +199,7 @@ struct DeleteRecordOpt {
 /// Run the resolve program
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut opts: Opts = Opts::parse();
+    let opts: Opts = Opts::parse();
 
     // enable logging early
     let log_level = if opts.debug {

--- a/util/src/dns.rs
+++ b/util/src/dns.rs
@@ -36,7 +36,7 @@ use trust_dns_proto::{rr::Name, xfer::DnsRequestOptions};
 /// This utility directly uses the trust-dns-client to perform actions with a single
 /// DNS server
 #[derive(Debug, Parser)]
-#[clap(name = "dns client")]
+#[clap(name = "trust dns client", version)]
 struct Opts {
     /// Specify a nameserver to use, ip and port e.g. 8.8.8.8:53 or \[2001:4860:4860::8888\]:53 (port required)
     #[clap(short = 'n', long)]

--- a/util/src/dns.rs
+++ b/util/src/dns.rs
@@ -254,7 +254,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn udp(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
     let nameserver = opts.nameserver;
 
-    println!("; using udp:{nameserver}");
+    println!("; using udp:{}", nameserver);
     let stream = UdpClientStream::<UdpSocket>::new(nameserver);
     let (client, bg) = AsyncClient::connect(stream).await?;
     let handle = tokio::spawn(bg);
@@ -267,7 +267,7 @@ async fn udp(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
 async fn tcp(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
     let nameserver = opts.nameserver;
 
-    println!("; using tcp:{nameserver}");
+    println!("; using tcp:{}", nameserver);
     let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(nameserver);
     let client = AsyncClient::new(stream, sender, None);
     let (client, bg) = client.await?;
@@ -291,7 +291,7 @@ async fn tls(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
     let dns_name = opts
         .tls_dns_name
         .expect("tls_dns_name is required tls connections");
-    println!("; using tls:{nameserver} dns_name:{dns_name}");
+    println!("; using tls:{} dns_name:{}", nameserver, dns_name);
 
     let mut config = tls_config();
     if opts.do_not_verify_nameserver_cert {
@@ -330,7 +330,7 @@ async fn https(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
     let dns_name = opts
         .tls_dns_name
         .expect("tls_dns_name is required https connections");
-    println!("; using https:{nameserver} dns_name:{dns_name}");
+    println!("; using https:{} dns_name:{}", nameserver, dns_name);
 
     let mut config = tls_config();
     if opts.do_not_verify_nameserver_cert {
@@ -369,7 +369,7 @@ async fn quic(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
     let dns_name = opts
         .tls_dns_name
         .expect("tls_dns_name is required quic connections");
-    println!("; using quic:{nameserver} dns_name:{dns_name}");
+    println!("; using quic:{} dns_name:{}", nameserver, dns_name);
 
     let mut config = quic::client_config_tls13_webpki_roots();
     if opts.do_not_verify_nameserver_cert {
@@ -398,7 +398,12 @@ async fn handle_request(
         Command::Query(query) => {
             let name = query.name;
             let ty = query.ty;
-            println!("; sending query: {name} {class} {ty}");
+            println!(
+                "; sending query: {name} {class} {ty}",
+                name = name,
+                class = class,
+                ty = ty
+            );
             client.query(name, class, ty).await?
         }
         Command::Notify(opt) => {
@@ -413,7 +418,12 @@ async fn handle_request(
                 Some(record_set_from(name.clone(), class, ty, ttl, rdata))
             };
 
-            println!("; sending notify: {name} {class} {ty}");
+            println!(
+                "; sending notify: {name} {class} {ty}",
+                name = name,
+                class = class,
+                ty = ty
+            );
             client.notify(name, class, ty, rdata).await?
         }
         Command::Create(opt) => {
@@ -425,7 +435,13 @@ async fn handle_request(
 
             let rdata = record_set_from(name.clone(), class, ty, ttl, rdata);
 
-            println!("; sending create: {name} {class} {ty} in {zone}");
+            println!(
+                "; sending create: {name} {class} {ty} in {zone}",
+                name = name,
+                class = class,
+                ty = ty,
+                zone = zone
+            );
             client.create(rdata, zone).await?
         }
         Command::Append(opt) => {
@@ -439,7 +455,12 @@ async fn handle_request(
             let rdata = record_set_from(name.clone(), class, ty, ttl, rdata);
 
             println!(
-                "; sending append: {name} {class} {ty} in {zone} and must_exist({must_exist})"
+                "; sending append: {name} {class} {ty} in {zone} and must_exist({must_exist})",
+                name = name,
+                class = class,
+                ty = ty,
+                zone = zone,
+                must_exist = must_exist
             );
             client.append(rdata, zone, must_exist).await?
         }
@@ -452,14 +473,20 @@ async fn handle_request(
 
             let rdata = record_set_from(name.clone(), class, ty, ttl, rdata);
 
-            println!("; sending delete-record: {name} {class} {ty} from {zone}");
+            println!(
+                "; sending delete-record: {name} {class} {ty} from {zone}",
+                name = name,
+                class = class,
+                ty = ty,
+                zone = zone
+            );
             client.delete_by_rdata(rdata, zone).await?
         }
     };
 
     let response = response.into_inner();
     println!("; received response");
-    println!("{response}");
+    println!("{response}", response = response);
     Ok(())
 }
 


### PR DESCRIPTION
This is a new CLI for trust-dns-client that mimics the `dig` command:

```shell
$> cargo install --all-features --path util --bin dns
...
```

The options are:

```shell
$> dns -h
trust dns client 0.21.2
A CLI interface for the trust-dns-client

USAGE:
    dns [OPTIONS] --nameserver <NAMESERVER> <SUBCOMMAND>

OPTIONS:
    -a, --alpn <ALPN>
            For TLS, HTTPS, and QUIC a custom ALPN code can be supplied

        --class <CLASS>
            The Class of the record [default: IN]

        --debug
            Enable debug and all logging

        --do-not-verify-nameserver-cert
            DANGER: do not verify remote nameserver

        --error
            Enable error logging

    -h, --help
            Print help information

        --info
            Enable info + warning + error logging

    -n, --nameserver <NAMESERVER>
            Specify a nameserver to use, ip and port e.g. 8.8.8.8:53 or \[2001:4860:4860::8888\]:53
            (port required)

    -p, --protocol <PROTOCOL>
            Protocol type to use for the communication [default: udp] [possible values: udp, tcp,
            tls, https, quic]

    -t, --tls-dns-name <TLS_DNS_NAME>
            TLS endpoint name, i.e. the name in the certificate presented by the remote server

    -V, --version
            Print version information

        --warn
            Enable warning + error logging

    -z, --zone <ZONE>
            Zone, required for dynamic DNS updates, e.g. example.com if updating www.example.com

SUBCOMMANDS:
    append           Append record data to a record set
    create           Create a new record in the target zone
    delete-record    Delete a single record from a zone, the data must match the record
    help             Print this message or the help of the given subcommand(s)
    notify           Notify a nameserver that a record has been updated
    query            Query a name server for the record of the given type
```

This supports all the protocols supported by trust-dns, `udp`, `tcp`, `tls`, `https`, and `quic`. 

Here's an example query:

```shell
$> dns -p https -t cloudflare-dns.com -n 1.1.1.1:443 query www.example.com. SOA
; using https:1.1.1.1:443 dns_name:cloudflare-dns.com
; sending query: www.example.com. IN SOA
; received response
; header 0:RD,RA:NoError:QUERY:0/1/1
; edns version: 0 dnssec_ok: false max_payload: 1232 opts: 0
; query
;; name: www.example.com. type: SOA class: IN
; answers 0
; nameservers 1
example.com. 3600 IN SOA ns.icann.org. noc.dns.icann.org. 2022040401 7200 3600 1209600 3600
; additionals 1
```

Fixes: #1663
 