### PR TITLE
Cleanup lex

### DIFF
--- a/crates/client/src/serialize/txt/zone_lex.rs
+++ b/crates/client/src/serialize/txt/zone_lex.rs
@@ -103,11 +103,7 @@ impl<'a> Lexer<'a> {
                 State::Comment { is_list } => {
                     match ch {
                         Some('\r') | Some('\n') => {
-                            if is_list {
-                                self.state = State::List;
-                            } else {
-                                self.state = State::EOL;
-                            }
+                            self.state = if is_list { State::List } else { State::EOL };
                         } // out of the comment
                         Some(_) => {
                             self.txt.next();

--- a/crates/client/src/serialize/txt/zone_lex.rs
+++ b/crates/client/src/serialize/txt/zone_lex.rs
@@ -150,15 +150,17 @@ impl<'a> Lexer<'a> {
                                 ))
                             })?;
 
-                            return match dollar.as_str() {
-                                "INCLUDE" => Ok(Some(Token::Include)),
-                                "ORIGIN" => Ok(Some(Token::Origin)),
-                                "TTL" => Ok(Some(Token::Ttl)),
-                                _ => Err(LexerErrorKind::UnrecognizedDollar(
-                                    char_data.take().unwrap_or_else(|| "".into()),
-                                )
-                                .into()),
-                            };
+                            return Ok(Some(match dollar.as_str() {
+                                "INCLUDE" => Token::Include,
+                                "ORIGIN" => Token::Origin,
+                                "TTL" => Token::Ttl,
+                                _ => {
+                                    return Err(LexerErrorKind::UnrecognizedDollar(
+                                        char_data.take().unwrap_or_else(|| "".into()),
+                                    )
+                                    .into())
+                                }
+                            }));
                         }
                     }
                 }

--- a/crates/client/src/serialize/txt/zone_lex.rs
+++ b/crates/client/src/serialize/txt/zone_lex.rs
@@ -154,18 +154,18 @@ impl<'a> Lexer<'a> {
                                 ))
                             })?;
 
-                            if "INCLUDE" == dollar {
-                                return Ok(Some(Token::Include));
-                            } else if "ORIGIN" == dollar {
-                                return Ok(Some(Token::Origin));
-                            } else if "TTL" == dollar {
-                                return Ok(Some(Token::Ttl));
-                            } else {
-                                return Err(LexerErrorKind::UnrecognizedDollar(
-                                    char_data.take().unwrap_or_else(|| "".into()),
-                                )
-                                .into());
-                            }
+                            let tok = match dollar.as_str() {
+                                "INCLUDE" => Token::Include,
+                                "ORIGIN" => Token::Origin,
+                                "TTL" => Token::Ttl,
+                                _ => {
+                                    return Err(LexerErrorKind::UnrecognizedDollar(
+                                        char_data.take().unwrap_or_else(|| "".into()),
+                                    )
+                                    .into());
+                                }
+                            };
+                            return Ok(Some(tok));
                         }
                     }
                 }

--- a/crates/client/src/serialize/txt/zone_lex.rs
+++ b/crates/client/src/serialize/txt/zone_lex.rs
@@ -154,18 +154,15 @@ impl<'a> Lexer<'a> {
                                 ))
                             })?;
 
-                            let tok = match dollar.as_str() {
-                                "INCLUDE" => Token::Include,
-                                "ORIGIN" => Token::Origin,
-                                "TTL" => Token::Ttl,
-                                _ => {
-                                    return Err(LexerErrorKind::UnrecognizedDollar(
-                                        char_data.take().unwrap_or_else(|| "".into()),
-                                    )
-                                    .into());
-                                }
+                            return match dollar.as_str() {
+                                "INCLUDE" => Ok(Some(Token::Include)),
+                                "ORIGIN" => Ok(Some(Token::Origin)),
+                                "TTL" => Ok(Some(Token::Ttl)),
+                                _ => Err(LexerErrorKind::UnrecognizedDollar(
+                                    char_data.take().unwrap_or_else(|| "".into()),
+                                )
+                                .into()),
                             };
-                            return Ok(Some(tok));
                         }
                     }
                 }

--- a/crates/client/src/serialize/txt/zone_lex.rs
+++ b/crates/client/src/serialize/txt/zone_lex.rs
@@ -66,9 +66,7 @@ impl<'a> Lexer<'a> {
                             char_data_vec = Some(Vec::new());
                             self.state = State::List;
                         }
-                        Some(')') => {
-                            return Err(LexerErrorKind::IllegalCharacter(ch.unwrap_or(')')).into())
-                        }
+                        Some(ch @ ')') => return Err(LexerErrorKind::IllegalCharacter(ch).into()),
                         Some('$') => {
                             self.txt.next();
                             char_data = Some(String::new());
@@ -142,9 +140,9 @@ impl<'a> Lexer<'a> {
                 State::Dollar => {
                     match ch {
                         // even this is a little broad for what's actually possible in a dollar...
-                        Some('A'..='Z') => {
+                        Some(ch @ 'A'..='Z') => {
                             self.txt.next();
-                            Self::push_to_str(&mut char_data, ch.unwrap())?;
+                            Self::push_to_str(&mut char_data, ch)?;
                         }
                         // finishes the Dollar...
                         Some(_) | None => {
@@ -198,8 +196,8 @@ impl<'a> Lexer<'a> {
                 },
                 State::CharData { is_list } => {
                     match ch {
-                        Some(')') if !is_list => {
-                            return Err(LexerErrorKind::IllegalCharacter(ch.unwrap_or(')')).into())
+                        Some(ch @ ')') if !is_list => {
+                            return Err(LexerErrorKind::IllegalCharacter(ch).into())
                         }
                         Some(ch) if ch.is_whitespace() || ch == ')' || ch == ';' => {
                             if is_list {
@@ -260,7 +258,7 @@ impl<'a> Lexer<'a> {
                         self.state = State::StartLine;
                         return Ok(Some(Token::EOL));
                     }
-                    Some(_) => return Err(LexerErrorKind::IllegalCharacter(ch.unwrap()).into()),
+                    Some(ch) => return Err(LexerErrorKind::IllegalCharacter(ch).into()),
                     None => return Err(LexerErrorKind::EOF.into()),
                 },
                 // to exhaust all cases, this should never be run...


### PR DESCRIPTION
[32d993f](https://github.com/bluejekyll/trust-dns/pull/1756/commits/32d993f8e866fa8914ed8f2c66eeb7bb998d1c1b) Used @ bindings in match to avoid `unwrap_or` https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#-bindings

Tried to make something more direct for reading in [0104201](https://github.com/bluejekyll/trust-dns/pull/1756/commits/01042017e9e047342c4d2f823904ecfa26e26d5a)