### PR TITLE
Mark ForwardLookup as public

### DIFF
--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -164,7 +164,10 @@ impl Authority for ForwardAuthority {
     }
 }
 
-pub struct ForwardLookup(ResolverLookup);
+/// A structure that holds the results of a forwarding lookup.
+///
+/// This exposes an interator interface for consumption downstream.
+pub struct ForwardLookup(pub ResolverLookup);
 
 impl LookupObject for ForwardLookup {
     fn is_empty(&self) -> bool {

--- a/crates/server/src/store/forwarder/mod.rs
+++ b/crates/server/src/store/forwarder/mod.rs
@@ -13,4 +13,5 @@ mod authority;
 mod config;
 
 pub use self::authority::ForwardAuthority;
+pub use self::authority::ForwardLookup;
 pub use self::config::ForwardConfig;


### PR DESCRIPTION
I am trying to implement a wrapper around ForwardAuthority so I can intercept for rewriting/auditing what a dns forwarder produces. However implementing a wrapper is extremely challenging without ForwardLookup and its contents being public.

As noted in the other branch I also added documentation to the struct as well.

Recreation of pull request #1727 with a clean git history. I also added pub to ResolverLookup that was required to construct it.