### PR TITLE
Make homepage link simpler for end users

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -19,7 +19,7 @@ Trust-DNS is a safe and secure DNS server with DNSEC support.
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/trust-dns-server"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -13,7 +13,7 @@ Trust-DNS is a safe and secure DNS library, for async-std. This Resolver library
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/async-std-resolver"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -18,7 +18,7 @@ Trust-DNS is a safe and secure DNS library. This is the Client library with DNSe
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/trust-dns"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -13,7 +13,7 @@ Trust-DNS is a safe and secure DNS library. This is the foundational DNS protoco
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/trust-dns-proto"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -18,7 +18,7 @@ Trust-DNS Recursor is a safe and secure DNS recursive resolver with DNSSec suppo
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/trust-dns-recursor"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -13,7 +13,7 @@ Trust-DNS is a safe and secure DNS library. This Resolver library  uses the Clie
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/trust-dns-resolver"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,7 +19,7 @@ Trust-DNS is a safe and secure DNS server with DNSSec support.
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/trust-dns-server"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/tests/compatibility-tests/Cargo.toml
+++ b/tests/compatibility-tests/Cargo.toml
@@ -13,7 +13,7 @@ Trust-DNS compatability testing library.
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/trust-dns"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -13,7 +13,7 @@ Trust-DNS integration testing library.
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/trust-dns"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -13,7 +13,7 @@ Utilities that complement Trust-DNS.
 
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/crate/trust-dns-util"
-homepage = "https://www.trust-dns.org/index.html"
+homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 
 # This points to a file in the repository (relative to this Cargo.toml). The


### PR DESCRIPTION
I advise to remove the deprecated www. subdomain from the homepage link.

I [quote a Google staffer](https://bugs.chromium.org/p/chromium/issues/detail?id=881410#c1):

> "www" is now considered a "trivial" subdomain.

The web server Nginx used by trust-dns.org is correctly configured to redirect to https://trust-dns.org/.

```
curl http://trust-dns.org 
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>

curl https://www.trust-dns.org/
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

While the Nginx configuration of the website should still support it, the deprecated convention should no longer be advertised in the files.

Secondly, index.html should also be removed from the commits [as advised here](https://webmasters.stackexchange.com/a/122313).

---

#### Nginx web server / website issue separate from this PR:
[As seen here](https://webmasters.stackexchange.com/a/140434), what needs to be also done for the trust-dns.org conf. of the Nginx web server should be something like that:

```
location / {
        #remove index.html from request
        rewrite ^/(.*)/index(\.html)?$ /$1 permanent;    
        rewrite ^/(.*)index(\.html)?$ /$1 permanent;        

        #remove .html from request
        rewrite ^/(.*)\.html$ /$1 permanent;
        
        try_files $uri ${uri}/index.html ${uri}.html =404;
    }
```