### PR TITLE
Openssl v3 compability issues with pkcs8 key

### DIFF
--- a/crates/proto/src/rustls/tls_server.rs
+++ b/crates/proto/src/rustls/tls_server.rs
@@ -34,6 +34,12 @@ pub fn read_cert(cert_path: &Path) -> ProtoResult<Vec<Certificate>> {
 }
 
 /// Reads a private key from a pkcs8 formatted, and possibly encoded file
+///
+/// ## Accepted formats
+///
+/// - A Sec1-encoded plaintext private key; as specified in RFC5915
+/// - A DER-encoded plaintext RSA private key; as specified in PKCS#1/RFC3447
+/// - DER-encoded plaintext private key; as specified in PKCS#8/RFC5958
 pub fn read_key(path: &Path) -> ProtoResult<PrivateKey> {
     let mut file = BufReader::new(File::open(path)?);
 

--- a/crates/proto/src/rustls/tls_server.rs
+++ b/crates/proto/src/rustls/tls_server.rs
@@ -57,18 +57,31 @@ pub fn read_key_from_der(path: &Path) -> ProtoResult<PrivateKey> {
     Ok(PrivateKey(buf))
 }
 
-/// Reads a private key from a pem formatted file
+/// Try to read a private key from a PEM formatted file.
+///
+/// ## Accepted formats
+///
+/// - DER-encoded plaintext RSA private key; as specified in PKCS#1/RFC3447
+/// - DER-encoded plaintext RSA private key; as specified in PKCS#8/RFC5958 default with openssl v3
+///
+/// ## Errors
+///
+/// Returns a [ProtoError] in either cases:
+///
+/// - Unable to open key at given `path`
+/// - Encountered an IO error
+/// - Unable to read key: either no key or no key found in the right format
 pub fn read_key_from_pem(path: &Path) -> ProtoResult<PrivateKey> {
     let file = File::open(path)?;
     let mut file = BufReader::new(file);
 
-    let mut keys = rustls_pemfile::rsa_private_keys(&mut file)
-        .map_err(|_| format!("Error reading RSA key from: {}", path.display()))?;
-    let key = keys
-        .pop()
-        .ok_or_else(|| format!("No RSA keys in file: {}", path.display()))?;
-
-    Ok(PrivateKey(key))
+    loop {
+        match rustls_pemfile::read_one(&mut file)? {
+            None => return Err(format!("No RSA keys in file: {}", path.display()).into()),
+            Some(Item::RSAKey(key)) | Some(Item::PKCS8Key(key)) => return Ok(PrivateKey(key)),
+            Some(_) => continue,
+        }
+    }
 }
 
 /// Construct the new Acceptor with the associated pkcs12 data


### PR DESCRIPTION
Review note: I am really outside of my comfort zone on this one, I am not by any mean an openSSL expert, it's just what I found by poking around error in CI and new OpenSSL v3 on my computer.

Hello I investigated failure In CI and tried to regenerate test certificate with openSSL v3 `OpenSSL 3.0.7 1 Nov 2022 (Library: OpenSSL 3.0.7 1 Nov 2022` on my Linux.

So I did this changes to `script/gen_certs.sh` since just don't worked with openssl v3.

What it does?

- removed `-verify` because It generated no sense error of unknown algorithm (not sure if it was wise)
- use `genpkey` since `genrsa` is marked deprecated

```diff
 echo "----> Generating CA <----"
-${OPENSSL:?} genrsa -out ca.key 4096
-${OPENSSL:?} req -x509 -new -nodes -key ca.key -days 365 -out ca.pem -verify -config /tmp/ca.conf
+${OPENSSL:?} genpkey -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out ca.key
+${OPENSSL:?} req -x509 -new -nodes -key ca.key -days 365 -out ca.pem -config /tmp/ca.conf
```
And later:
```diff
 echo "----> Generating CERT  <----"
-${OPENSSL:?} genrsa -out cert-key.pem 4096
+${OPENSSL:?} genpkey -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out cert-key.pem
```

And get this error:

```
cargo make all-features
[...]
failures:

---- quic::tests::test_quic_stream stdout ----
using server src path: /home/darnuria/programmation/trust-dns
thread 'quic::tests::test_quic_stream' panicked at 'called `Result::unwrap()` on an `Err` value: ProtoError { kind: Msg("No RSA keys in file: /home/darnuria/programmation/trust-dns/tests/test-data/cert-key.pem"), backtrack: None }', crates/proto/src/quic/tests.rs:68:6
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    quic::tests::test_quic_stream
```

After investigation I found that openssl V3 `genrsa` and `genpkey` issue now pkcs8 pem RSA pem key there is an option to revert that from `openssl-genrsa` man:
```
       openssl-genrsa - generate an RSA private key
[...]

       This command has been deprecated.  The openssl-genpkey(1) command should be used instead.

       This command generates an RSA private key.
[...]
       -traditional
           Write the key using the traditional PKCS#1 format instead of the PKCS#8 format.
```

So I went down to the function causing problems with the CI after regenerating certificates rustls side.

First I wondered that it was problem `rustls_pemfile` side so I opened first a PR there: https://github.com/rustls/pemfile/pull/10 but, afterthought I closed it in favor of this PR.

## CI ISSUEs still not solved:

For Openssl side I suppose the problem is that the cert/key created with an older Openssl and read with a newer cause some issue I have to dig on this point, just regenerating cert/key/ is not satisfying.

And rustls side it's something to be 'future' proof by accepting pkcs8 key (what this PR try to do)