### PR TITLE
Use `u16::*_be_bytes` represent length field

### DIFF
--- a/crates/proto/src/quic/quic_stream.rs
+++ b/crates/proto/src/quic/quic_stream.rs
@@ -143,7 +143,7 @@ impl QuicStream {
         // sent over DoQ connections MUST be encoded as a 2-octet length field followed by the message content as specified in [RFC1035].
         let bytes_len = u16::try_from(bytes.len())
             .map_err(|_e| ProtoErrorKind::MaxBufferSizeExceeded(bytes.len()))?;
-        let len = bytes_len.to_ne_bytes().to_vec();
+        let len = bytes_len.to_be_bytes().to_vec();
         let len = Bytes::from(len);
 
         debug!("received packet len: {} bytes: {:x?}", bytes_len, bytes);
@@ -179,7 +179,7 @@ impl QuicStream {
         // following above, the data should be first the length, followed by the message(s)
         let mut len = [0u8; 2];
         self.receive_stream.read_exact(&mut len).await?;
-        let len = u16::from_ne_bytes(len) as usize;
+        let len = u16::from_be_bytes(len) as usize;
 
         // RFC: DoQ Queries and Responses are sent on QUIC streams, which in theory can carry up to 2^62 bytes.
         //  However, DNS messages are restricted in practice to a maximum size of 65535 bytes. This maximum size

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -331,10 +331,7 @@ impl<S: DnsTcpStream> Stream for TcpStream<S> {
 
                         // will return if the socket will block
                         // the length is 16 bits
-                        let len: [u8; 2] = [
-                            (buffer.len() >> 8 & 0xFF) as u8,
-                            (buffer.len() & 0xFF) as u8,
-                        ];
+                        let len = u16::to_be_bytes(buffer.len() as u16);
 
                         debug!("sending message len: {} to: {}", buffer.len(), dst);
                         *send_state = Some(WriteTcpState::LenBytes {
@@ -390,8 +387,7 @@ impl<S: DnsTcpStream> Stream for TcpStream<S> {
                         debug!("remain ReadTcpState::LenBytes: {}", pos);
                         None
                     } else {
-                        let length =
-                            u16::from(bytes[0]) << 8 & 0xFF00 | u16::from(bytes[1]) & 0x00FF;
+                        let length = u16::from_be_bytes(*bytes);
                         debug!("got length: {}", length);
                         let mut bytes = vec![0; length as usize];
                         bytes.resize(length as usize, 0);


### PR DESCRIPTION
In DoQ packet, portable code should represent length filed in big endian rather than native endian.