### PR TITLE
Explicit test for label max len and use ProtoErrorKind.

### DIFF
--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -481,6 +481,12 @@ mod tests {
     }
 
     #[test]
+    fn test_from_ascii_adversial_utf8() {
+        let expect_err = Label::from_ascii("🦀");
+        assert!(expect_err.is_err());
+    }
+
+    #[test]
     fn test_to_lowercase() {
         assert_ne!(Label::from_ascii("ABC").unwrap().to_string(), "abc");
         assert_ne!(Label::from_ascii("abcDEF").unwrap().to_string(), "abcdef");

--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -75,6 +75,10 @@ impl Label {
     ///
     /// This will return an Error if the label is not an ascii string
     pub fn from_ascii(s: &str) -> ProtoResult<Self> {
+        if s.len() > 63 {
+            return Err(ProtoErrorKind::LabelBytesTooLong(s.len()).into());
+        }
+
         if s.as_bytes() == WILDCARD {
             return Ok(Self::wildcard());
         }

--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -44,7 +44,7 @@ impl Label {
             return Err("Label requires a minimum length of 1".into());
         }
         if bytes.len() > 63 {
-            return Err(format!("Label exceeds maximum length 63: {}", bytes.len()).into());
+            return Err(ProtoErrorKind::LabelBytesTooLong(bytes.len()).into());
         };
         Ok(Self(TinyVec::from(bytes)))
     }

--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -398,6 +398,31 @@ mod tests {
         assert_eq!(Label::from_utf8("🦀").unwrap().to_ascii(), "xn--zs9h");
     }
 
+    fn assert_panic_label_too_long(error: ProtoResult<Label>, len: usize) {
+        assert!(error.is_err());
+        match *error.unwrap_err().kind() {
+            ProtoErrorKind::LabelBytesTooLong(n) if n == len => (),
+            ProtoErrorKind::LabelBytesTooLong(_) => {
+                panic!("LabelTooLongError error don't report the size of the label provided.")
+            }
+            _ => panic!("Should have returned a LabelTooLongError"),
+        }
+    }
+
+    #[test]
+    fn test_label_too_long_raw() {
+        let label_too_long = b"alwaystestingcodewithatoolonglabeltoolongtofitin63bytesisagoodhabit";
+        let error = Label::from_raw_bytes(label_too_long);
+        assert_panic_label_too_long(error, label_too_long.len());
+    }
+
+    #[test]
+    fn test_label_too_long_ascii() {
+        let label_too_long = "alwaystestingcodewithatoolonglabeltoolongtofitin63bytesisagoodhabit";
+        let error = Label::from_ascii(label_too_long);
+        assert_panic_label_too_long(error, label_too_long.len());
+    }
+
     #[test]
     fn test_decoding() {
         assert_eq!(Label::from_raw_bytes(b"abc").unwrap().to_string(), "abc");

--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -63,7 +63,10 @@ impl Label {
         match idna::Config::default()
             .use_std3_ascii_rules(true)
             .transitional_processing(true)
-            .verify_dns_length(true)
+            // length don't exceding 63 is done in `from_ascii`
+            // on puny encoded string
+            // idna error are opaque so early failure is not possible.
+            .verify_dns_length(false)
             .to_ascii(s)
         {
             Ok(puny) => Self::from_ascii(&puny),
@@ -399,14 +402,53 @@ mod tests {
     }
 
     fn assert_panic_label_too_long(error: ProtoResult<Label>, len: usize) {
+        // poor man debug since ProtoResult don't implement Partial Eq due to ssl errors.
+        eprintln!("{:?}", error);
         assert!(error.is_err());
         match *error.unwrap_err().kind() {
             ProtoErrorKind::LabelBytesTooLong(n) if n == len => (),
-            ProtoErrorKind::LabelBytesTooLong(_) => {
-                panic!("LabelTooLongError error don't report the size of the label provided.")
+            ProtoErrorKind::LabelBytesTooLong(e) => {
+                panic!(
+                    "LabelTooLongError error don't report expected size {} of the label provided.",
+                    e
+                )
             }
             _ => panic!("Should have returned a LabelTooLongError"),
         }
+    }
+
+    #[test]
+    fn test_label_too_long_ascii_with_utf8() {
+        let label_too_long = "alwaystestingcodewithatoolonglabeltoolongtofitin63bytesisagoodhabit";
+        let error = Label::from_utf8(label_too_long);
+        assert_panic_label_too_long(error, label_too_long.len());
+    }
+
+    #[test]
+    fn test_label_too_long_utf8_puny_emoji() {
+        // too long only puny 65
+        let emoji_case = "💜🦀🏖️🖥️😨🚀✨🤖💚🦾🦿😱😨✉️👺📚💻🗓️🤡🦀😈🚀💀⚡🦄";
+        let error = Label::from_utf8(emoji_case);
+        assert_panic_label_too_long(error, 64);
+    }
+
+    #[test]
+    fn test_label_too_long_utf8_puny_emoji_mixed() {
+        // too long mixed 65
+        // Something international to say
+        // "Hello I like automn coffee 🦀 interresting"
+        let emoji_case = "こんにちは-I-mögen-jesień-café-🦀-intéressant";
+        let error = Label::from_utf8(emoji_case);
+        assert_panic_label_too_long(error, 65);
+    }
+
+    #[test]
+    fn test_label_too_long_utf8_puny_mixed() {
+        // edge case 64 octet long.
+        // xn--testwithalonglabelinutf8tofitin63octetsisagoodhabit-f2106cqb
+        let edge_case = "🦀testwithalonglabelinutf8tofitin63octetsisagoodhabit🦀";
+        let error = Label::from_utf8(edge_case);
+        assert_panic_label_too_long(error, 64);
     }
 
     #[test]


### PR DESCRIPTION
While reviewing code for #1787 I found that some `Label` making code ~authorized~ enforcing with label length superior to 63 bytes has no explicit testing.
Also moved to use `ProtoErrorKind::LabelBytesTooLong` instead of text error.

Code bout utf8 might be splited into an other pr I chooses to recheck manually since the error is opaque.

EDIT: it's Friday... rephrased the message it was just gibbering
If anything is wrong: 

- removing the usage of `ProtoErrorKind::LabelBytesTooLong`
- Just keeping the test with strings
- or remove the early failure

Please tell me. :)