### PR TITLE
resolver: use errors' Display impl

### DIFF
--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -41,7 +41,7 @@ pub fn parse_resolv_conf<T: AsRef<[u8]>>(data: T) -> io::Result<(ResolverConfig,
     let parsed_conf = resolv_conf::Config::parse(&data).map_err(|e| {
         io::Error::new(
             io::ErrorKind::Other,
-            format!("Error parsing resolv.conf: {:?}", e),
+            format!("Error parsing resolv.conf: {}", e),
         )
     })?;
     into_resolver_config(parsed_conf)
@@ -93,7 +93,7 @@ fn into_resolver_config(
         search.push(Name::from_str_relaxed(&search_domain).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::Other,
-                format!("Error parsing resolv.conf: {:?}", e),
+                format!("Error parsing resolv.conf: {}", e),
             )
         })?);
     }


### PR DESCRIPTION
hi!

we had an error message saying `InvalidOption(2)` down this code path when using sentry's symbolicator. Since `resolve_conf` has a human-oriented message:

> option at line 2 is not recognized

We would like to change these formatting to `Display`.

The crate stack was like: symbolicator -> reqwest -> trust-dns -> resolv_conf, so we needed to dig some layers down to reach the wrong thing in our `resolv.conf` files (vim helpfully highlight those too!).

after:
```rust
[crates/resolver/src/bin/test_wrong.rs:4] system_conf::parse_resolv_conf("search example.-.").err().unwrap() = Custom {
    kind: Other,
    error: "Error parsing resolv.conf: Malformed label: -",
}
[crates/resolver/src/bin/test_wrong.rs:7] system_conf::parse_resolv_conf("options unknown:1").err().unwrap() = Custom {
    kind: Other,
    error: "Error parsing resolv.conf: option at line 0 is not recognized",
}
```

before:
```rust
[crates/resolver/src/bin/test_wrong.rs:4] system_conf::parse_resolv_conf("search example.-.").err().unwrap() = Custom {
    kind: Other,
    error: "Error parsing resolv.conf: ProtoError { kind: Msg(\"Malformed label: -\") }",
}
[crates/resolver/src/bin/test_wrong.rs:7] system_conf::parse_resolv_conf("options unknown:1").err().unwrap() = Custom {
    kind: Other,
    error: "Error parsing resolv.conf: InvalidOption(0)",
}
```

If you find this helpful, and you're fine with it, please label `hacktoberfest-accepted` as well. Thanks in advance!
