### PR TITLE
TSIG documenting client tsig code + update rfc link

### DIFF
--- a/crates/client/src/rr/dnssec/tsig.rs
+++ b/crates/client/src/rr/dnssec/tsig.rs
@@ -5,7 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! tsigner is a structure for computing tsig messasignuthentication code for dns transactions
+//! Trust dns implementation of Secret Key Transaction Authentication for DNS (TSIG)
+//! [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945) November 2020
+//!
+//! Current deviation from RFC in implementation as of 2022-10-28
+//!
+//! - Mac checking don't support HMAC truncation with TSIG (pedantic constant time verification)
+//! - Time checking not in TSIG implementation but in caller
+
 use tracing::debug;
 
 use crate::proto::error::{ProtoError, ProtoResult};

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -90,7 +90,7 @@ pub enum ResponseCode {
     NXRRSet,
 
     /// Server Not Authoritative for zone [RFC 2136](https://tools.ietf.org/html/rfc2136)
-    /// or Not Authorized [RFC 2845](https://tools.ietf.org/html/rfc2845)
+    /// or Not Authorized [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945)
     NotAuth,
 
     /// Name not contained in zone [RFC 2136](https://tools.ietf.org/html/rfc2136)
@@ -99,13 +99,13 @@ pub enum ResponseCode {
     /// Bad OPT Version [RFC 6891](https://tools.ietf.org/html/rfc6891#section-9)
     BADVERS,
 
-    /// TSIG Signature Failure [RFC 2845](https://tools.ietf.org/html/rfc2845)
+    /// TSIG Signature Failure [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945)
     BADSIG,
 
-    /// Key not recognized [RFC 2845](https://tools.ietf.org/html/rfc2845)
+    /// Key not recognized [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945)
     BADKEY,
 
-    /// Signature out of time window [RFC 2845](https://tools.ietf.org/html/rfc2845)
+    /// Signature out of time window [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945)
     BADTIME,
 
     /// Bad TKEY Mode [RFC 2930](https://tools.ietf.org/html/rfc2930#section-2.6)

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -639,8 +639,15 @@ impl TsigAlgorithm {
         Ok(len)
     }
 
-    /// Return true if cryptographic operations needed for using this algorithm are supported,
-    /// false otherwise
+    /// Return `true` if cryptographic operations needed for using this algorithm are supported,
+    /// `false` otherwise
+    ///
+    /// ## Supported
+    ///
+    /// - HmacSha256
+    /// - HmacSha384
+    /// - HmacSha512
+    /// - HmacSha512_256
     pub fn supported(&self) -> bool {
         use TsigAlgorithm::*;
         matches!(self, HmacSha256 | HmacSha384 | HmacSha512)


### PR DESCRIPTION
Two fold: 

- Add module doc about TSIG client implementation (ref to RFC) and documentation of deviation from the RFC (may need a review did a summary based on comments in `verify_message_byte`).
- Update TSIG to newer RFC