### PR TITLE
doc: Fix warnings reported by cargo doc

### DIFF
--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! Use [`AsyncResolver`](crate::AsyncResolver) for performing DNS queries. `AsyncResolver` is a `async-std` based async resolver, and can be used inside any `asyn-std` based system.
 //!
-//! This as best as possible attempts to abide by the DNS RFCs, please file issues at https://github.com/bluejekyll/trust-dns .
+//! This as best as possible attempts to abide by the DNS RFCs, please file issues at <https://github.com/bluejekyll/trust-dns>.
 //!
 //! # Usage
 //!

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -177,7 +177,7 @@ impl Header {
     /// Construct a new header based off the request header. This copies over the RD (recursion-desired)
     ///   and CD (checking-disabled), as well as the op_code and id of the request.
     ///
-    /// See https://datatracker.ietf.org/doc/html/rfc6895#section-2
+    /// See <https://datatracker.ietf.org/doc/html/rfc6895#section-2>
     ///
     /// ```text
     /// The AA, TC, RD, RA, and CD bits are each theoretically meaningful

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -282,7 +282,7 @@ impl UdpSocket for tokio::net::UdpSocket {
 
     /// setups up a "client" udp connection that will only receive packets from the associated address
     ///
-    /// if the addr is ipv4 then it will bind local addr to 0.0.0.0:0, ipv6 [::]0
+    /// if the addr is ipv4 then it will bind local addr to 0.0.0.0:0, ipv6 \[::\]0
     async fn connect(addr: SocketAddr) -> io::Result<Self> {
         let bind_addr: SocketAddr = match addr {
             SocketAddr::V4(_addr) => (Ipv4Addr::UNSPECIFIED, 0).into(),


### PR DESCRIPTION
Adjust links so that they are rendered clickable and fix the escaping of
Markdown reference for IPv6 localhost.