### PR TITLE
Add option to use a provided name server order

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -738,7 +738,7 @@ pub enum ServerOrderingStrategy {
     /// Servers are ordered based on collected query statistics. The ordering
     /// may vary over time.
     Default,
-    /// The order provided to the reoslver is used. The ordering does not vary
+    /// The order provided to the resolver is used. The ordering does not vary
     /// over time.
     Strict,
 }

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -731,6 +731,25 @@ impl Default for LookupIpStrategy {
     }
 }
 
+/// The strategy for establishing the query order of name servers in a pool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize))]
+pub enum ServerOrderingStrategy {
+    /// Servers are ordered based on collected query statistics. The ordering
+    /// may vary over time.
+    Default,
+    /// The order provided to the reoslver is used. The ordering does not vary
+    /// over time.
+    Strict,
+}
+
+impl Default for ServerOrderingStrategy {
+    /// Returns [`ServerOrderingStrategy::Default`] as the default.
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
 /// Configuration for the Resolver
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(
@@ -797,6 +816,8 @@ pub struct ResolverOpts {
     pub preserve_intermediates: bool,
     /// Try queries over TCP if they fail over UDP.
     pub try_tcp_on_error: bool,
+    /// The server ordering strategy that the resolver should use.
+    pub server_ordering_strategy: ServerOrderingStrategy,
 }
 
 impl Default for ResolverOpts {
@@ -825,6 +846,7 @@ impl Default for ResolverOpts {
             preserve_intermediates: true,
 
             try_tcp_on_error: false,
+            server_ordering_strategy: ServerOrderingStrategy::default(),
         }
     }
 }

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -737,16 +737,16 @@ impl Default for LookupIpStrategy {
 pub enum ServerOrderingStrategy {
     /// Servers are ordered based on collected query statistics. The ordering
     /// may vary over time.
-    Default,
+    QueryStatistics,
     /// The order provided to the resolver is used. The ordering does not vary
     /// over time.
-    Strict,
+    UserProvidedOrder,
 }
 
 impl Default for ServerOrderingStrategy {
-    /// Returns [`ServerOrderingStrategy::Default`] as the default.
+    /// Returns [`ServerOrderingStrategy::QueryStatistics`] as the default.
     fn default() -> Self {
-        Self::Default
+        Self::QueryStatistics
     }
 }
 

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -184,8 +184,8 @@ where
             // select the highest priority connection
             //   reorder the connections based on current view...
             //   this reorders the inner set
-            ServerOrderingStrategy::Default => conns.sort_unstable(),
-            ServerOrderingStrategy::Strict => {}
+            ServerOrderingStrategy::QueryStatistics => conns.sort_unstable(),
+            ServerOrderingStrategy::UserProvidedOrder => {}
         }
         let request_loop = request.clone();
 


### PR DESCRIPTION
This corresponds to the "on/off" switch discussed in https://github.com/bluejekyll/trust-dns/issues/1702. A later pull
request will make improvements to the "Default" strategy.