### PR TITLE
README: Fix feature name

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Currently the root key is hardcoded into the system. This gives validation of
  appear to rate limit the connections, validating RRSIG records back to the root
  can require a significant number of additional queries for those records.
 
-Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-rustls` must be enabled.
+Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-ring` must be enabled.
 
 ## RFCs implemented
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -32,7 +32,7 @@ Currently the root key is hardcoded into the system. This gives validation of
  appear to rate limit the connections, validating RRSIG records back to the root
  can require a significant number of additional queries for those records.
 
-Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-rustls` must be enabled.
+Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-ring` must be enabled.
 
 ## Future goals
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -70,7 +70,7 @@ Currently the root key is hardcoded into the system. This gives validation of
  appear to rate limit the connections, validating RRSIG records back to the root
  can require a significant number of additional queries for those records.
 
-Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-rustls` must be enabled.
+Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-ring` must be enabled.
 
 ## Minimum Rust Version
 

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -77,7 +77,7 @@ Currently the root key is hardcoded into the system. This gives validation of
  appear to rate limit the connections, validating RRSIG records back to the root
  can require a significant number of additional queries for those records.
 
-Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-rustls` must be enabled.
+Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-ring` must be enabled.
 
 ## Testing the resolver via CLI with resolve
 


### PR DESCRIPTION
Previously used `dnssec-rustls` does not seem to be used anymore.

This patch updates the name to `dnssec-ring` that is in use.