### PR TITLE
Make maximum request depth configurable

### DIFF
--- a/crates/proto/src/xfer/dns_request.rs
+++ b/crates/proto/src/xfer/dns_request.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, DerefMut};
 use crate::op::Message;
 
 /// A set of options for expressing options to how requests should be treated
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct DnsRequestOptions {
     /// When true, the underlying DNS protocols will not return on the first response received.
@@ -25,6 +25,20 @@ pub struct DnsRequestOptions {
     // TODO: add EDNS options here?
     /// When true, will add EDNS options to the request.
     pub use_edns: bool,
+
+    /// Specifies maximum request depth for DNSSEC validation.
+    pub max_request_depth: usize,
+}
+
+impl Default for DnsRequestOptions {
+    #[allow(deprecated)]
+    fn default() -> Self {
+        Self {
+            max_request_depth: 26,
+            expects_multiple_responses: false,
+            use_edns: false,
+        }
+    }
 }
 
 /// A DNS request object

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -116,8 +116,8 @@ where
     fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {
         let mut request = request.into();
 
-        // backstop, this might need to be configurable at some point
-        if self.request_depth > 26 {
+        // backstop
+        if self.request_depth > request.options().max_request_depth {
             return Box::pin(stream::once(future::err(Self::Error::from(
                 ProtoError::from("exceeded max validation depth"),
             ))));


### PR DESCRIPTION
This PR addresses the comment left in the source code allowing clients to adjust the request depth. This is especially important in DNSSEC queries for which the default request depth may not be enough. This PR depends on other merged PRs like #1742.

Fixes #1735.

Thank you for your time! :wave: 