### PR TITLE
Update idna dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,11 +490,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -717,11 +716,10 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -859,12 +857,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1036,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
@@ -2004,13 +1996,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
  "serde",
 ]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -81,7 +81,7 @@ futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 h2 = { version = "0.3.0", features = ["stream"], optional = true }
 http = { version = "0.2", optional = true }
-idna = "0.2.3"
+idna = "0.3.0"
 ipnet = "2.3.0"
 js-sys = { version = "0.3.44", optional = true }
 lazy_static = "1.2.0"
@@ -102,7 +102,7 @@ tokio = { version = "1.0", features = ["io-util"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-openssl = { version = "0.6.0", optional = true }
 tokio-rustls = { version = "0.23.0", optional = true, features = ["early-data"] }
-url = "2.1.0"
+url = "2.3.1"
 wasm-bindgen-crate = { version = "0.2.58", optional = true, package = "wasm-bindgen" }
 webpki = { version = "0.22.0", optional = true }
 webpki-roots = { version = "0.22.1", optional = true }


### PR DESCRIPTION
In my project I use the trust-dns-resolver and idna crates.

Now, when I try to bump the 0.major version of these crates to 0.22 and 0.3, respectively, the idna dependency is duplicated because trust-dns-proto still depends on idna 0.2.

The proposed change bumps the idna version to 0.3. Including this version bump in an 0.22.* release would be welcome.

Thank you.
