### PR TITLE
Fix stuck of dns over tls  with clear text SNI

### DIFF
--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -43,6 +43,9 @@ lazy_static! {
             .unwrap()
             .with_root_certificates(root_store)
             .with_no_client_auth();
+        
+        // the port (853) of dot is for dns dedicated, sni is unnecessary. (ISP block by the SNI name)
+        client_config.enable_sni = false;
 
         client_config.alpn_protocols.push(ALPN_H2.to_vec());
 

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -43,8 +43,8 @@ lazy_static! {
             .unwrap()
             .with_root_certificates(root_store)
             .with_no_client_auth();
-        
-        // the port (853) of dot is for dns dedicated, sni is unnecessary. (ISP block by the SNI name)
+
+        // The port (853) of DOT is for dns dedicated, SNI is unnecessary. (ISP block by the SNI name)
         client_config.enable_sni = false;
 
         client_config.alpn_protocols.push(ALPN_H2.to_vec());


### PR DESCRIPTION
Fix issue: https://github.com/bluejekyll/trust-dns/issues/1819

The port (853) of DOT is for dns dedicated, SNI is unnecessary. (ISP block by the SNI name)

---

<img width="788" alt="图片" src="https://user-images.githubusercontent.com/16131917/200714568-b7fd1c97-dba8-41ff-b8ff-2cda92a4c49f.png">

