### PR TITLE
Improve CAA rdata display

### DIFF
--- a/crates/client/src/serialize/txt/rdata_parsers/caa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/caa.rs
@@ -135,10 +135,10 @@ mod tests {
         assert!(parse(vec!["0", "issue", "example.net"].into_iter()).is_ok());
 
         // issuer critical = true
-        test_to_string_parse_is_reversible(CAA::new_issue(true, None, vec![]), "128 issue \";\"");
+        test_to_string_parse_is_reversible(CAA::new_issue(true, None, vec![]), "128 issue \"\"");
 
         // deny
-        test_to_string_parse_is_reversible(CAA::new_issue(false, None, vec![]), "0 issue \";\"");
+        test_to_string_parse_is_reversible(CAA::new_issue(false, None, vec![]), "0 issue \"\"");
 
         // only hostname
         test_to_string_parse_is_reversible(

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -843,15 +843,11 @@ impl fmt::Display for Value {
 
         match self {
             Value::Issuer(name, values) => {
-                if name.is_none() && values.is_empty() {
-                    write!(f, ";")?;
-                } else {
-                    if let Some(name) = name {
-                        write!(f, "{}", name)?;
-                    }
-                    for value in values.iter() {
-                        write!(f, "; {}", value)?;
-                    }
+                if let Some(name) = name {
+                    write!(f, "{}", name)?;
+                }
+                for value in values.iter() {
+                    write!(f, "; {}", value)?;
                 }
             }
             Value::Url(url) => write!(f, "{}", url)?,
@@ -1121,7 +1117,7 @@ mod tests {
     #[test]
     fn test_to_string() {
         let deny = CAA::new_issue(false, None, vec![]);
-        assert_eq!(deny.to_string(), "0 issue \";\"");
+        assert_eq!(deny.to_string(), "0 issue \"\"");
 
         let empty_options = CAA::new_issue(
             false,

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -853,7 +853,7 @@ impl fmt::Display for Value {
             Value::Url(url) => write!(f, "{}", url)?,
             Value::Unknown(v) => match str::from_utf8(v) {
                 Ok(text) => write!(f, "{}", text)?,
-                Err(_) => write!(f, "{:?}", v)?,
+                Err(_) => return Err(fmt::Error),
             },
         }
 

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -1119,7 +1119,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tostring() {
+    fn test_to_string() {
         let deny = CAA::new_issue(false, None, vec![]);
         assert_eq!(deny.to_string(), "0 issue \";\"");
 
@@ -1156,6 +1156,13 @@ mod tests {
             flag_set.to_string(),
             "128 issue \"example.com; one=1; two=2\""
         );
+
+        let empty_domain = CAA::new_issue(
+            false,
+            None,
+            vec![KeyValue::new("one", "1"), KeyValue::new("two", "2")],
+        );
+        assert_eq!(empty_domain.to_string(), "0 issue \"; one=1; two=2\"");
 
         // Examples from RFC 6844, with added quotes
         assert_eq!(


### PR DESCRIPTION
This PR improves the CAA RData Display trait.

It adds the examples from the RFC 6844 as test cases and fixes the `fmt::Display` for  the `Value` struct.
- Shows the `true` `issuer_critical` flag as `128` instead of `1`.
  - Ideally, the flag should have been stored as a `u8`.
- Fixes how the `;` separator is handled.
- Shows `Value::Unknown` as a string, if it is a valid UTF8 string.

