### PR TITLE
Allow customizing the static hosts configuration

### DIFF
--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -436,6 +436,11 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
         .await
     }
 
+    /// Customizes the static hosts used in this resolver.
+    pub fn set_hosts(&mut self, hosts: Option<Hosts>) {
+        self.hosts = hosts.map(|hosts| Arc::new(hosts));
+    }
+
     lookup_fn!(
         reverse_lookup,
         lookup::ReverseLookup,

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -438,7 +438,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
 
     /// Customizes the static hosts used in this resolver.
     pub fn set_hosts(&mut self, hosts: Option<Hosts>) {
-        self.hosts = hosts.map(|hosts| Arc::new(hosts));
+        self.hosts = hosts.map(Arc::new);
     }
 
     lookup_fn!(

--- a/crates/resolver/src/system_conf/mod.rs
+++ b/crates/resolver/src/system_conf/mod.rs
@@ -19,7 +19,7 @@ mod unix;
 #[cfg(unix)]
 #[cfg(feature = "system-config")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "system-config", unix))))]
-pub use self::unix::read_system_conf;
+pub use self::unix::{read_system_conf, parse_resolv_conf};
 
 #[cfg(windows)]
 #[cfg(feature = "system-config")]

--- a/crates/resolver/src/system_conf/mod.rs
+++ b/crates/resolver/src/system_conf/mod.rs
@@ -19,7 +19,7 @@ mod unix;
 #[cfg(unix)]
 #[cfg(feature = "system-config")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "system-config", unix))))]
-pub use self::unix::{read_system_conf, parse_resolv_conf};
+pub use self::unix::{parse_resolv_conf, read_system_conf};
 
 #[cfg(windows)]
 #[cfg(feature = "system-config")]

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -37,7 +37,7 @@ fn read_resolv_conf<P: AsRef<Path>>(path: P) -> io::Result<(ResolverConfig, Reso
     parse_resolv_conf(&data)
 }
 
-fn parse_resolv_conf<T: AsRef<[u8]>>(data: T) -> io::Result<(ResolverConfig, ResolverOpts)> {
+pub fn parse_resolv_conf<T: AsRef<[u8]>>(data: T) -> io::Result<(ResolverConfig, ResolverOpts)> {
     let parsed_conf = resolv_conf::Config::parse(&data).map_err(|e| {
         io::Error::new(
             io::ErrorKind::Other,


### PR DESCRIPTION
This allows custom runtimes to provide the hosts configuration in their
own way, like using io_uring instead of the `std::fs::File::open()` to
read the system hosts file.

Also publicized the `resolver::system_conf::unix::parse_resolv_conf` function for the same reason.