### PR TITLE
Do not fail parse_resolv_conf on invalid hostname

### DIFF
--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -52,6 +52,10 @@ fn into_resolver_config(
     parsed_config: resolv_conf::Config,
 ) -> io::Result<(ResolverConfig, ResolverOpts)> {
     let domain = if let Some(domain) = parsed_config.get_system_domain() {
+        // The system domain name maybe appear to be valid to the resolv_conf
+        // crate but actually be invalid. For example, if the hostname is "matt.schulte's computer"
+        // In order to prevent a hostname which macOS or Windows would consider
+        // valid from returning an error here we turn parse errors to options
         Name::from_str(domain.as_str()).ok()
     } else {
         None

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -52,7 +52,7 @@ fn into_resolver_config(
     parsed_config: resolv_conf::Config,
 ) -> io::Result<(ResolverConfig, ResolverOpts)> {
     let domain = if let Some(domain) = parsed_config.get_system_domain() {
-        Some(Name::from_str(domain.as_str())?)
+        Name::from_str(domain.as_str()).ok()
     } else {
         None
     };


### PR DESCRIPTION
On macOS, user's can set their hostname to something invalid such as
matt.schulte's macbookpro. This will cause parse_resolv_conf to fail
because "into_resolver_config" will think the hostname contains the
system domain and then fail to parse that system domain.

Instead, we should treat the hostname as if it contains no domain (the
same as if the hostname contained no ".").

This fixes #1739 