### PR TITLE
FIX WIP: Zone Parser panics when hostname entry has a leading whitespace. 

### DIFF
--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -472,14 +472,19 @@ mod tests {
         let domain = Name::from_str("parameter.origin.org.").unwrap();
 
         let zone_data = r#"$ORIGIN parsed.zone.origin.org.
- a-only 60 IN A 1.2.3.4
+ faulty-record-type 60 IN A 1.2.3.4
 "#;
 
         let lexer = Lexer::new(zone_data);
         let result = Parser::new().parse(lexer, Some(domain), None);
         assert!(
-            result.is_err(),
-            "whitespace not allowed in beginning of hostname line: {:#?}",
+            result.is_err()
+                & result
+                    .as_ref()
+                    .unwrap_err()
+                    .to_string()
+                    .contains("FAULTY-RECORD-TYPE"),
+            "unexpected success: {:#?}",
             result
         );
     }

--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -462,3 +462,25 @@ enum State {
     Include, // $INCLUDE <filename>
     Origin,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zone_parse() {
+        let domain = Name::from_str("parameter.origin.org.").unwrap();
+
+        let zone_data = r#"$ORIGIN parsed.zone.origin.org.
+ a-only 60 IN A 1.2.3.4
+"#;
+
+        let lexer = Lexer::new(zone_data);
+        let result = Parser::new().parse(lexer, Some(domain), None);
+        assert!(
+            result.is_err(),
+            "whitespace not allowed in beginning of hostname line: {:#?}",
+            result
+        );
+    }
+}

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -53,7 +53,7 @@ impl FromStr for DNSClass {
     /// assert_eq!(DNSClass::IN, var);
     /// ```
     fn from_str(str: &str) -> ProtoResult<Self> {
-        debug_assert!(str.chars().all(|x| char::is_ascii_uppercase(&x)));
+        debug_assert!(str.chars().all(|x| !char::is_ascii_lowercase(&x)));
         match str {
             "IN" => Ok(Self::IN),
             "CH" => Ok(Self::CH),
@@ -170,24 +170,34 @@ impl Display for DNSClass {
     }
 }
 
-#[test]
-fn test_order() {
-    let ordered = vec![
-        DNSClass::IN,
-        DNSClass::CH,
-        DNSClass::HS,
-        DNSClass::NONE,
-        DNSClass::ANY,
-    ];
-    let mut unordered = vec![
-        DNSClass::NONE,
-        DNSClass::HS,
-        DNSClass::CH,
-        DNSClass::IN,
-        DNSClass::ANY,
-    ];
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_order() {
+        let ordered = vec![
+            DNSClass::IN,
+            DNSClass::CH,
+            DNSClass::HS,
+            DNSClass::NONE,
+            DNSClass::ANY,
+        ];
+        let mut unordered = vec![
+            DNSClass::NONE,
+            DNSClass::HS,
+            DNSClass::CH,
+            DNSClass::IN,
+            DNSClass::ANY,
+        ];
 
-    unordered.sort();
+        unordered.sort();
 
-    assert_eq!(unordered, ordered);
+        assert_eq!(unordered, ordered);
+    }
+
+    #[test]
+    fn check_dns_class_parse_wont_panic_with_symbols() {
+        let dns_class = "a-b-c".to_ascii_uppercase().parse::<DNSClass>();
+        assert!(matches!(&dns_class, Err(ProtoError { .. })));
+    }
 }

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -199,7 +199,7 @@ impl FromStr for RecordType {
     /// ```
     fn from_str(str: &str) -> ProtoResult<Self> {
         // TODO missing stuff?
-        debug_assert!(str.chars().all(|x| char::is_digit(x, 36)));
+        debug_assert!(str.chars().all(|x| !char::is_ascii_lowercase(&x)));
         match str {
             "A" => Ok(Self::A),
             "AAAA" => Ok(Self::AAAA),
@@ -543,5 +543,11 @@ mod tests {
             assert_eq!(rtype.to_string().to_ascii_uppercase().as_str(), *name);
             assert!(rtypes.insert(rtype));
         }
+    }
+
+    #[test]
+    fn check_record_type_parse_wont_panic_with_symbols() {
+        let dns_class = "a-b-c".to_ascii_uppercase().parse::<RecordType>();
+        assert!(matches!(&dns_class, Err(ProtoError { .. })));
     }
 }


### PR DESCRIPTION
# Context:
https://github.com/bluejekyll/trust-dns/issues/1843
Zone parses panic when parsing a zone that contains a hostname with a leading whitespace, instead of resulting in an Err, when running in `#cfg(debug)`.

## Expected behavior
When parsing an invalid zone, we expected an Err, but instead trust-dns panics:

> The faulty zone
```
$ORIGIN parsed.zone.origin.org.
 faulty-record-type 60 IN A 1.2.3.4
```

> The error
```
---- serialize::txt::zone::tests::test_zone_parse stdout ----
thread 'serialize::txt::zone::tests::test_zone_parse' panicked at 'assertion failed: str.chars().all(|x| char::is_ascii_uppercase(&x))', crates/proto/src/rr/dns_class.rs:56:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# Root cause:

The root cause of the error was a `debug_assert` call that assumed that after an `to_ascii_uppercase`, all characters turn into ascii uppercase letters.
The `debug_assert` failed because of characters that are not letters, such as the `-`.

When a line in the zone file starts with a whitespace, it does not represent a new hostname. It represents a record belonging to the previous line.

Therefore, the parser was not trying to parse the `faulty-record-type` as a hostname name.

The parser *correctly* tried to parse the faulty hostname as a `DNSClass` and then as a `RecordType`.

However, since the `faulty-record-type` contained an `-`, it panicked.

# This PR:

- [x] adds a test to show a zone  that when parsed, panics.
- [x] relaxes the debug assert causing the panic.

