### PR TITLE
fix DNSSEC typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,7 +510,7 @@ bound for implementing the `Connect` trait.
 
 - Trust-DNS Proto crate to separate server management from base operations #222
 - Trust-DNS Util crate for dnssec management tools (@briansmith)
-- Integration tests for Server to validate all supported DNSSec key types
+- Integration tests for Server to validate all supported DNSSEC key types
 - *breaking* Common features `dnssec-ring`, `dnssec-openssl`, and `dnssec` across all crates (replaces `openssl` and `ring` features)
 - Clarified `tls` feature with `tls-openssl`, and `tls` in server (in preparation for `tls-rustls`)
 - Support for rfc6844, CAA record type #234
@@ -556,13 +556,13 @@ bound for implementing the `Connect` trait.
 
 ### Added
 
-- RSA and ECDSA validation with *ring* for DNSSec, removes dependency on openssl (@briansmith)
+- RSA and ECDSA validation with *ring* for DNSSEC, removes dependency on openssl (@briansmith)
 - `lookup` to `ClientHandle`, simpler form with `Query`
 - `query` to `Query` for ease of Query creation
 
 ### Changed
 
-- Large celanup of signing and verification paths in DNSSec (@briansmith)
+- Large celanup of signing and verification paths in DNSSEC (@briansmith)
 - *breaking* changed `TrustAnchor::insert_trust_anchor` to more safely consume `PublicKey` rather than `Vec<u8>`
 
 ## 0.11.2 (Client/Server)
@@ -898,7 +898,7 @@ and there is no easy way to migrate the original Server to use ServerFuture.
 
 ### Added
 
-- SecureClientHandle, for future based DNSSec validation.
+- SecureClientHandle, for future based DNSSEC validation.
 - ClientFuture, futures based client implementation, #32
 
 ### Fixed
@@ -939,7 +939,7 @@ and there is no easy way to migrate the original Server to use ServerFuture.
 - Resolver no longer depends on Client
 - *breaking* Resolver no longer returns io:Errors, use `From<ResolveError>` for `io::Error`
 - Resolver is now `Send`
-- DNSSec now disabled by default in Resolver, see `dnssec-ring` or `dnssec-openssl` features #268
+- DNSSEC now disabled by default in Resolver, see `dnssec-ring` or `dnssec-openssl` features #268
 - CNAME chaining was cleaned up #271 (@briansmith)
 - On hostname parsing to IpAddr, return without lookup #302 (@cssivision)
 - Change default `LookupIpStrategy` from `Ipv4AndIpv6` to `Ipv4thenIpv6` #301 (@cssivision)
@@ -1078,9 +1078,9 @@ and there is no easy way to migrate the original Server to use ServerFuture.
 - Updated rust-openssl to 0.7.8 which include new RSA creation bindings
 - NSEC resolver validation
 - NSEC3 parsing support
-- DNSSec validation of RRSIG and DNSKEY records back to root cert
+- DNSSEC validation of RRSIG and DNSKEY records back to root cert
 - Integration with OpenSSL (depends on fork until rust-openssl 0.7.6+ is cut)
-- Binary serialization and deserialization of all DNSSec RFC4034 record types
+- Binary serialization and deserialization of all DNSSEC RFC4034 record types
 - EDNS support
 - Coveralls support added
 - Partial implementation of SIG0 support for dynamic update
@@ -1109,7 +1109,7 @@ and there is no easy way to migrate the original Server to use ServerFuture.
 
 ### Added
 
-- Support for DNSSec validation
+- Support for DNSSEC validation
 - LRU Cache
 
 ## 0.4.0 (Client/Server 2015-10-17)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ as high level interfaces, which is a bit more rare.
 
 | Feature                                                                                                         | Description                                           |
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| [SyncDnssecClient](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/struct.SyncDnssecClient.html)              | DNSSec validation                                     |
+| [SyncDnssecClient](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/struct.SyncDnssecClient.html)              | DNSSEC validation                                     |
 | [create](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/trait.Client.html#method.create)                     | atomic create of a record, with authenticated request |
 | [append](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/trait.Client.html#method.append)                     | verify existence of a record and append to it         |
 | [compare_and_swap](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/trait.Client.html#method.compare_and_swap) | atomic (depends on server) compare and swap           |
@@ -97,7 +97,7 @@ To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` s
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
 
-## DNSSec status
+## DNSSEC status
 
 Currently the root key is hardcoded into the system. This gives validation of
 DNSKEY and DS records back to the root. NSEC is implemented, but not NSEC3.
@@ -297,10 +297,10 @@ Success for query name: www.example.com. type: A class: IN
 The Client has a few features which can be disabled for different reasons when embedding in other software.
 
 - `dnssec-openssl`
-  It is a default feature, so default-features will need to be set to false (this will disable all other default features in trust-dns). Until there are other crypto libraries supported, this will also disable DNSSec validation. The functions will still exist, but will always return errors on validation. The below example line will disable all default features and enable OpenSSL, remove `"openssl"` to remove the dependency on OpenSSL.
+  It is a default feature, so default-features will need to be set to false (this will disable all other default features in trust-dns). Until there are other crypto libraries supported, this will also disable DNSSEC validation. The functions will still exist, but will always return errors on validation. The below example line will disable all default features and enable OpenSSL, remove `"openssl"` to remove the dependency on OpenSSL.
 
 - `dnssec-ring`
-  Ring support can be used for RSA and ED25519 DNSSec validation.
+  Ring support can be used for RSA and ED25519 DNSSEC validation.
 
 - `dns-over-native-tls`
   Uses `native-tls` for DNS-over-TLS implementation, only supported in client and resolver, not server.

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)
 description = """
-Trust-DNS is a safe and secure DNS server with DNSEC support.
+Trust-DNS is a safe and secure DNS server with DNSSEC support.
  Eventually this could be a replacement for BIND9. The DNSSEC support allows
  for live signing of all records, in it does not currently support
  records signed offline. The server supports dynamic DNS with SIG0 authenticated

--- a/bin/README.md
+++ b/bin/README.md
@@ -2,7 +2,7 @@
 
 Trust-DNS provides a binary for hosting or forwarding DNS zones.
 
-This a named implementation for DNS zone hosting. It is capable of performing signing all records in the zone for server DNSSec RRSIG records associated with all records in a zone. There is also a `named` binary that can be generated from the library with `cargo install trust-dns`. Dynamic updates are supported via `SIG0` (an mTLS authentication method is under development).
+This a named implementation for DNS zone hosting. It is capable of performing signing all records in the zone for server DNSSEC RRSIG records associated with all records in a zone. There is also a `named` binary that can be generated from the library with `cargo install trust-dns`. Dynamic updates are supported via `SIG0` (an mTLS authentication method is under development).
 
 ## Features
 
@@ -24,7 +24,7 @@ To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` s
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
 
-## DNSSec status
+## DNSSEC status
 
 Currently the root key is hardcoded into the system. This gives validation of
  DNSKEY and DS records back to the root. NSEC is implemented, but not NSEC3.

--- a/bin/tests/named_test_rsa_dnssec.rs
+++ b/bin/tests/named_test_rsa_dnssec.rs
@@ -203,7 +203,7 @@ fn test_dnssec_restart_with_update_journal() {
     let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
     let server_path = Path::new(&server_path);
     let journal =
-        server_path.join("tests/test-data/named_test_configs/example.com_dnsec_update.jrnl");
+        server_path.join("tests/test-data/named_test_configs/example.com_dnssec_update.jrnl");
     std::fs::remove_file(&journal).ok();
 
     generic_test(

--- a/crates/async-std-resolver/README.md
+++ b/crates/async-std-resolver/README.md
@@ -11,7 +11,7 @@ This library contains implementations for IPv4 (A) and IPv6 (AAAA) resolution, m
 - NameServer pools with performance based priority usage
 - Caching of query results
 - NxDomain/NoData caching (negative caching)
-- TBD (in tokio impl): DNSSec validation
+- TBD (in tokio impl): DNSSEC validation
 - Generic Record Type Lookup
 - CNAME chain resolution
 - _experimental_ mDNS support (enable with `mdns` feature)

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.60.0"
 # uploaded to crates.io (aka this is not markdown)
 description = """
 Trust-DNS is a safe and secure DNS library. This is the Client library with DNSSEC support.
- DNSSec with NSEC validation for negative records, is complete. The client supports
+ DNSSEC with NSEC validation for negative records, is complete. The client supports
  dynamic DNS with SIG0 authenticated requests, implementing easy to use high level
  funtions. Trust-DNS is based on the Tokio and Futures libraries, which means
  it should be easily integrated into other software that also use those

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)
 description = """
-Trust-DNS is a safe and secure DNS library. This is the Client library with DNSec support.
+Trust-DNS is a safe and secure DNS library. This is the Client library with DNSSEC support.
  DNSSec with NSEC validation for negative records, is complete. The client supports
  dynamic DNS with SIG0 authenticated requests, implementing easy to use high level
  funtions. Trust-DNS is based on the Tokio and Futures libraries, which means

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -6,9 +6,9 @@ This library contains basic implementations for DNS record serialization, and co
 
 ## Features
 
-The `client` is capable of DNSSec validation as well as offering higher order functions for performing DNS operations:
+The `client` is capable of DNSSEC validation as well as offering higher order functions for performing DNS operations:
 
-- [SyncDnssecClient](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/struct.SyncDnssecClient.html) - DNSSec validation
+- [SyncDnssecClient](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/struct.SyncDnssecClient.html) - DNSSEC validation
 - [create](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/trait.Client.html#method.create) - atomic create of a record, with authenticated request
 - [append](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/trait.Client.html#method.append) - verify existence of a record and append to it
 - [compare_and_swap](https://docs.rs/trust-dns-client/latest/trust_dns_client/client/trait.Client.html#method.compare_and_swap) - atomic (depends on server) compare and swap
@@ -62,7 +62,7 @@ To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` s
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
 
-## DNSSec status
+## DNSSEC status
 
 Currently the root key is hardcoded into the system. This gives validation of
 DNSKEY and DS records back to the root. NSEC is implemented, but not NSEC3.

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -62,7 +62,7 @@ pub(crate) type NewFutureObj<H> = Pin<
 /// There was a strong attempt to make it backwards compatible, but making it a drop in replacement
 /// for the old Client was not possible. This trait has two implementations, the `SyncClient` which
 /// is a standard DNS Client, and the `SyncDnssecClient` which is a wrapper on `DnssecDnsHandle`
-/// providing DNSSec validation.
+/// providing DNSSEC validation.
 ///
 /// *note* When upgrading from previous usage, both `SyncClient` and `SyncDnssecClient` have an
 /// signer which can be optionally associated to the Client. This replaces the previous per-function
@@ -107,7 +107,7 @@ pub trait Client {
         runtime.block_on(ClientStreamingResponse(client.send(msg)).collect::<Vec<_>>())
     }
 
-    /// A *classic* DNS query, i.e. does not perform any DNSSec operations
+    /// A *classic* DNS query, i.e. does not perform any DNSSEC operations
     ///
     /// *Note* As of now, this will not recurse on PTR record responses, that is up to
     ///        the caller.
@@ -524,7 +524,7 @@ where
     }
 }
 
-/// A DNS client which will validate DNSSec records upon receipt
+/// A DNS client which will validate DNSSEC records upon receipt
 #[cfg(feature = "dnssec")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
 pub struct SyncDnssecClient<CC: ClientConnection> {

--- a/crates/client/src/client/memoize_client_handle.rs
+++ b/crates/client/src/client/memoize_client_handle.rs
@@ -25,7 +25,7 @@ use crate::op::Query;
 ///
 /// This wraps a ClientHandle, changing the implementation `send()` to store the response against
 ///  the Message.Query that was sent. This should reduce network traffic especially during things
-///  like DNSSec validation. *Warning* this will currently cache for the life of the Client.
+///  like DNSSEC validation. *Warning* this will currently cache for the life of the Client.
 #[derive(Clone)]
 #[must_use = "queries can only be sent through a ClientHandle"]
 pub struct MemoizeClientHandle<H: ClientHandle> {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -65,7 +65,7 @@
 //! trust-dns-client = "*"
 //! ```
 //!
-//! By default DNSSec validation is built in with OpenSSL, this can be disabled with:
+//! By default DNSSEC validation is built in with OpenSSL, this can be disabled with:
 //!
 //! ```toml
 //! [dependencies]
@@ -74,7 +74,7 @@
 //!
 //! ## Objects
 //!
-//! There are two variations of implementations of the Client. The `SyncClient`, a synchronous client, and the `AsyncClient`, a Tokio async client. `SyncClient` is an implementation of the `Client` trait, there is another implementation, `SyncDnssecClient`, which validates DNSSec records. For these basic examples we'll only look at the `SyncClient`
+//! There are two variations of implementations of the Client. The `SyncClient`, a synchronous client, and the `AsyncClient`, a Tokio async client. `SyncClient` is an implementation of the `Client` trait, there is another implementation, `SyncDnssecClient`, which validates DNSSEC records. For these basic examples we'll only look at the `SyncClient`
 //!
 //! First we must decide on the type of connection, there are three supported by Trust-DNS today, UDP, TCP and TLS. TLS requires OpenSSL by default, see also [trust-dns-native-tls](https://docs.rs/trust-dns-native-tls) and [trust-dns-rustls](https://docs.rs/trust-dns-rustls) for other TLS options.
 //!
@@ -92,7 +92,7 @@
 //! let client = SyncClient::new(conn);
 //! ```
 //!
-//! At this point the client is ready to be used. See also `client::SyncDnssecClient` for DNSSec validation. The rest of these examples will assume that the above boilerplate has already been performed.
+//! At this point the client is ready to be used. See also `client::SyncDnssecClient` for DNSSEC validation. The rest of these examples will assume that the above boilerplate has already been performed.
 //!
 //! ## Querying
 //!

--- a/crates/client/src/rr/dnssec/signer.rs
+++ b/crates/client/src/rr/dnssec/signer.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! signer is a structure for performing many of the signing processes of the DNSSec specification
+//! signer is a structure for performing many of the signing processes of the DNSSEC specification
 use tracing::debug;
 
 #[cfg(feature = "dnssec")]
@@ -24,7 +24,7 @@ use {
     crate::serialize::binary::BinEncoder,
 };
 
-/// Use for performing signing and validation of DNSSec based components. The SigSigner can be used for singing requests and responses with SIG0, or DNSSEC RRSIG records. The format is based on the SIG record type.
+/// Use for performing signing and validation of DNSSEC based components. The SigSigner can be used for singing requests and responses with SIG0, or DNSSEC RRSIG records. The format is based on the SIG record type.
 ///
 /// TODO: warning this struct and it's impl are under high volatility, expect breaking changes
 ///
@@ -300,7 +300,7 @@ impl SigSigner {
     }
 
     /// Version of Signer for signing RRSIGs and SIG0 records.
-    #[deprecated(note = "use SIG0 or DNSSec constructors")]
+    #[deprecated(note = "use SIG0 or DNSSEC constructors")]
     pub fn new(
         algorithm: Algorithm,
         key: KeyPair<Private>,
@@ -311,7 +311,7 @@ impl SigSigner {
     ) -> Self {
         let dnskey = key
             .to_dnskey(algorithm)
-            .expect("something went wrong, use one of the SIG0 or DNSSec constructors");
+            .expect("something went wrong, use one of the SIG0 or DNSSEC constructors");
 
         Self {
             key_rdata: dnskey.into(),

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -34,7 +34,7 @@ pub struct Edns {
     rcode_high: u8,
     // Indicates the implementation level of the setter. (from TTL)
     version: u8,
-    // Is DNSSec supported (from TTL)
+    // Is DNSSEC supported (from TTL)
     dnssec_ok: bool,
     // max payload size, minimum of 512, (from RR CLASS)
     max_payload: u16,
@@ -70,7 +70,7 @@ impl Edns {
         self.version
     }
 
-    /// Specifies that DNSSec is supported for this Client or Server
+    /// Specifies that DNSSEC is supported for this Client or Server
     pub fn dnssec_ok(&self) -> bool {
         self.dnssec_ok
     }
@@ -107,7 +107,7 @@ impl Edns {
         self
     }
 
-    /// Set to true if DNSSec is supported
+    /// Set to true if DNSSEC is supported
     pub fn set_dnssec_ok(&mut self, dnssec_ok: bool) -> &mut Self {
         self.dnssec_ok = dnssec_ok;
         self

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -262,13 +262,13 @@ impl Header {
         self
     }
 
-    /// Specifies that the data is authentic, i.e. the resolver believes all data to be valid through DNSSec
+    /// Specifies that the data is authentic, i.e. the resolver believes all data to be valid through DNSSEC
     pub fn set_authentic_data(&mut self, authentic_data: bool) -> &mut Self {
         self.authentic_data = authentic_data;
         self
     }
 
-    /// Used during recursive resolution to specified if a resolver should or should not validate DNSSec signatures
+    /// Used during recursive resolution to specified if a resolver should or should not validate DNSSEC signatures
     pub fn set_checking_disabled(&mut self, checking_disabled: bool) -> &mut Self {
         self.checking_disabled = checking_disabled;
         self

--- a/crates/proto/src/rr/dnssec/algorithm.rs
+++ b/crates/proto/src/rr/dnssec/algorithm.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::*;
 use crate::serialize::binary::*;
 
-/// DNSSec signing and validation algorithms.
+/// DNSSEC signing and validation algorithms.
 ///
 /// For [reference](http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml)
 ///  the iana documents have all the officially registered algorithms.

--- a/crates/proto/src/rr/dnssec/rdata/key.rs
+++ b/crates/proto/src/rr/dnssec/rdata/key.rs
@@ -578,8 +578,8 @@ pub enum Protocol {
     /// Reserved for use with email
     #[deprecated = "Deprecated by RFC3445"]
     Email,
-    /// Reserved for use with DNSSec (Trust-DNS only supports DNSKEY with DNSSec)
-    DNSSec,
+    /// Reserved for use with DNSSEC (Trust-DNS only supports DNSKEY with DNSSEC)
+    DNSSEC,
     /// Reserved to refer to the Oakley/IPSEC
     #[deprecated = "Deprecated by RFC3445"]
     IPSec,
@@ -593,7 +593,7 @@ pub enum Protocol {
 
 impl Default for Protocol {
     fn default() -> Self {
-        Self::DNSSec
+        Self::DNSSEC
     }
 }
 
@@ -603,7 +603,7 @@ impl From<u8> for Protocol {
             0 => Self::Reserved,
             1 => Self::TLS,
             2 => Self::Email,
-            3 => Self::DNSSec,
+            3 => Self::DNSSEC,
             4 => Self::IPSec,
             255 => Self::All,
             _ => Self::Other(field),
@@ -617,7 +617,7 @@ impl From<Protocol> for u8 {
             Protocol::Reserved => 0,
             Protocol::TLS => 1,
             Protocol::Email => 2,
-            Protocol::DNSSec => 3,
+            Protocol::DNSSEC => 3,
             Protocol::IPSec => 4,
             Protocol::All => 255,
             Protocol::Other(field) => field,

--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -533,7 +533,7 @@ pub enum DNSSECRData {
     /// ```
     TSIG(TSIG),
 
-    /// Unknown or unsupported DNSSec record data
+    /// Unknown or unsupported DNSSEC record data
     Unknown {
         /// RecordType code
         code: u16,

--- a/crates/proto/src/rr/dnssec/tbs.rs
+++ b/crates/proto/src/rr/dnssec/tbs.rs
@@ -1,4 +1,4 @@
-//! hash functions for DNSSec operations
+//! hash functions for DNSSEC operations
 
 use super::rdata::{sig, DNSSECRData, SIG};
 use crate::error::*;

--- a/crates/proto/src/rr/dnssec/trust_anchor.rs
+++ b/crates/proto/src/rr/dnssec/trust_anchor.rs
@@ -23,7 +23,7 @@ use crate::rr::dnssec::PublicKey;
 const ROOT_ANCHOR_ORIG: &[u8] = include_bytes!("roots/19036.rsa");
 const ROOT_ANCHOR_2018: &[u8] = include_bytes!("roots/20326.rsa");
 
-/// The root set of trust anchors for validating DNSSec, anything in this set will be trusted
+/// The root set of trust anchors for validating DNSSEC, anything in this set will be trusted
 #[derive(Clone)]
 pub struct TrustAnchor {
     // TODO: these should also store some information, or more specifically, metadata from the signed

--- a/crates/proto/src/rr/dnssec/verifier.rs
+++ b/crates/proto/src/rr/dnssec/verifier.rs
@@ -1,4 +1,4 @@
-//! Verifier is a structure for performing many of the signing processes of the DNSSec specification
+//! Verifier is a structure for performing many of the signing processes of the DNSSEC specification
 
 use crate::error::*;
 use crate::rr::dnssec::rdata::{DNSKEY, KEY, SIG};

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -37,7 +37,7 @@ impl RecordSet {
     /// * `record_type` - `RecordType` of this `RecordSet`, all records in the `RecordSet` must be of the
     ///                   specified `RecordType`.
     /// * `serial` - current serial number of the `SOA` record, this is to be used for `IXFR` and
-    ///              signing for DNSSec after updates.
+    ///              signing for DNSSEC after updates.
     ///
     /// # Return value
     ///
@@ -270,7 +270,7 @@ impl RecordSet {
     ///
     /// * `record` - `Record` asserts that the `name` and `record_type` match the `RecordSet`.
     /// * `serial` - current serial number of the `SOA` record, this is to be used for `IXFR` and
-    ///              signing for DNSSec after updates. The serial will only be updated if the
+    ///              signing for DNSSEC after updates. The serial will only be updated if the
     ///              record was added.
     ///
     /// # Return value
@@ -393,7 +393,7 @@ impl RecordSet {
     /// * `record` - `Record` asserts that the `name` and `record_type` match the `RecordSet`. Removes
     ///              any `record` if the record data, `RData`, match.
     /// * `serial` - current serial number of the `SOA` record, this is to be used for `IXFR` and
-    ///              signing for DNSSec after updates. The serial will only be updated if the
+    ///              signing for DNSSEC after updates. The serial will only be updated if the
     ///              record was added.
     ///
     /// # Return value

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -34,7 +34,7 @@ pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
     /// Error of the response, generally this will be `ProtoError`
     type Error: From<ProtoError> + Error + Clone + Send + Unpin + 'static;
 
-    /// Only returns true if and only if this DNS handle is validating DNSSec.
+    /// Only returns true if and only if this DNS handle is validating DNSSEC.
     ///
     /// If the DnsHandle impl is wrapping other clients, then the correct option is to delegate the question to the wrapped client.
     fn is_verifying_dnssec(&self) -> bool {

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! The `DnssecDnsHandle` is used to validate all DNS responses for correct DNSSec signatures.
+//! The `DnssecDnsHandle` is used to validate all DNS responses for correct DNSSEC signatures.
 
 use std::clone::Clone;
 use std::collections::HashSet;
@@ -38,7 +38,7 @@ struct Rrset {
     pub(crate) records: Vec<Record>,
 }
 
-/// Performs DNSSec validation of all DNS responses from the wrapped DnsHandle
+/// Performs DNSSEC validation of all DNS responses from the wrapped DnsHandle
 ///
 /// This wraps a DnsHandle, changing the implementation `send()` to validate all
 ///  message responses for Query operations. Update operation responses are not validated by

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.60.0"
 description = """
 *WARNING* This library is experimental
 
-Trust-DNS Recursor is a safe and secure DNS recursive resolver with DNSSec support.
+Trust-DNS Recursor is a safe and secure DNS recursive resolver with DNSSEC support.
  Trust-DNS is based on the Tokio and Futures libraries, which means
  it should be easily integrated into other software that also use those
  libraries. This library can be used as in the server and binary for performing recursive lookups.

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -11,7 +11,7 @@ This library contains implementations for IPv4 (A) and IPv6 (AAAA) resolution, m
 - NameServer pools with performance based priority usage
 - Caching of query results
 - NxDomain/NoData caching (negative caching)
-- DNSSec validation
+- DNSSEC validation
 - Generic Record Type Lookup
 - CNAME chain resolution
 - _experimental_ mDNS support (enable with `mdns` feature)
@@ -69,7 +69,7 @@ let mut resolver = Resolver::new(ResolverConfig::cloudflare_tls(), ResolverOpts:
 /// see example above...
 ```
 
-## DNSSec status
+## DNSSEC status
 
 Currently the root key is hardcoded into the system. This gives validation of
 DNSKEY and DS records back to the root. NSEC is implemented, but not NSEC3.

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -596,7 +596,7 @@ pub mod testing {
         thread_two.join().expect("thread_two failed");
     }
 
-    /// Test IP lookup from URLs with DNSSec validation.
+    /// Test IP lookup from URLs with DNSSEC validation.
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
     pub fn sec_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
@@ -636,7 +636,7 @@ pub mod testing {
         }
     }
 
-    /// Test IP lookup from domains that exist but unsigned with DNSSec validation.
+    /// Test IP lookup from domains that exist but unsigned with DNSSEC validation.
     #[allow(deprecated)]
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -191,7 +191,7 @@ where
         };
 
         // TODO: take all records and cache them?
-        //  if it's DNSSec they must be signed, otherwise?
+        //  if it's DNSSEC they must be signed, otherwise?
         let records: Result<Records, ResolveError> = match response_message {
             // this is the only cacheable form
             Err(ResolveError {
@@ -253,7 +253,7 @@ where
     ///  and a record for the name, regardless of CNAME presence, what have you
     ///  ultimately does not exist.
     ///
-    /// This also handles empty responses in the same way. When performing DNSSec enabled queries, we should
+    /// This also handles empty responses in the same way. When performing DNSSEC enabled queries, we should
     ///  never enter here, and should never cache unless verified requests.
     ///
     /// TODO: should this should be expanded to do a forward lookup? Today, this will fail even if there are
@@ -262,7 +262,7 @@ where
     /// # Arguments
     ///
     /// * `message` - message to extract SOA, etc, from for caching failed requests
-    /// * `valid_nsec` - species that in DNSSec mode, this request is safe to cache
+    /// * `valid_nsec` - species that in DNSSEC mode, this request is safe to cache
     /// * `negative_ttl` - this should be the SOA minimum for negative ttl
     fn handle_nxdomain(
         is_dnssec: bool,
@@ -439,7 +439,7 @@ where
             })
         } else {
             // TODO: review See https://tools.ietf.org/html/rfc2308 for NoData section
-            // Note on DNSSec, in secure_client_handle, if verify_nsec fails then the request fails.
+            // Note on DNSSEC, in secure_client_handle, if verify_nsec fails then the request fails.
             //   this will mean that no unverified negative caches will make it to this point and be stored
             Err(Self::handle_nxdomain(
                 is_dnssec,

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -795,7 +795,7 @@ pub struct ResolverOpts {
     pub check_names: bool,
     /// Enable edns, for larger records
     pub edns0: bool,
-    /// Use DNSSec to validate the request
+    /// Use DNSSEC to validate the request
     pub validate: bool,
     /// The ip_strategy for the Resolver to use when lookup Ipv4 or Ipv6 addresses
     pub ip_strategy: LookupIpStrategy,

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,8 +8,8 @@ rust-version = "1.60.0"
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)
 description = """
-Trust-DNS is a safe and secure DNS server with DNSSec support.
- Eventually this could be a replacement for BIND9. The DNSSec support allows
+Trust-DNS is a safe and secure DNS server with DNSSEC support.
+ Eventually this could be a replacement for BIND9. The DNSSEC support allows
  for live signing of all records, in it does not currently support
  records signed offline. The server supports dynamic DNS with SIG0 authenticated
  requests. Trust-DNS is based on the Tokio and Futures libraries, which means

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -2,7 +2,7 @@
 
 Trust-DNS Server is a library which implements the zone authoritory functionality.
 
-This library contains basic implementations for DNS zone hosting. It is capable of performing signing all records in the zone for server DNSSec RRSIG records associated with all records in a zone. There is also a `named` binary that can be generated from the library with `cargo install trust-dns`. Dynamic updates are supported via `SIG0` (an mTLS authentication method is under development).
+This library contains basic implementations for DNS zone hosting. It is capable of performing signing all records in the zone for server DNSSEC RRSIG records associated with all records in a zone. There is also a `named` binary that can be generated from the library with `cargo install trust-dns`. Dynamic updates are supported via `SIG0` (an mTLS authentication method is under development).
 
 ## Features
 

--- a/crates/server/src/config/dnssec.rs
+++ b/crates/server/src/config/dnssec.rs
@@ -23,7 +23,7 @@ use crate::client::rr::{
     domain::IntoName,
 };
 
-/// Key pair configuration for DNSSec keys for signing a zone
+/// Key pair configuration for DNSSEC keys for signing a zone
 #[derive(Deserialize, PartialEq, Eq, Debug)]
 pub struct KeyConfig {
     /// file path to the key

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -186,7 +186,7 @@ impl ZoneConfig {
     /// * `file` - relative to Config base path, to the zone file
     /// * `allow_update` - enable dynamic updates
     /// * `allow_axfr` - enable AXFR transfers
-    /// * `enable_dnssec` - enable signing of the zone for DNSSec
+    /// * `enable_dnssec` - enable signing of the zone for DNSSEC
     /// * `keys` - list of private and public keys used to sign a zone
     pub fn new(
         zone: String,

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -590,7 +590,7 @@ impl InnerInMemory {
 
         #[cfg(not(feature = "dnssec"))]
         fn is_nsec(_upsert_type: RecordType, _occupied_type: RecordType) -> bool {
-            // TODO: we should make the DNSSec RecordTypes always visible
+            // TODO: we should make the DNSSEC RecordTypes always visible
             false
         }
 

--- a/tests/test-data/named_test_configs/all_supported_dnssec.toml
+++ b/tests/test-data/named_test_configs/all_supported_dnssec.toml
@@ -1,4 +1,4 @@
-## Example configuration for all supported (including ring) signing options for DNSSec.
+## Example configuration for all supported (including ring) signing options for DNSSEC.
 
 ## Default zones, these should be present on all nameservers, except in rare
 ##  configuration cases

--- a/tests/test-data/named_test_configs/dnssec_with_update.toml
+++ b/tests/test-data/named_test_configs/dnssec_with_update.toml
@@ -1,4 +1,4 @@
-## Example configuration for supported OpenSSL DNSSec signing options.
+## Example configuration for supported OpenSSL DNSSEC signing options.
 
 ## Default zones, these should be present on all nameservers, except in rare
 ##  configuration cases

--- a/tests/test-data/named_test_configs/dnssec_with_update.toml
+++ b/tests/test-data/named_test_configs/dnssec_with_update.toml
@@ -43,7 +43,7 @@ zone_type = "Primary"
 enable_dnssec = true
 
 ## An ordered list of stores
-stores = { type = "sqlite", zone_file_path = "example.com.zone", journal_file_path = "example.com_dnsec_update.jrnl", allow_update = true }
+stores = { type = "sqlite", zone_file_path = "example.com.zone", journal_file_path = "example.com_dnssec_update.jrnl", allow_update = true }
 
 [[zones.keys]]
 key_path = "../tests/test-data/named_test_configs/dnssec/rsa_2048.pem"

--- a/tests/test-data/named_test_configs/dnssec_with_update_deprecated.toml
+++ b/tests/test-data/named_test_configs/dnssec_with_update_deprecated.toml
@@ -1,6 +1,6 @@
 ## Deprecated format of dnssec_and_dynamic_dns
 
-## Example configuration for supported OpenSSL DNSSec signing options.
+## Example configuration for supported OpenSSL DNSSEC signing options.
 
 ## Default zones, these should be present on all nameservers, except in rare
 ##  configuration cases

--- a/tests/test-data/named_test_configs/openssl_dnssec.toml
+++ b/tests/test-data/named_test_configs/openssl_dnssec.toml
@@ -1,4 +1,4 @@
-## Example configuration for supported OpenSSL DNSSec signing options.
+## Example configuration for supported OpenSSL DNSSEC signing options.
 
 ## Default zones, these should be present on all nameservers, except in rare
 ##  configuration cases

--- a/tests/test-data/named_test_configs/ring_dnssec.toml
+++ b/tests/test-data/named_test_configs/ring_dnssec.toml
@@ -1,4 +1,4 @@
-## Example configuration for all supported (including ring) signing options for DNSSec.
+## Example configuration for all supported (including ring) signing options for DNSSEC.
 
 ## Default zones, these should be present on all nameservers, except in rare
 ##  configuration cases

--- a/util/README.md
+++ b/util/README.md
@@ -81,7 +81,7 @@ OPTIONS:
     -o, --output <OUTPUT_FILE>    Output FILE to write to [default: out.pem]
 
 ARGS:
-    <PRIVATE_KEY_FILE>    Input FILE from which to read the DNSSec private key
+    <PRIVATE_KEY_FILE>    Input FILE from which to read the DNSSEC private key
 ```
 
 

--- a/util/src/bind_dnskey_to_pem.rs
+++ b/util/src/bind_dnskey_to_pem.rs
@@ -43,7 +43,7 @@ use trust_dns_client::rr::dnssec::Algorithm;
     author = "Benjamin Fry <benjaminfry@me.com>"
 )]
 struct Cli {
-    /// Input FILE from which to read the DNSSec private key
+    /// Input FILE from which to read the DNSSEC private key
     #[arg(
         long = "key",
         value_name = "PRIVATE_KEY_FILE",


### PR DESCRIPTION
At least 40 files have typos with "DNSSEC".
This PR fixes the DNSSEC typo.