### PR TITLE
Drop UDP packets on send failure

### DIFF
--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -70,7 +70,7 @@ impl<T: RequestHandler> ServerFuture<T> {
                     let message = match message {
                         Err(e) => {
                             warn!("error receiving message on udp_socket: {}", e);
-                            continue;
+                            break;
                         }
                         Ok(message) => message,
                     };


### PR DESCRIPTION
Two fixes here:
* If the sending a UDP response fails, the packet is left in the buffer and retried on the next iteration. Unfortunately, some send errors aren't recoverable: a route becoming invalid will cause trust-dns-server to tight loop forever while it tries to send before receiving. I can pretty reliably reproduce this on Windows 10 by running a proxying server and putting the machine into Modern Standby. The simple fix is to drop the UDP packet if sending returns an error.
* If the recv half actually does fail, the stream will never return None. Most errors on recv aren't recoverable and shouldn't be retried-- the interface to which the server is attached getting deleted is one common case. Because `UdpStream::poll_next` never returns `Poll::Ready(None)`, the server will never terminate on errors. Ideally we would fuse UdpStream by returning Some(Err) once, then None thereafter to indicate the stream is permanently unusable. But for now, breaking on error fixes the immediate problem.