### PR TITLE
proto: allow unrestricted length character length in SVCB param values

### DIFF
--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -1183,9 +1183,6 @@ mod tests {
         emit(&mut encoder, &rdata).expect("failed to emit SVCB");
         let bytes = encoder.into_bytes();
 
-        println!("svcb: {}", rdata);
-        println!("bytes: {:?}", bytes);
-
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
         let read_rdata =
             read(&mut decoder, Restrict::new(bytes.len() as u16)).expect("failed to read back");

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -298,9 +298,18 @@ impl<'a> BinEncoder<'a> {
             .into());
         }
 
+        self.emit_character_data_unrestricted(char_data)
+    }
+
+    /// Emit character data of unrestricted length
+    ///
+    /// Although character strings are typically restricted to being no longer than 255 characters,
+    /// some modern standards allow longer strings to be encoded.
+    pub fn emit_character_data_unrestricted<S: AsRef<[u8]>>(&mut self, data: S) -> ProtoResult<()> {
         // first the length is written
-        self.emit(char_bytes.len() as u8)?;
-        self.write_slice(char_bytes)
+        let data = data.as_ref();
+        self.emit(data.len() as u8)?;
+        self.write_slice(data)
     }
 
     /// Emit one byte into the buffer


### PR DESCRIPTION
Fixes yet another fuzzing issue.