### PR TITLE
Clean unwrap again

### DIFF
--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -122,7 +122,7 @@ where
             }
         }
 
-        info!("signing zone: {}", zone_config.get_zone().unwrap());
+        info!("signing zone: {}", zone_config.get_zone()?);
         authority.secure_zone().await.expect("failed to sign zone");
     }
     Ok(())
@@ -257,10 +257,7 @@ async fn load_zone(
         }
     };
 
-    info!(
-        "zone successfully loaded: {}",
-        zone_config.get_zone().unwrap()
-    );
+    info!("zone successfully loaded: {}", zone_config.get_zone()?);
     Ok(authority)
 }
 

--- a/bin/src/named.rs
+++ b/bin/src/named.rs
@@ -425,8 +425,12 @@ fn main() {
 
     // TODO: support all the IPs asked to listen on...
     // TODO:, there should be the option to listen on any port, IP and protocol option...
-    let v4addr = config.get_listen_addrs_ipv4();
-    let v6addr = config.get_listen_addrs_ipv6();
+    let v4addr = config
+        .get_listen_addrs_ipv4()
+        .expect("Error with parsing provided by configuration Ipv4");
+    let v6addr = config
+        .get_listen_addrs_ipv6()
+        .expect("Error with parsing provided by configuration Ipv6");
     let mut listen_addrs: Vec<IpAddr> = v4addr
         .into_iter()
         .map(IpAddr::V4)

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -788,15 +788,12 @@ impl<R> ClientStreamXfrState<R> {
                     }
                     1 => {
                         *self = Ended;
-                        if answers.last().unwrap(/* answers is not empty */).rr_type()
-                            == RecordType::SOA
-                        {
-                            Ok(())
-                        } else {
-                            Err(ClientErrorKind::Message(
+                        match answers.last().map(|r| r.rr_type()) {
+                            Some(RecordType::SOA) => Ok(()),
+                            _ => Err(ClientErrorKind::Message(
                                 "invalid zone transfer, contains trailing records",
                             )
-                            .into())
+                            .into()),
                         }
                     }
                     _ => {

--- a/crates/client/src/rr/dnssec/keypair.rs
+++ b/crates/client/src/rr/dnssec/keypair.rs
@@ -362,7 +362,7 @@ impl<K: HasPrivate> KeyPair<K> {
             #[cfg(feature = "openssl")]
             KeyPair::RSA(ref pkey) | KeyPair::EC(ref pkey) => {
                 let digest_type = DigestType::from(algorithm).to_openssl_digest()?;
-                let mut signer = Signer::new(digest_type, pkey).unwrap();
+                let mut signer = Signer::new(digest_type, pkey)?;
                 signer.update(tbs.as_ref())?;
                 signer.sign_to_vec().map_err(Into::into).and_then(|bytes| {
                     if let KeyPair::RSA(_) = *self {
@@ -435,7 +435,7 @@ impl<K: HasPrivate> KeyPair<K> {
             #[cfg(feature = "ring")]
             KeyPair::ECDSA(ref ec_key) => {
                 let rng = rand::SystemRandom::new();
-                Ok(ec_key.sign(&rng, tbs.as_ref()).unwrap().as_ref().to_vec())
+                Ok(ec_key.sign(&rng, tbs.as_ref())?.as_ref().to_vec())
             }
             #[cfg(feature = "ring")]
             KeyPair::ED25519(ref ed_key) => Ok(ed_key.sign(tbs.as_ref()).as_ref().to_vec()),

--- a/crates/proto/src/rr/dnssec/public_key.rs
+++ b/crates/proto/src/rr/dnssec/public_key.rs
@@ -67,7 +67,7 @@ fn verify_with_pkey(
     signature: &[u8],
 ) -> ProtoResult<()> {
     let digest_type = DigestType::from(algorithm).to_openssl_digest()?;
-    let mut verifier = Verifier::new(digest_type, pkey).unwrap();
+    let mut verifier = Verifier::new(digest_type, pkey)?;
     verifier.update(message)?;
     verifier
         .verify(signature)

--- a/crates/proto/src/tests/tcp.rs
+++ b/crates/proto/src/tests/tcp.rs
@@ -34,10 +34,11 @@ fn tcp_server_setup(
             println!("Thread Killer has been awoken, killing process");
             std::process::exit(-1);
         })
-        .unwrap();
+        .expect("Thread spawning failed");
 
     // TODO: need a timeout on listen
-    let server = std::net::TcpListener::bind(SocketAddr::new(server_addr, 0)).unwrap();
+    let server = std::net::TcpListener::bind(SocketAddr::new(server_addr, 0))
+        .expect("Unable to bind a TCP socket");
     let server_addr = server.local_addr().unwrap();
 
     // an in and out server

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -11,7 +11,7 @@ pub mod dnssec;
 
 use std::fs::File;
 use std::io::Read;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{AddrParseError, Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
@@ -75,19 +75,13 @@ impl Config {
     }
 
     /// set of listening ipv4 addresses (for TCP and UDP)
-    pub fn get_listen_addrs_ipv4(&self) -> Vec<Ipv4Addr> {
-        self.listen_addrs_ipv4
-            .iter()
-            .map(|s| s.parse().unwrap())
-            .collect()
+    pub fn get_listen_addrs_ipv4(&self) -> Result<Vec<Ipv4Addr>, AddrParseError> {
+        self.listen_addrs_ipv4.iter().map(|s| s.parse()).collect()
     }
 
     /// set of listening ipv6 addresses (for TCP and UDP)
-    pub fn get_listen_addrs_ipv6(&self) -> Vec<Ipv6Addr> {
-        self.listen_addrs_ipv6
-            .iter()
-            .map(|s| s.parse().unwrap())
-            .collect()
+    pub fn get_listen_addrs_ipv6(&self) -> Result<Vec<Ipv6Addr>, AddrParseError> {
+        self.listen_addrs_ipv6.iter().map(|s| s.parse()).collect()
     }
 
     /// port on which to listen for connections on specified addresses

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -116,7 +116,7 @@ impl FileAuthority {
             .map_err(|e| format!("failed to read {}: {:?}", zone_path.display(), e))?;
         let reader = BufReader::new(file);
         for line in reader.lines() {
-            let content = line.unwrap();
+            let content = line.map_err(|err| format!("failed to read line: {:?}", err))?;
             let mut lexer = Lexer::new(&content);
 
             match (lexer.next_token(), lexer.next_token(), lexer.next_token()) {

--- a/crates/server/src/store/sqlite/persistence.rs
+++ b/crates/server/src/store/sqlite/persistence.rs
@@ -42,13 +42,9 @@ impl Journal {
     /// Constructs a new Journal opening a Sqlite connection to the file at the specified path
     pub fn from_file(journal_file: &Path) -> PersistenceResult<Self> {
         let result = Self::new(Connection::open(journal_file)?);
-        match result {
-            Ok(mut journal) => {
-                journal.schema_up().unwrap();
-                Ok(journal)
-            }
-            Err(err) => Err(err),
-        }
+        let mut journal = result?;
+        journal.schema_up()?;
+        Ok(journal)
     }
 
     /// Returns a reference to the Sqlite Connection

--- a/crates/server/tests/config_tests.rs
+++ b/crates/server/tests/config_tests.rs
@@ -35,8 +35,8 @@ fn test_read_config() {
     let config: Config = Config::read_config(&path).unwrap();
 
     assert_eq!(config.get_listen_port(), 53);
-    assert_eq!(config.get_listen_addrs_ipv4(), Vec::<Ipv4Addr>::new());
-    assert_eq!(config.get_listen_addrs_ipv6(), Vec::<Ipv6Addr>::new());
+    assert_eq!(config.get_listen_addrs_ipv4(), Ok(Vec::<Ipv4Addr>::new()));
+    assert_eq!(config.get_listen_addrs_ipv6(), Ok(Vec::<Ipv6Addr>::new()));
     assert_eq!(config.get_tcp_request_timeout(), Duration::from_secs(5));
     assert_eq!(config.get_log_level(), tracing::Level::INFO);
     assert_eq!(config.get_directory(), Path::new("/var/named"));
@@ -111,7 +111,7 @@ fn test_parse_toml() {
     let config: Config = "listen_addrs_ipv4 = [\"0.0.0.0\"]".parse().unwrap();
     assert_eq!(
         config.get_listen_addrs_ipv4(),
-        vec![Ipv4Addr::new(0, 0, 0, 0)]
+        Ok(vec![Ipv4Addr::new(0, 0, 0, 0)])
     );
 
     let config: Config = "listen_addrs_ipv4 = [\"0.0.0.0\", \"127.0.0.1\"]"
@@ -119,22 +119,22 @@ fn test_parse_toml() {
         .unwrap();
     assert_eq!(
         config.get_listen_addrs_ipv4(),
-        vec![Ipv4Addr::new(0, 0, 0, 0), Ipv4Addr::new(127, 0, 0, 1)]
+        Ok(vec![Ipv4Addr::new(0, 0, 0, 0), Ipv4Addr::new(127, 0, 0, 1)])
     );
 
     let config: Config = "listen_addrs_ipv6 = [\"::0\"]".parse().unwrap();
     assert_eq!(
         config.get_listen_addrs_ipv6(),
-        vec![Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)]
+        Ok(vec![Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)])
     );
 
     let config: Config = "listen_addrs_ipv6 = [\"::0\", \"::1\"]".parse().unwrap();
     assert_eq!(
         config.get_listen_addrs_ipv6(),
-        vec![
+        Ok(vec![
             Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0),
             Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
-        ]
+        ])
     );
 
     let config: Config = "tcp_request_timeout = 25".parse().unwrap();


### PR DESCRIPTION
An other pull request who try to remove `unwraps calls`.

If any commit is better to be dropped tell me! On to roll-up if needed.
I chose to remove some unwrap who are "not possible" rustc can know it and lift the `?` branch (because where is a size check) and it's future proof and fool prof.

May check cargo asm of the function to check my statement in a comment later.