### PR TITLE
Fix all Tokio usage to version to 1.21.

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -84,14 +84,14 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0.20"
 time = "0.3"
 tracing = "0.1.30"
-tokio = { version = "1.0", features = ["rt"] }
+tokio = { version = "1.21", features = ["rt"] }
 trust-dns-proto = { version = "0.22.0", path = "../proto"}
 webpki = { version = "0.22.0", optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.5", default-features = false, features = ["std", "executor"] }
 openssl = { version = "0.10", features = ["v102", "v110"], optional = false }
-tokio = { version = "1.0", features = ["rt", "macros"] }
+tokio = { version = "1.21", features = ["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "env-filter"] }
 
 [package.metadata.docs.rs]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -99,7 +99,7 @@ socket2 = { version = "0.4.0", optional = true }
 thiserror = "1.0.20"
 tinyvec = { version = "1.1.1", features = ["alloc"] }
 tracing = "0.1.30"
-tokio = { version = "1.0", features = ["io-util"], optional = true }
+tokio = { version = "1.21", features = ["io-util"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-openssl = { version = "0.6.0", optional = true }
 tokio-rustls = { version = "0.23.0", optional = true, features = ["early-data"] }
@@ -111,7 +111,7 @@ webpki-roots = { version = "0.22.1", optional = true }
 [dev-dependencies]
 futures-executor = { version = "0.3.5", default-features = false, features = ["std"] }
 openssl = { version = "0.10", features = ["v102", "v110"] }
-tokio = { version = "1.0", features = ["rt", "time", "macros"] }
+tokio = { version = "1.21", features = ["rt", "time", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "env-filter"] }
 
 [package.metadata.docs.rs]

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -86,13 +86,13 @@ serde = { version = "1.0.114", features = ["derive"], optional = true }
 thiserror = "1.0.20"
 time = "0.3"
 tracing = "0.1.30"
-tokio = { version = "1.0", features = ["net"] }
+tokio = { version = "1.21", features = ["net"] }
 toml = "0.5"
 trust-dns-proto = { version = "0.22.0", path = "../proto" }
 trust-dns-resolver = { version = "0.22.0", path = "../resolver" }
 
 [dev-dependencies]
-tokio = { version="1.0", features = ["macros", "rt"] }
+tokio = { version = "1.21", features = ["macros", "rt"] }
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "env-filter"] }
 
 [package.metadata.docs.rs]

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -95,7 +95,7 @@ ipconfig = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 futures-executor = { version = "0.3.5", default-features = false, features = ["std"] }
-tokio = { version="1.0", features = ["macros", "test-util"] }
+tokio = { version = "1.21", features = ["macros", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "env-filter"] }
 
 [package.metadata.docs.rs]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -103,7 +103,7 @@ trust-dns-recursor = { version = "0.22.0", path = "../recursor", features = ["se
 trust-dns-resolver = { version = "0.22.0", path = "../resolver", features = ["serde-config"], optional = true }
 
 [dev-dependencies]
-tokio = { version="1.21", features = ["macros", "rt"] }
+tokio = { version = "1.21", features = ["macros", "rt"] }
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "env-filter"] }
 
 [package.metadata.docs.rs]

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -79,7 +79,7 @@ rand = "0.8"
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 rustls = "0.20"
 time = "0.3"
-tokio = { version = "1.0", features = ["time", "rt"] }
+tokio = { version = "1.21", features = ["time", "rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "env-filter"] }
 trust-dns-client= { version = "0.22.0", path = "../../crates/client" }
@@ -91,4 +91,4 @@ webpki-roots = { version = "0.22", optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.5", features = ["thread-pool"] }
-tokio = { version="1.0", features = ["macros", "rt"] }
+tokio = { version = "1.21", features = ["macros", "rt"] }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -86,6 +86,6 @@ trust-dns-client = { version = "0.22.0", path = "../crates/client" }
 trust-dns-proto = { version = "0.22.0", path = "../crates/proto" }
 trust-dns-recursor = { version = "0.22.0", path = "../crates/recursor" }
 trust-dns-resolver = { version = "0.22.0", path = "../crates/resolver" }
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.21", features = ["rt-multi-thread", "macros", "time"] }
 webpki = { version = "0.22.0", optional = true }
 webpki-roots = { version = "0.22.1", optional = true }


### PR DESCRIPTION
I was wondering why trust-dns build where so big so I went doing some dependencies version inspection. Don't know what will be the impact but it's still interesting.

Did a really simple `rg -A 10 dependencies **/cargo.toml ` to have a first quick summary.

(will add cargo lock after my `cargo make all-feature` ends)