### PR TITLE
Clean up ForwardAuthority api

### DIFF
--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -199,10 +199,9 @@ async fn load_zone(
         }
         #[cfg(feature = "resolver")]
         Some(StoreConfig::Forward(ref config)) => {
-            let forwarder = ForwardAuthority::try_from_config(zone_name, zone_type, config);
-            let authority = forwarder.await?;
+            let forwarder = ForwardAuthority::try_from_config(zone_name, zone_type, config)?;
 
-            Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
+            Box::new(Arc::new(forwarder)) as Box<dyn AuthorityObject>
         }
         #[cfg(feature = "sqlite")]
         None if zone_config.is_update_allowed() => {

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -37,7 +37,7 @@ impl ForwardAuthority {
     /// TODO: change this name to create or something
     #[allow(clippy::new_without_default)]
     #[doc(hidden)]
-    pub async fn new(runtime: TokioHandle) -> Result<Self, String> {
+    pub fn new(runtime: TokioHandle) -> Result<Self, String> {
         let resolver = TokioAsyncResolver::from_system_conf(runtime)
             .map_err(|e| format!("error constructing new Resolver: {}", e))?;
 
@@ -48,7 +48,7 @@ impl ForwardAuthority {
     }
 
     /// Read the Authority for the origin from the specified configuration
-    pub async fn try_from_config(
+    pub fn try_from_config(
         origin: Name,
         _zone_type: ZoneType,
         config: &ForwardConfig,

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -8,17 +8,16 @@ use tokio::runtime::Runtime;
 
 use trust_dns_client::rr::{Name, RData, RecordType};
 use trust_dns_resolver::TokioHandle;
-use trust_dns_server::authority::{Authority, LookupObject};
-use trust_dns_server::store::forwarder::ForwardAuthority;
+use trust_dns_server::{
+    authority::{Authority, LookupObject},
+    store::forwarder::ForwardAuthority,
+};
 
 #[ignore]
 #[test]
 fn test_lookup() {
     let runtime = Runtime::new().expect("failed to create Tokio Runtime");
-    let forwarder = ForwardAuthority::new(TokioHandle);
-    let forwarder = runtime
-        .block_on(forwarder)
-        .expect("failed to create forwarder");
+    let forwarder = ForwardAuthority::new(TokioHandle).expect("failed to create forwarder");
 
     let lookup = runtime
         .block_on(forwarder.lookup(


### PR DESCRIPTION
I removed async from ForwardAuthority's new and try_from_config methods.

Neither of them have any await calls so async adds a future layer for no benefit. Tests were adjusted to account for this too.