### PR TITLE
Don't retry authoritative NOERROR with an empty set, from trusted resolvers

### DIFF
--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -378,8 +378,8 @@ impl Recursor {
                     let mut udp = NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Udp);
                     let mut tcp = NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Tcp);
 
-                    udp.trust_nx_responses = true;
-                    tcp.trust_nx_responses = true;
+                    udp.trust_negative_responses = true;
+                    tcp.trust_negative_responses = true;
 
                     config_group.push(udp);
                     config_group.push(tcp);

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -149,7 +149,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> NameSe
 
                 // First evaluate if the message succeeded.
                 let response =
-                    ResolveError::from_response(response, self.config.trust_nx_responses)?;
+                    ResolveError::from_response(response, self.config.trust_negative_responses)?;
 
                 // TODO: consider making message::take_edns...
                 let remote_edns = response.extensions().clone();
@@ -176,7 +176,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> NameSe
 
     /// Specifies that this NameServer will treat negative responses as permanent failures and will not retry
     pub fn trust_nx_responses(&self) -> bool {
-        self.config.trust_nx_responses
+        self.config.trust_negative_responses
     }
 }
 
@@ -236,7 +236,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> Eq for
 pub(crate) fn mdns_nameserver<C, P>(
     options: ResolverOpts,
     conn_provider: P,
-    trust_nx_responses: bool,
+    trust_negative_responses: bool,
 ) -> NameServer<C, P>
 where
     C: DnsHandle<Error = ResolveError>,
@@ -246,7 +246,7 @@ where
         socket_addr: *MDNS_IPV4,
         protocol: Protocol::Mdns,
         tls_dns_name: None,
-        trust_nx_responses,
+        trust_negative_responses,
         #[cfg(feature = "dns-over-rustls")]
         tls_config: None,
         bind_addr: None,
@@ -278,7 +278,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Udp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,
@@ -317,7 +317,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 252),
             protocol: Protocol::Udp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -476,7 +476,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 253),
             protocol: Protocol::Udp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,
@@ -486,7 +486,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Udp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,
@@ -548,7 +548,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Tcp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -68,7 +68,7 @@ fn into_resolver_config(
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
             protocol: Protocol::Udp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,
@@ -77,7 +77,7 @@ fn into_resolver_config(
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
             protocol: Protocol::Tcp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,
@@ -129,7 +129,7 @@ mod tests {
                 socket_addr: addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
-                trust_nx_responses: false,
+                trust_negative_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
                 bind_addr: None,
@@ -138,7 +138,7 @@ mod tests {
                 socket_addr: addr,
                 protocol: Protocol::Tcp,
                 tls_dns_name: None,
-                trust_nx_responses: false,
+                trust_negative_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
                 bind_addr: None,

--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -32,7 +32,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,
@@ -41,7 +41,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -56,7 +56,7 @@ impl RecursiveAuthority {
                 socket_addr,
                 protocol: Protocol::Tcp,
                 tls_dns_name: None,
-                trust_nx_responses: false,
+                trust_negative_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
                 bind_addr: None, // TODO: need to support bind addresses
@@ -66,7 +66,7 @@ impl RecursiveAuthority {
                 socket_addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
-                trust_nx_responses: false,
+                trust_negative_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
                 bind_addr: None,

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -14,7 +14,7 @@ use futures::stream::{once, Stream};
 use futures::{future, Future};
 
 use trust_dns_client::op::{Message, Query};
-use trust_dns_client::rr::{Name, RData, Record};
+use trust_dns_client::rr::{rdata::SOA, Name, RData, Record};
 use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::{DnsHandle, DnsRequest, DnsResponse};
 
@@ -80,6 +80,11 @@ pub fn cname_record(name: Name, cname: Name) -> Record {
 
 pub fn v4_record(name: Name, ip: Ipv4Addr) -> Record {
     Record::from_rdata(name, 86400, RData::A(ip))
+}
+
+pub fn soa_record(name: Name, mname: Name) -> Record {
+    let soa = SOA::new(mname, Default::default(), 1, 3600, 60, 86400, 3600);
+    Record::from_rdata(name, 86400, RData::SOA(soa))
 }
 
 pub fn message(

--- a/util/src/recurse.rs
+++ b/util/src/recurse.rs
@@ -125,7 +125,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: opts.bind.map(|ip| SocketAddr::new(ip, 0)),
@@ -135,7 +135,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: opts.bind.map(|ip| SocketAddr::new(ip, 0)),

--- a/util/src/resolve.rs
+++ b/util/src/resolve.rs
@@ -275,7 +275,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: opts.bind.map(|ip| SocketAddr::new(ip, 0)),
@@ -285,7 +285,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
-            trust_nx_responses: false,
+            trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: opts.bind.map(|ip| SocketAddr::new(ip, 0)),


### PR DESCRIPTION
Resolves https://github.com/bluejekyll/trust-dns/issues/1860