### PR TITLE
Add --reverse, --file and --interval to util/resolve

### DIFF
--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -429,6 +429,12 @@ macro_rules! lookup_type {
             }
         }
 
+        impl From<$l> for Lookup {
+            fn from(revlookup: $l) -> Self {
+                revlookup.0
+            }
+        }
+
         /// An iterator over the Lookup type
         pub struct $i<'i>(LookupIter<'i>);
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -85,7 +85,6 @@ trust-dns-client = { version = "0.22.0", path = "../crates/client" }
 trust-dns-proto = { version = "0.22.0", path = "../crates/proto" }
 trust-dns-recursor = { version = "0.22.0", path = "../crates/recursor" }
 trust-dns-resolver = { version = "0.22.0", path = "../crates/resolver" }
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "time"] }
 webpki = { version = "0.22.0", optional = true }
 webpki-roots = { version = "0.22.1", optional = true }
-


### PR DESCRIPTION
This PR adds:

* The ability to run reverse lookups. The previous code allowed for reverse lookups but required the user to pass `in-addr.arpa` hostnames.  Passing `--reverse` makes the conversion automatically.

* The ability to resolve names given in a file (one name per line). 

Happy to make adjustments or integrate any feedback to improve it further.

