### PR TITLE
Possibility to have AsyncClient return SerialMessages

### DIFF
--- a/bin/tests/named_tests.rs
+++ b/bin/tests/named_tests.rs
@@ -20,6 +20,7 @@ use trust_dns_client::op::ResponseCode;
 use trust_dns_client::rr::*;
 use trust_dns_client::tcp::TcpClientStream;
 use trust_dns_client::udp::UdpClientStream;
+use trust_dns_proto::op::Message;
 
 // TODO: Needed for when TLS tests are added back
 // #[cfg(feature = "dns-over-openssl")]
@@ -81,7 +82,7 @@ fn test_ipv4_only_toml_startup() {
             tcp_port.expect("no tcp_port"),
         );
         let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
-        let client = AsyncClient::new(Box::new(stream), sender, None);
+        let client = AsyncClient::<Message>::new(Box::new(stream), sender, None);
 
         assert!(io_loop.block_on(client).is_err());
         //let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -161,7 +162,7 @@ fn test_nodata_where_name_exists() {
             tcp_port.expect("no tcp_port"),
         );
         let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
-        let client = AsyncClient::new(Box::new(stream), sender, None);
+        let client = AsyncClient::<Message>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
 
@@ -186,7 +187,7 @@ fn test_nxdomain_where_no_name_exists() {
             tcp_port.expect("no tcp_port"),
         );
         let (stream, sender) = TcpClientStream::<AsyncIoTokioAsStd<TokioTcpStream>>::new(addr);
-        let client = AsyncClient::new(Box::new(stream), sender, None);
+        let client = AsyncClient::<Message>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         trust_dns_proto::spawn_bg(&io_loop, bg);
 

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -621,15 +621,15 @@ where
 
 /// A future result of a Client Request
 #[must_use = "futures do nothing unless polled"]
-pub struct ClientResponse<R>(pub(crate) R)
+pub struct ClientResponse<R, M = Message>(pub(crate) R)
 where
-    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static;
+    R: Stream<Item = Result<DnsResponse<M>, ProtoError>> + Send + Unpin + 'static;
 
-impl<R> Future for ClientResponse<R>
+impl<R, M> Future for ClientResponse<R, M>
 where
-    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static,
+    R: Stream<Item = Result<DnsResponse<M>, ProtoError>> + Send + Unpin + 'static,
 {
-    type Output = Result<DnsResponse, ClientError>;
+    type Output = Result<DnsResponse<M>, ClientError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -646,16 +646,16 @@ where
 /// Accept messages until the end of a zone transfer. For AXFR, it search for a starting and an
 /// ending SOA. For IXFR, it do so taking into account there will be other SOA inbetween
 #[must_use = "stream do nothing unless polled"]
-pub struct ClientStreamXfr<R>
+pub struct ClientStreamXfr<R, M = Message>
 where
-    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static,
+    R: Stream<Item = Result<DnsResponse<M>, ProtoError>> + Send + Unpin + 'static,
 {
     state: ClientStreamXfrState<R>,
 }
 
-impl<R> ClientStreamXfr<R>
+impl<R, M> ClientStreamXfr<R, M>
 where
-    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static,
+    R: Stream<Item = Result<DnsResponse<M>, ProtoError>> + Send + Unpin + 'static,
 {
     fn new(inner: R, maybe_incr: bool) -> Self {
         Self {

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -1093,13 +1093,13 @@ mod tests {
 
     #[tokio::test]
     async fn async_client() {
-        use std::net::Ipv4Addr;
-        use std::str::FromStr;
-        use tokio::net::TcpStream as TokioTcpStream;
         use crate::client::{AsyncClient, ClientHandle};
         use crate::proto::iocompat::AsyncIoTokioAsStd;
         use crate::rr::{DNSClass, Name, RData, RecordType};
         use crate::tcp::TcpClientStream;
+        use std::net::Ipv4Addr;
+        use std::str::FromStr;
+        use tokio::net::TcpStream as TokioTcpStream;
 
         // Since we used UDP in the previous examples, let's change things up a bit and use TCP here
         let (stream, sender) =

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -608,15 +608,15 @@ where
 
 /// A stream result of a Client Request
 #[must_use = "stream do nothing unless polled"]
-pub struct ClientStreamingResponse<R>(pub(crate) R)
+pub struct ClientStreamingResponse<R, M = Message>(pub(crate) R)
 where
-    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static;
+    R: Stream<Item = Result<DnsResponse<M>, ProtoError>> + Send + Unpin + 'static;
 
-impl<R> Stream for ClientStreamingResponse<R>
+impl<R, M> Stream for ClientStreamingResponse<R, M>
 where
-    R: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static,
+    R: Stream<Item = Result<DnsResponse<M>, ProtoError>> + Send + Unpin + 'static,
 {
-    type Item = Result<DnsResponse, ClientError>;
+    type Item = Result<DnsResponse<M>, ClientError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(ready!(self.0.poll_next_unpin(cx)).map(|r| r.map_err(ClientError::from)))

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -228,10 +228,11 @@
 //! use std::str::FromStr;
 //! use tokio::net::TcpStream as TokioTcpStream;
 //! use trust_dns_client::client::{AsyncClient, ClientHandle};
+//! use trust_dns_client::op::Message;
 //! use trust_dns_client::proto::iocompat::AsyncIoTokioAsStd;
 //! use trust_dns_client::rr::{DNSClass, Name, RData, RecordType};
 //! use trust_dns_client::tcp::TcpClientStream;
-//!
+
 //! #[tokio::main]
 //! async fn main() {
 //!     // Since we used UDP in the previous examples, let's change things up a bit and use TCP here
@@ -243,7 +244,7 @@
 //!     //   the client is a handle to an unbounded queue for sending requests via the
 //!     //   background. The background must be scheduled to run before the client can
 //!     //   send any dns requests
-//!     let client = AsyncClient::new(stream, sender, None);
+//!     let client = AsyncClient::<Message>::new(stream, sender, None);
 //!
 //!     // await the connection to be established
 //!     let (mut client, bg) = client.await.expect("connection failed");

--- a/crates/client/src/rr/dnssec/tsig.rs
+++ b/crates/client/src/rr/dnssec/tsig.rs
@@ -262,7 +262,7 @@ mod tests {
 
         assert!(question.signature().is_empty());
         question
-            .finalize(&signer, time_begin as u32)
+            .finalize::<TSigner, Message>(&signer, time_begin as u32)
             .expect("should have signed");
         assert!(!question.signature().is_empty());
 
@@ -292,7 +292,7 @@ mod tests {
 
         assert!(question.signature().is_empty());
         question
-            .finalize(&signer, time_begin as u32)
+            .finalize::<TSigner, Message>(&signer, time_begin as u32)
             .expect("should have signed");
         assert!(!question.signature().is_empty());
 

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -9,6 +9,7 @@
 
 #![deny(missing_docs)]
 
+use std::convert::Infallible;
 use std::{fmt, io, sync};
 
 #[cfg(not(feature = "openssl"))]
@@ -346,6 +347,12 @@ where
             #[cfg(feature = "backtrace")]
             backtrack: trace!(),
         }
+    }
+}
+
+impl From<Infallible> for ProtoError {
+    fn from(_: Infallible) -> Self {
+        unreachable!();
     }
 }
 

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -847,7 +847,7 @@ impl Deref for Message {
 }
 
 /// Alias for a function verifying if a message is properly signed
-pub type MessageVerifier = Box<dyn FnMut(&[u8]) -> ProtoResult<DnsResponse> + Send>;
+pub type MessageVerifier<M = Message> = Box<dyn FnMut(&[u8]) -> ProtoResult<DnsResponse<M>> + Send>;
 
 /// A trait for performing final amendments to a Message before it is sent.
 ///

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -19,7 +19,7 @@ use tracing::{debug, warn};
 
 use crate::error::ProtoError;
 use crate::op::message::NoopMessageFinalizer;
-use crate::op::{MessageFinalizer, MessageVerifier};
+use crate::op::{Message, MessageFinalizer, MessageVerifier};
 use crate::udp::udp_stream::{NextRandomUdpSocket, UdpSocket};
 use crate::xfer::{DnsRequest, DnsRequestSender, DnsResponse, DnsResponseStream, SerialMessage};
 use crate::Time;
@@ -166,7 +166,7 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> DnsRequestSender
         let mut verifier = None;
         if let Some(ref signer) = self.signer {
             if signer.should_finalize_message(&message) {
-                match message.finalize::<MF>(signer.borrow(), now) {
+                match message.finalize::<MF, Message>(signer.borrow(), now) {
                     Ok(answer_verifier) => verifier = answer_verifier,
                     Err(e) => {
                         debug!("could not sign message: {}", e);

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -129,27 +129,27 @@ impl<M: Clone> Stream for DnsExchangeSend<M> {
 ///
 /// It must be spawned before any DNS messages are sent.
 #[must_use = "futures do nothing unless polled"]
-pub struct DnsExchangeBackground<S, TE>
+pub struct DnsExchangeBackground<S, TE, M = Message>
 where
-    S: DnsRequestSender + 'static + Send + Unpin,
+    S: DnsRequestSender<M> + 'static + Send + Unpin,
 {
     io_stream: S,
-    outbound_messages: Peekable<mpsc::Receiver<OneshotDnsRequest>>,
+    outbound_messages: Peekable<mpsc::Receiver<OneshotDnsRequest<M>>>,
     marker: PhantomData<TE>,
 }
 
-impl<S, TE> DnsExchangeBackground<S, TE>
+impl<S, TE, M> DnsExchangeBackground<S, TE, M>
 where
-    S: DnsRequestSender + 'static + Send + Unpin,
+    S: DnsRequestSender<M> + 'static + Send + Unpin,
 {
-    fn pollable_split(&mut self) -> (&mut S, &mut Peekable<mpsc::Receiver<OneshotDnsRequest>>) {
+    fn pollable_split(&mut self) -> (&mut S, &mut Peekable<mpsc::Receiver<OneshotDnsRequest<M>>>) {
         (&mut self.io_stream, &mut self.outbound_messages)
     }
 }
 
-impl<S, TE> Future for DnsExchangeBackground<S, TE>
+impl<S, TE, M> Future for DnsExchangeBackground<S, TE, M>
 where
-    S: DnsRequestSender + 'static + Send + Unpin,
+    S: DnsRequestSender<M> + 'static + Send + Unpin,
     TE: Time + Unpin,
 {
     type Output = Result<(), ProtoError>;

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -19,6 +19,7 @@ use tracing::{debug, warn};
 use crate::error::*;
 use crate::xfer::dns_handle::DnsHandle;
 use crate::xfer::DnsResponseReceiver;
+use crate::xfer::Message;
 use crate::xfer::{
     BufDnsRequestStreamHandle, DnsRequest, DnsRequestSender, DnsResponse, OneshotDnsRequest,
     CHANNEL_BUFFER_SIZE,
@@ -107,13 +108,16 @@ impl DnsHandle for DnsExchange {
 
 /// A Stream that will resolve to Responses after sending the request
 #[must_use = "futures do nothing unless polled"]
-pub struct DnsExchangeSend {
-    result: DnsResponseReceiver,
-    _sender: BufDnsRequestStreamHandle,
+pub struct DnsExchangeSend<M = Message>
+where
+    M: Clone,
+{
+    result: DnsResponseReceiver<M>,
+    _sender: BufDnsRequestStreamHandle<M>,
 }
 
-impl Stream for DnsExchangeSend {
-    type Item = Result<DnsResponse, ProtoError>;
+impl<M: Clone> Stream for DnsExchangeSend<M> {
+    type Item = Result<DnsResponse<M>, ProtoError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // as long as there is no result, poll the exchange

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -28,9 +28,12 @@ pub trait DnsStreamHandle: 'static + Send {
 }
 
 /// A trait for implementing high level functions of DNS.
-pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
+pub trait DnsHandle<M = Message>: 'static + Clone + Send + Sync + Unpin
+where
+    M: Clone,
+{
     /// The associated response from the response stream, this should resolve to the Response messages
-    type Response: Stream<Item = Result<DnsResponse, Self::Error>> + Send + Unpin + 'static;
+    type Response: Stream<Item = Result<DnsResponse<M>, Self::Error>> + Send + Unpin + 'static;
     /// Error of the response, generally this will be `ProtoError`
     type Error: From<ProtoError> + Error + Clone + Send + Unpin + 'static;
 

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -25,7 +25,7 @@ use rand::distributions::{Distribution, Standard};
 use tracing::{debug, warn};
 
 use crate::error::*;
-use crate::op::{MessageFinalizer, MessageVerifier};
+use crate::op::{Message, MessageFinalizer, MessageVerifier};
 use crate::xfer::{
     ignore_send, BufDnsStreamHandle, DnsClientStream, DnsRequest, DnsRequestSender, DnsResponse,
     DnsResponseStream, SerialMessage, CHANNEL_BUFFER_SIZE,
@@ -293,7 +293,7 @@ where
         let mut verifier = None;
         if let Some(ref signer) = self.signer {
             if signer.should_finalize_message(&request) {
-                match request.finalize::<MF>(signer.borrow(), now) {
+                match request.finalize::<MF, Message>(signer.borrow(), now) {
                     Ok(answer_verifier) => verifier = answer_verifier,
                     Err(e) => {
                         debug!("could not sign message: {}", e);

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -35,20 +35,20 @@ use crate::Time;
 
 const QOS_MAX_RECEIVE_MSGS: usize = 100; // max number of messages to receive from the UDP socket
 
-struct ActiveRequest {
+struct ActiveRequest<M = Message> {
     // the completion is the channel for a response to the original request
-    completion: mpsc::Sender<Result<DnsResponse, ProtoError>>,
+    completion: mpsc::Sender<Result<DnsResponse<M>, ProtoError>>,
     request_id: u16,
     timeout: Box<dyn Future<Output = ()> + Send + Unpin>,
-    verifier: Option<MessageVerifier>,
+    verifier: Option<MessageVerifier<M>>,
 }
 
-impl ActiveRequest {
+impl<M> ActiveRequest<M> {
     fn new(
-        completion: mpsc::Sender<Result<DnsResponse, ProtoError>>,
+        completion: mpsc::Sender<Result<DnsResponse<M>, ProtoError>>,
         request_id: u16,
         timeout: Box<dyn Future<Output = ()> + Send + Unpin>,
-        verifier: Option<MessageVerifier>,
+        verifier: Option<MessageVerifier<M>>,
     ) -> Self {
         Self {
             completion,

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -117,8 +117,10 @@ enum DnsResponseStreamInner {
     Boxed(Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>),
 }
 
-type TimeoutFuture = Pin<
-    Box<dyn Future<Output = Result<Result<DnsResponse, ProtoError>, io::Error>> + Send + 'static>,
+type TimeoutFuture<M = Message> = Pin<
+    Box<
+        dyn Future<Output = Result<Result<DnsResponse<M>, ProtoError>, io::Error>> + Send + 'static,
+    >,
 >;
 
 // TODO: this needs to have the IP addr of the remote system...

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -127,7 +127,7 @@ type TimeoutFuture = Pin<
 ///
 /// For Most DNS requests, only one response is expected, the exception is a multicast request.
 #[derive(Clone, Debug)]
-pub struct DnsResponse(Message);
+pub struct DnsResponse<M = Message>(M);
 
 // TODO: when `impl Trait` lands in stable, remove this, and expose FlatMap over answers, et al.
 impl DnsResponse {
@@ -279,22 +279,24 @@ impl DnsResponse {
             _ => None,
         }
     }
+}
 
+impl<M> DnsResponse<M> {
     /// Take the inner Message from the response
-    pub fn into_inner(self) -> Message {
+    pub fn into_inner(self) -> M {
         self.0
     }
 }
 
-impl Deref for DnsResponse {
-    type Target = Message;
+impl<M> Deref for DnsResponse<M> {
+    type Target = M;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for DnsResponse {
+impl<M> DerefMut for DnsResponse<M> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -110,11 +110,11 @@ where
     }
 }
 
-enum DnsResponseStreamInner {
-    Timeout(TimeoutFuture),
-    Receiver(mpsc::Receiver<ProtoResult<DnsResponse>>),
+enum DnsResponseStreamInner<M = Message> {
+    Timeout(TimeoutFuture<M>),
+    Receiver(mpsc::Receiver<ProtoResult<DnsResponse<M>>>),
     Error(Option<ProtoError>),
-    Boxed(Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>),
+    Boxed(Pin<Box<dyn Future<Output = Result<DnsResponse<M>, ProtoError>> + Send>>),
 }
 
 type TimeoutFuture<M = Message> = Pin<

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -7,6 +7,7 @@
 
 //! `DnsResponse` wraps a `Message` and any associated connection details
 
+use std::convert::TryFrom;
 use std::future::Future;
 use std::io;
 use std::ops::{Deref, DerefMut};
@@ -313,6 +314,13 @@ impl From<DnsResponse> for Message {
 impl From<Message> for DnsResponse {
     fn from(message: Message) -> Self {
         Self(message)
+    }
+}
+
+impl TryFrom<Vec<u8>> for DnsResponse {
+    type Error = ProtoError;
+    fn try_from(buffer: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(Self(Message::from_vec(&buffer)?))
     }
 }
 

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -324,6 +324,14 @@ impl TryFrom<Vec<u8>> for DnsResponse {
     }
 }
 
+impl TryFrom<Vec<u8>> for DnsResponse<Vec<u8>> {
+    type Error = ProtoError;
+    fn try_from(buffer: Vec<u8>) -> Result<Self, ProtoError> {
+        Message::from_vec(&buffer)?;
+        Ok(Self(buffer))
+    }
+}
+
 /// ```text
 /// [RFC 2308](https://tools.ietf.org/html/rfc2308#section-2) DNS NCACHE March 1998
 ///

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -215,10 +215,13 @@ impl OneshotDnsRequest {
     }
 }
 
-struct OneshotDnsResponse(oneshot::Sender<DnsResponseStream>);
+struct OneshotDnsResponse<M = Message>(oneshot::Sender<DnsResponseStream<M>>);
 
-impl OneshotDnsResponse {
-    fn send_response(self, serial_response: DnsResponseStream) -> Result<(), DnsResponseStream> {
+impl<M> OneshotDnsResponse<M> {
+    fn send_response(
+        self,
+        serial_response: DnsResponseStream<M>,
+    ) -> Result<(), DnsResponseStream<M>> {
         self.0.send(serial_response)
     }
 }

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -147,8 +147,11 @@ pub trait DnsRequestSender<M = Message>:
 
 /// Used for associating a name_server to a DnsRequestStreamHandle
 #[derive(Clone)]
-pub struct BufDnsRequestStreamHandle {
-    sender: mpsc::Sender<OneshotDnsRequest>,
+pub struct BufDnsRequestStreamHandle<M = Message>
+where
+    M: Clone,
+{
+    sender: mpsc::Sender<OneshotDnsRequest<M>>,
 }
 
 macro_rules! try_oneshot {
@@ -165,8 +168,8 @@ macro_rules! try_oneshot {
     };
 }
 
-impl DnsHandle for BufDnsRequestStreamHandle {
-    type Response = DnsResponseReceiver;
+impl<M: Clone + Send + 'static> DnsHandle<M> for BufDnsRequestStreamHandle<M> {
+    type Response = DnsResponseReceiver<M>;
     type Error = ProtoError;
 
     fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -227,17 +227,17 @@ impl<M> OneshotDnsResponse<M> {
 }
 
 /// A Stream that wraps a oneshot::Receiver<Stream> and resolves to items in the inner Stream
-pub enum DnsResponseReceiver {
+pub enum DnsResponseReceiver<M = Message> {
     /// The receiver
-    Receiver(oneshot::Receiver<DnsResponseStream>),
+    Receiver(oneshot::Receiver<DnsResponseStream<M>>),
     /// The stream once received
-    Received(DnsResponseStream),
+    Received(DnsResponseStream<M>),
     /// Error during the send operation
     Err(Option<ProtoError>),
 }
 
-impl Stream for DnsResponseReceiver {
-    type Item = Result<DnsResponse, ProtoError>;
+impl<M> Stream for DnsResponseReceiver<M> {
+    type Item = Result<DnsResponse<M>, ProtoError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -17,6 +17,7 @@ use futures_util::stream::{Fuse, Peekable, Stream, StreamExt};
 use tracing::{debug, warn};
 
 use crate::error::*;
+use crate::op::Message;
 use crate::Time;
 
 mod dns_exchange;
@@ -125,13 +126,15 @@ impl DnsStreamHandle for BufDnsStreamHandle {
 /// The underlying Stream implementation should yield `Some(())` whenever it is ready to send a message,
 ///   NotReady, if it is not ready to send a message, and `Err` or `None` in the case that the stream is
 ///   done, and should be shutdown.
-pub trait DnsRequestSender: Stream<Item = Result<(), ProtoError>> + Send + Unpin + 'static {
+pub trait DnsRequestSender<M = Message>:
+    Stream<Item = Result<(), ProtoError>> + Send + Unpin + 'static
+{
     /// Send a message, and return a stream of response
     ///
     /// # Return
     ///
     /// A stream which will resolve to SerialMessage responses
-    fn send_message(&mut self, message: DnsRequest) -> DnsResponseStream;
+    fn send_message(&mut self, message: DnsRequest) -> DnsResponseStream<M>;
 
     /// Allows the upstream user to inform the underling stream that it should shutdown.
     ///

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -189,13 +189,13 @@ impl DnsHandle for BufDnsRequestStreamHandle {
 
 // TODO: this future should return the origin message in the response on errors
 /// A OneshotDnsRequest creates a channel for a response to message
-pub struct OneshotDnsRequest {
+pub struct OneshotDnsRequest<M = Message> {
     dns_request: DnsRequest,
-    sender_for_response: oneshot::Sender<DnsResponseStream>,
+    sender_for_response: oneshot::Sender<DnsResponseStream<M>>,
 }
 
-impl OneshotDnsRequest {
-    fn oneshot(dns_request: DnsRequest) -> (Self, oneshot::Receiver<DnsResponseStream>) {
+impl<M> OneshotDnsRequest<M> {
+    fn oneshot(dns_request: DnsRequest) -> (Self, oneshot::Receiver<DnsResponseStream<M>>) {
         let (sender_for_response, receiver) = oneshot::channel();
 
         (
@@ -207,7 +207,7 @@ impl OneshotDnsRequest {
         )
     }
 
-    fn into_parts(self) -> (DnsRequest, OneshotDnsResponse) {
+    fn into_parts(self) -> (DnsRequest, OneshotDnsResponse<M>) {
         (
             self.dns_request,
             OneshotDnsResponse(self.sender_for_response),

--- a/crates/proto/src/xfer/serial_message.rs
+++ b/crates/proto/src/xfer/serial_message.rs
@@ -9,6 +9,7 @@ use std::net::SocketAddr;
 
 use crate::error::ProtoResult;
 use crate::op::Message;
+use std::convert::TryInto;
 
 /// A DNS message in serialized form, with either the target address or source address
 pub struct SerialMessage {
@@ -26,6 +27,13 @@ impl SerialMessage {
     /// Get a reference to the bytes
     pub fn bytes(&self) -> &[u8] {
         &self.message
+    }
+
+    /// see `Header::id()`
+    pub fn id(&self) -> Option<u16> {
+        self.message
+            .get(0..2)
+            .map(|bytes| u16::from_be_bytes(bytes.try_into().unwrap()))
     }
 
     /// Get the source or destination address (context dependent)

--- a/crates/proto/src/xfer/serial_message.rs
+++ b/crates/proto/src/xfer/serial_message.rs
@@ -12,6 +12,7 @@ use crate::op::Message;
 use std::convert::TryInto;
 
 /// A DNS message in serialized form, with either the target address or source address
+#[derive(Clone)]
 pub struct SerialMessage {
     // TODO: change to Bytes? this would be more compatible with some underlying libraries
     message: Vec<u8>,

--- a/crates/server/tests/authority_battery/dynamic_update.rs
+++ b/crates/server/tests/authority_battery/dynamic_update.rs
@@ -29,7 +29,9 @@ fn update_authority<A: Authority<Lookup = AuthLookup>>(
     key: &SigSigner,
     authority: &mut A,
 ) -> UpdateResult<bool> {
-    message.finalize(key, 1).expect("failed to sign message");
+    message
+        .finalize::<SigSigner, Message>(key, 1)
+        .expect("failed to sign message");
     let message = message.to_bytes().unwrap();
     let request = MessageRequest::from_bytes(&message).unwrap();
 

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -82,7 +82,7 @@ fn test_query_udp_ipv6() {
         .next()
         .unwrap();
     let stream = UdpClientStream::<TokioUdpSocket>::new(addr);
-    let client = AsyncClient::connect(stream);
+    let client = AsyncClient::<Message>::connect(stream);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
 
@@ -266,7 +266,7 @@ fn test_notify() {
     catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
 
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
-    let client = AsyncClient::new(stream, sender, None);
+    let client = AsyncClient::<Message>::new(stream, sender, None);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     trust_dns_proto::spawn_bg(&io_loop, bg);
 
@@ -1009,7 +1009,7 @@ fn test_timeout_query_tcp() {
         addr,
         std::time::Duration::from_millis(1),
     );
-    let client = AsyncClient::with_timeout(
+    let client = AsyncClient::<Message>::with_timeout(
         Box::new(stream),
         sender,
         std::time::Duration::from_millis(1),


### PR DESCRIPTION
Here's a PoC for allowing AsyncClient to return responses as either Message or Vec<u8>.

The idea is to make DnsResponse and AsyncClient and everything in between generic over the response message representation so that AsyncClient can return either Messages or Vec<u8>. This PR is mostly just a big stack of commits adding a type parameter to one thing after another building up from DnsResponse to AsyncClient and adding little tweaks here and there to make things work. To start things off I made it so the response message id is extracted directly from the buffer (SerialMessage) instead of from the parsed Message - it's easy enough and we always have the buffer available in send_serial_message().

To avoid breaking lots of code I added Message as the default argument for the parameter. I don't know why this works in other places but doesn't work for AsyncClient.

I added a unit test as a quick and dirty example of usage. It probably has lots of room for improvement and it ought to be complemented with proper documentation.

When constructing an AsyncClient you have to choose between Message and Vec<u8>. Another option would be to let the caller decide for each call. This feel to me a bit like an artificial restriction, but I'm not sure what the use case would like for mixing calls for Messages and Vecs to the same AsyncClient.

I'm using `impl TryFrom<Vec<u8>> for DnsResponse<M>` parsing but we need to keep the Vec<u8> around so I clone it. I've focused on getting things to work first, deferring efficiency aspects at least for now.

I consistently added the type parameter to all the types themselves. In some cases it would probably better to add them to individual associated functions. For some traits maybe it's better to have them as associated types. Now that I have working code it's probably a good idea to revisit this aspect of the design.

Another thing I thought of but haven't looked into is making some deeper functions return Vec<u8> instead of DnsResponse<M>. The potential benefit of this would be simplifying some of the type signatures. But maybe it's a terrible idea for other reasons.

I've only made things work for the AsyncClient. I haven't looked into the others.

**Edit:** Originally I implemented DnsResponse<SerialMessage> but I changed it to DnsResponse<Vec<u8>>. I also updated some of my reasoning in a few places.

Fixes #1814.