### PR TITLE
ignore RUSTSEC-2021-0139 unmaintained ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432f044e9077ad6666f3446df0489a71ac3ed0336ea54edf6b85e00cd7562283"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -313,7 +313,7 @@ description = "Run cargo audit on all crates"
 workspace = false
 dependencies = ["check", "install-audit"]
 command = "cargo"
-args = ["audit", "--deny", "warnings"]
+args = ["audit", "--deny", "warnings", "--ignore", "RUSTSEC-2021-0139"]
 
 [tasks.cleanliness]
 description = "Runs clippy, fmt, and audit"


### PR DESCRIPTION
This is a temporary fix for the ansi_term unmaintained alert, tracked in #1767. It will fix the cleanliness issue.