### PR TITLE
Fix bench errors in rust-analyzer

### DIFF
--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -1,3 +1,4 @@
+#![cfg(nightly)]
 #![feature(test)]
 
 extern crate test;

--- a/crates/client/benches/lower_name_benches.rs
+++ b/crates/client/benches/lower_name_benches.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#![cfg(nightly)]
 #![feature(test)]
 
 extern crate test;

--- a/crates/proto/benches/lib.rs
+++ b/crates/proto/benches/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(nightly)]
 #![feature(test)]
 
 extern crate test;

--- a/crates/proto/benches/name_benches.rs
+++ b/crates/proto/benches/name_benches.rs
@@ -1,3 +1,4 @@
+#![cfg(nightly)]
 #![feature(test)]
 
 extern crate test;


### PR DESCRIPTION
`#![feature(test)]` is nightly, but rust-analyzer sees files in `benches` and still tries to build them. This causes spurious errors in IDEs such as VSCode. Marking each bench file as nightly-only fixes this.