### PR TITLE
Mark ForwardLookup as public

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -37,7 +37,7 @@ CARGO_MAKE_CRATES_IO_TOKEN = { value = "--token=${CRATES_IO_TOKEN}", condition =
 [tasks.install-openssl]
 description = "Installs OpenSSL on Windows"
 workspace = false
-env = { OPENSSL_VERSION = "1_1_1o", OPENSSL_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}\\target\\OpenSSL" }
+env = { OPENSSL_VERSION = "1_1_1p", OPENSSL_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}\\target\\OpenSSL" }
 condition = { platforms = ["windows"], files_not_exist = ["${OPENSSL_DIR}"] }
 script_runner = "powershell"
 script_extension = "ps1"

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -164,7 +164,7 @@ impl Authority for ForwardAuthority {
     }
 }
 
-/// A structure that holders the results of a forwarding lookup.
+/// A structure that holds the results of a forwarding lookup.
 ///
 /// This exposes an interator interface for consumption downstream.
 pub struct ForwardLookup(ResolverLookup);

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -164,6 +164,9 @@ impl Authority for ForwardAuthority {
     }
 }
 
+/// A structure that holders the results of a forwarding lookup.
+///
+/// This exposes an interator interface for consumption downstream.
 pub struct ForwardLookup(ResolverLookup);
 
 impl LookupObject for ForwardLookup {

--- a/crates/server/src/store/forwarder/mod.rs
+++ b/crates/server/src/store/forwarder/mod.rs
@@ -13,4 +13,5 @@ mod authority;
 mod config;
 
 pub use self::authority::ForwardAuthority;
+pub use self::authority::ForwardLookup;
 pub use self::config::ForwardConfig;


### PR DESCRIPTION
I am trying to implement a wrapper around ForwardAuthority so I can intercept for rewriting/auditing what a dns forwarder produces. However implementing a wrapper is extremely challenging without ForwardLookup also being public.