### PR TITLE
[rfc8659] CAA RR Change references to RFC 6844 to 8659.

### DIFF
--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -239,7 +239,7 @@ pub enum Property {
     ///    Certification Practices or Certificate Policy, or that a
     ///    Certificate Evaluator may use to report observation of a possible
     ///    policy violation. The Incident Object Description Exchange Format
-    ///    (IODEF) format is used [RFC5070](https://tools.ietf.org/html/rfc5070).
+    ///    (IODEF) format is used [RFC7970](https://www.rfc-editor.org/rfc/rfc7970).
     Iodef,
     /// Unknown format to Trust-DNS
     Unknown(String),
@@ -604,7 +604,7 @@ pub fn read_issuer(bytes: &[u8]) -> ProtoResult<(Option<Name>, Vec<KeyValue>)> {
 ///    that violate the security policy of the issuer or the domain name
 ///    holder.
 ///
-///    The Incident Object Description Exchange Format (IODEF) [RFC5070] is
+///    The Incident Object Description Exchange Format (IODEF) [RFC7970](https://www.rfc-editor.org/info/rfc7970) is
 ///    used to present the incident report in machine-readable form.
 ///
 ///    The iodef property takes a URL as its parameter.  The URL scheme type

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -8,7 +8,7 @@
 //! allows a DNS domain name holder to specify one or more Certification
 //! Authorities (CAs) authorized to issue certificates for that domain.
 //!
-//! [RFC 6844, DNS Certification Authority Authorization, January 2013](https://tools.ietf.org/html/rfc6844)
+//! [RFC 8659, DNS Certification Authority Authorization, November 2019](https://www.rfc-editor.org/rfc/rfc8659)
 //!
 //! ```text
 //! The Certification Authority Authorization (CAA) DNS Resource Record
@@ -34,7 +34,7 @@ use url::Url;
 
 /// The CAA RR Type
 ///
-/// [RFC 6844, DNS Certification Authority Authorization, January 2013](https://tools.ietf.org/html/rfc6844#section-3)
+/// [RFC 8659, DNS Certification Authority Authorization, November 2019](https://www.rfc-editor.org/rfc/rfc8659)
 ///
 /// ```text
 /// 3.  The CAA RR Type
@@ -279,8 +279,8 @@ impl Property {
 
 impl From<String> for Property {
     fn from(tag: String) -> Self {
-        // RFC6488 section 5.1 states that "Matching of tag values is case
-        // insensitive."
+        // [RFC 8659 section 4.1-11](https://www.rfc-editor.org/rfc/rfc8659#section-4.1-11)
+        // states that "Matching of tag values is case insensitive."
         let lower = tag.to_ascii_lowercase();
         match &lower as &str {
             "issue" => return Self::Issue,
@@ -400,7 +400,7 @@ enum ParseNameKeyPairState {
 
 /// Reads the issuer field according to the spec
 ///
-/// [RFC 6844, DNS Certification Authority Authorization, January 2013](https://tools.ietf.org/html/rfc6844#section-5.2)
+/// [RFC 8659, DNS Certification Authority Authorization, November 2019](https://www.rfc-editor.org/rfc/rfc8659)
 ///
 /// ```text
 /// 5.2.  CAA issue Property
@@ -469,8 +469,7 @@ enum ParseNameKeyPairState {
 ///
 /// Updated parsing rules:
 ///
-/// [RFC 6844bis, CAA Resource Record, May 2018](https://tools.ietf.org/html/draft-ietf-lamps-rfc6844bis-00)
-/// [RFC 6844, CAA Record Extensions, May 2018](https://tools.ietf.org/html/draft-ietf-acme-caa-04)
+/// [RFC8659] Canonical presentation form and ABNF](https://www.rfc-editor.org/rfc/rfc8659#name-canonical-presentation-form)
 ///
 /// This explicitly allows `-` in key names, diverging from the original RFC. To support this, key names will
 /// allow `-` as non-starting characters. Additionally, this significantly relaxes the characters allowed in the value
@@ -595,7 +594,7 @@ pub fn read_issuer(bytes: &[u8]) -> ProtoResult<(Option<Name>, Vec<KeyValue>)> {
 
 /// Incident Object Description Exchange Format
 ///
-/// [RFC 6844, DNS Certification Authority Authorization, January 2013](https://tools.ietf.org/html/rfc6844#section-5.4)
+/// [RFC 8659, DNS Certification Authority Authorization, November 2019](https://www.rfc-editor.org/rfc/rfc8659#section-4.4)
 ///
 /// ```text
 /// 5.4.  CAA iodef Property
@@ -628,7 +627,7 @@ pub fn read_iodef(url: &[u8]) -> ProtoResult<Url> {
 
 /// Issuer key and value pairs.
 ///
-/// See [RFC 6844, DNS Certification Authority Authorization, January 2013](https://tools.ietf.org/html/rfc6844#section-5.2)
+/// [RFC 8659, DNS Certification Authority Authorization, November 2019](https://www.rfc-editor.org/rfc/rfc8659#section-4.2)
 /// for more explanation.
 #[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -659,7 +658,7 @@ impl KeyValue {
 
 /// Read the binary CAA format
 ///
-/// [RFC 6844, DNS Certification Authority Authorization, January 2013](https://tools.ietf.org/html/rfc6844#section-5.1)
+/// [RFC 8659, DNS Certification Authority Authorization, November 2019](https://www.rfc-editor.org/rfc/rfc8659#section-4.1)
 ///
 /// ```text
 /// 5.1.  Syntax
@@ -838,7 +837,7 @@ impl fmt::Display for Property {
 }
 
 impl fmt::Display for Value {
-    // https://datatracker.ietf.org/doc/html/rfc6844#section-5.1.1
+    // https://www.rfc-editor.org/rfc/rfc8659#section-4.1.1
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str("\"")?;
 


### PR DESCRIPTION
code was written here circa 2017, in 2019 [rfc8659](https://datatracker.ietf.org/doc/html/rfc8659) was issued.