### PR TITLE
make doq transport settings more consistent with RFC

### DIFF
--- a/crates/proto/src/quic/mod.rs
+++ b/crates/proto/src/quic/mod.rs
@@ -8,6 +8,7 @@
 //! QUIC protocol related components for DNS over QUIC (DoQ)
 
 mod quic_client_stream;
+mod quic_config;
 mod quic_server;
 mod quic_stream;
 

--- a/crates/proto/src/quic/quic_config.rs
+++ b/crates/proto/src/quic/quic_config.rs
@@ -1,0 +1,33 @@
+// Copyright 2015-2022 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use quinn::{EndpointConfig, TransportConfig, VarInt};
+
+/// Returns a default endpoint configuration for DNS-over-QUIC
+pub(crate) fn endpoint() -> EndpointConfig {
+    // set some better EndpointConfig defaults for DoQ
+    let mut endpoint_config = EndpointConfig::default();
+
+    // all DNS packets have a maximum size of u16 due to DoQ and 1035 rfc
+    // TODO: the RFC claims max == u16::max, but this matches the max in some test servers.
+    endpoint_config
+        .max_udp_payload_size(0x45acu16 as u64)
+        .expect("max udp payload size exceeded");
+
+    endpoint_config
+}
+
+/// Returns a default endpoint configuration for DNS-over-QUIC
+pub(crate) fn transport() -> TransportConfig {
+    let mut transport_config = TransportConfig::default();
+
+    transport_config.max_concurrent_uni_streams(VarInt::from_u32(0));
+    transport_config.datagram_receive_buffer_size(None);
+    transport_config.datagram_send_buffer_size(0);
+
+    transport_config
+}

--- a/crates/server/src/server/quic_handler.rs
+++ b/crates/server/src/server/quic_handler.rs
@@ -113,7 +113,9 @@ impl ResponseHandler for QuicResponseHandle {
         let bytes = Bytes::from(bytes);
 
         debug!("sending quic response: {}", bytes.len());
-        self.0.lock().await.send_bytes(bytes).await?;
+        let mut lock = self.0.lock().await;
+        lock.send_bytes(bytes).await?;
+        lock.finish().await?;
 
         Ok(info)
     }


### PR DESCRIPTION
I'm trying to debug issues with DoQ and some servers out there, but can't get to the root yet. These changes are things that appear to differ from RFC and some inconsistency between the client and server.

related: #1687