### PR TITLE
Also declare MSRV in Cargo.toml

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-dns"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -3,6 +3,7 @@ name = "async-std-resolver"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-dns-client"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -2,6 +2,7 @@
 name = "trust-dns-proto"
 version = "0.22.0"
 edition = "2018"
+rust-version = "1.60.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 # A short blurb about the package. This is not rendered in any format when

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-dns-recursor"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-dns-resolver"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-dns-server"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.60.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/tests/compatibility-tests/Cargo.toml
+++ b/tests/compatibility-tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-dns-compatibility"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-dns-integration"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -3,6 +3,7 @@ name = "trust-dns-util"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)


### PR DESCRIPTION
Follow-up to #1813: Also declare the MSRV in Cargo.toml, for the benefit of dependent apps and libraries.

See https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field.

Thank you.