### PR TITLE
proto: Increase the maximum request depth to 26

### DIFF
--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -117,7 +117,7 @@ where
         let mut request = request.into();
 
         // backstop, this might need to be configurable at some point
-        if self.request_depth > 20 {
+        if self.request_depth > 26 {
             return Box::pin(stream::once(future::err(Self::Error::from(
                 ProtoError::from("exceeded max validation depth"),
             ))));


### PR DESCRIPTION
OPENPGPKEY requests in the wild has been found to exceed the maximum request depth (20) partially due to parallel requests that increase the counter by 2 or 4.

Increasing the value to 26 allows these requests to succeed. The test vector used to validate this change is a validating request for OPENPGPKEY records for the following name:

    A47CB586A51ACB93ACB9EF806F35F29131548E59E2FACD58CF6232E3._openpgpkey.debian.org

See: https://github.com/bluejekyll/trust-dns/issues/1735