### PR TITLE
remove named binary

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -71,7 +71,6 @@ tls = ["dns-over-openssl"]
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
 # mtls = ["trust-dns-client/mtls"]
 
-## DEPRECATED
 [[bin]]
 name = "trust-dns"
 path = "src/named.rs"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -73,10 +73,6 @@ tls = ["dns-over-openssl"]
 
 ## DEPRECATED
 [[bin]]
-name = "named"
-path = "src/named.rs"
-
-[[bin]]
 name = "trust-dns"
 path = "src/named.rs"
 

--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -43,7 +43,7 @@ where
     let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
     println!("using server src path: {}", server_path);
 
-    let mut command = Command::new(&format!("{}/target/debug/named", server_path));
+    let mut command = Command::new(&format!("{}/target/debug/trust-dns", server_path));
     command
         .stdout(Stdio::piped())
         .env(


### PR DESCRIPTION
The `named` binary is a duplicate of the `trust-dns` binary.
They both take the same path `src/named.rs`.

People may think having a `named` binary offers a drop-in replacement with BIND.
But at the same time, it conflicts with BIND and the `named` binary.
I think Trust-DNS provides enough compatibility by itself with BIND but does not need to provide as well a `named` binary.

Some users may have installed on their system both BIND and Trust-DNS.
They may want to use or try both for some reasons.
Or they may use BIND only for BIND utilities such as `dig`, `host` and `nslookup`.
On Arch Linux, BIND and the BIND utilities are part of [the same package](https://archlinux.org/packages/extra/x86_64/bind/).
And overwriting the `named` binary would just create an unnecessary conflict.
For example, [PowerDNS](https://archlinux.org/packages/community/x86_64/powerdns/), another BIND alternative, does not conflict with BIND because it does not provide a `named` binary.
Trust-DNS is a [great brand in the making](https://letsencrypt.org/2022/12/05/ed-letter-2022.html), and I believe we should promote more the use of the `trust-dns` binary.

