### PR TITLE
Show rfc9250 DoQ support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -424,7 +424,7 @@ bound for implementing the `Connect` trait.
 - (server) Authority trait for generic Authorities (File, Sqlite, Forwarder) #674
 - (server) ANAME resolutions #720
 - (server) Additional section processing for ANAME, CNAME, MX, NS, and SRV #720
-- (server) Added endpoint name config to DoH and DoT TLS endpoint #714
+- (server) Added endpoint name config to DoQ, DoT and DoH TLS endpoint #714
 - (proto) NAPTR record data (no additional record processing support) #731
 - (server) Added support for wildcard lookups, i.e. `*.example.com` in zone files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -801,7 +801,7 @@ and there is no easy way to migrate the original Server to use ServerFuture.
 
 ### Added
 
-- DNS-over-TLS configurations (requires one of `dns-over-native-tls` or `dns-over-rustls` features) #396
+- DNS over TLS configurations (requires one of `dns-over-native-tls` or `dns-over-rustls` features) #396
 - Experimental DNS-SD, service discovery (RFC 6763, `mdns` feature required) #363
 - Experimental mDNS, multicast DNS, known issues persist (RFC 6762, `mdns` feature required) #337
 - Exposed TTLs on `Lookup` objects @hawkw #444

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ When making submitting PRs please keep refactoring commits separate from functio
 
 ### Test policy
 
-All PRs *must* be passing all tests. Ideally any PR submitted should have more than 85% code coverage, but this is not mandated. When tests are failing, especially on previous branches this is often due to checked in testing keys for the DoH and DoT tests. See **Updating Security Related Tests**.
+All PRs *must* be passing all tests. Ideally any PR submitted should have more than 85% code coverage, but this is not mandated. When tests are failing, especially on previous branches this is often due to checked in testing keys for the DoQ, DoT and DoH tests. See **Updating Security Related Tests**.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -109,59 +109,59 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 
 ## RFCs implemented
 
-- [RFC 8499](https://tools.ietf.org/html/rfc8499): No more master/slave, in honor of [Juneteenth](https://en.wikipedia.org/wiki/Juneteenth)
+- [RFC 8499](https://www.rfc-editor.org/rfc/rfc8499): No more master/slave, in honor of [Juneteenth](https://en.wikipedia.org/wiki/Juneteenth)
 
 ### Basic operations
 
-- [RFC 1035](https://tools.ietf.org/html/rfc1035): Base DNS spec (see the Resolver for caching)
-- [RFC 2308](https://tools.ietf.org/html/rfc2308): Negative Caching of DNS Queries (see the Resolver)
-- [RFC 2782](https://tools.ietf.org/html/rfc2782): Service location
-- [RFC 3596](https://tools.ietf.org/html/rfc3596): IPv6
-- [RFC 6891](https://tools.ietf.org/html/rfc6891): Extension Mechanisms for DNS
-- [RFC 6761](https://tools.ietf.org/html/rfc6761): Special-Use Domain Names (resolver)
-- [RFC 6762](https://tools.ietf.org/html/rfc6762): mDNS Multicast DNS (experimental feature: `mdns`)
-- [RFC 6763](https://tools.ietf.org/html/rfc6763): DNS-SD Service Discovery (experimental feature: `mdns`)
-- [RFC ANAME](https://tools.ietf.org/html/draft-ietf-dnsop-aname-02): Address-specific DNS aliases (`ANAME`)
+- [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035): Base DNS spec (see the Resolver for caching)
+- [RFC 2308](https://www.rfc-editor.org/rfc/rfc2308): Negative Caching of DNS Queries (see the Resolver)
+- [RFC 2782](https://www.rfc-editor.org/rfc/rfc2782): Service location
+- [RFC 3596](https://www.rfc-editor.org/rfc/rfc3596): IPv6
+- [RFC 6891](https://www.rfc-editor.org/rfc/rfc6891): Extension Mechanisms for DNS
+- [RFC 6761](https://www.rfc-editor.org/rfc/rfc6761): Special-Use Domain Names (resolver)
+- [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762): mDNS Multicast DNS (experimental feature: `mdns`)
+- [RFC 6763](https://www.rfc-editor.org/rfc/rfc6763): DNS-SD Service Discovery (experimental feature: `mdns`)
+- [RFC ANAME](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-aname-02): Address-specific DNS aliases (`ANAME`)
 
 ### Update operations
 
-- [RFC 2136](https://tools.ietf.org/html/rfc2136): Dynamic Update
-- [RFC 7477](https://tools.ietf.org/html/rfc7477): Child-to-Parent Synchronization in DNS
+- [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136): Dynamic Update
+- [RFC 7477](https://www.rfc-editor.org/rfc/rfc7477): Child-to-Parent Synchronization in DNS
 
 ### Secure DNS operations
 
-- [RFC 3007](https://tools.ietf.org/html/rfc3007): Secure Dynamic Update
-- [RFC 4034](https://tools.ietf.org/html/rfc4034): DNSSEC Resource Records
-- [RFC 4035](https://tools.ietf.org/html/rfc4035): Protocol Modifications for DNSSEC
-- [RFC 4509](https://tools.ietf.org/html/rfc4509): SHA-256 in DNSSEC Delegation Signer
-- [RFC 5702](https://tools.ietf.org/html/rfc5702): SHA-2 Algorithms with RSA in DNSKEY and RRSIG for DNSSEC
-- [RFC 6844](https://tools.ietf.org/html/rfc6844): DNS Certification Authority Authorization (CAA) Resource Record
-- [RFC 6698](https://tools.ietf.org/html/rfc6698): The DNS-Based Authentication of Named Entities (DANE) Transport Layer Security (TLS) Protocol: TLSA
-- [RFC 6840](https://tools.ietf.org/html/rfc6840): Clarifications and Implementation Notes for DNSSEC
-- [RFC 6844](https://tools.ietf.org/html/rfc6844): DNS Certification Authority Authorization Resource Record
-- [RFC 6944](https://tools.ietf.org/html/rfc6944): DNSKEY Algorithm Implementation Status
-- [RFC 6975](https://tools.ietf.org/html/rfc6975): Signaling Cryptographic Algorithm Understanding
-- [RFC 7858](https://tools.ietf.org/html/rfc7858): DNS over TLS (feature: `dns-over-rustls`, `dns-over-native-tls`, or `dns-over-openssl`)
-- [RFC DoH](https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-14): DNS over HTTPS, DoH (feature: `dns-over-https-rustls`)
+- [RFC 3007](https://www.rfc-editor.org/rfc/rfc3007): Secure Dynamic Update
+- [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034): DNSSEC Resource Records
+- [RFC 4035](https://www.rfc-editor.org/rfc/rfc4035): Protocol Modifications for DNSSEC
+- [RFC 4509](https://www.rfc-editor.org/rfc/rfc4509): SHA-256 in DNSSEC Delegation Signer
+- [RFC 5702](https://www.rfc-editor.org/rfc/rfc5702): SHA-2 Algorithms with RSA in DNSKEY and RRSIG for DNSSEC
+- [RFC 6844](https://www.rfc-editor.org/rfc/rfc6844): DNS Certification Authority Authorization (CAA) Resource Record
+- [RFC 6698](https://www.rfc-editor.org/rfc/rfc6698): The DNS-Based Authentication of Named Entities (DANE) Transport Layer Security (TLS) Protocol: TLSA
+- [RFC 6840](https://www.rfc-editor.org/rfc/rfc6840): Clarifications and Implementation Notes for DNSSEC
+- [RFC 6844](https://www.rfc-editor.org/rfc/rfc6844): DNS Certification Authority Authorization Resource Record
+- [RFC 6944](https://www.rfc-editor.org/rfc/rfc6944): DNSKEY Algorithm Implementation Status
+- [RFC 6975](https://www.rfc-editor.org/rfc/rfc6975): Signaling Cryptographic Algorithm Understanding
+- [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858): DNS over TLS (feature: `dns-over-rustls`, `dns-over-native-tls`, or `dns-over-openssl`)
+- [RFC DoH](https://datatracker.ietf.org/doc/html/draft-ietf-doh-dns-over-https-14): DNS over HTTPS, DoH (feature: `dns-over-https-rustls`)
 
 ## RFCs in progress or not yet implemented
 
 ### Basic operations
 
-- [RFC 2317](https://tools.ietf.org/html/rfc2317): Classless IN-ADDR.ARPA delegation
+- [RFC 2317](https://www.rfc-editor.org/rfc/rfc2317): Classless IN-ADDR.ARPA delegation
 
 ### Update operations
 
-- [RFC 1995](https://tools.ietf.org/html/rfc1995): Incremental Zone Transfer
-- [RFC 1996](https://tools.ietf.org/html/rfc1996): Notify secondaries of update
-- [Update Leases](https://tools.ietf.org/html/draft-sekar-dns-ul-01): Dynamic DNS Update Leases
-- [Long-Lived Queries](https://tools.ietf.org/html/draft-sekar-dns-llq-01): Notify with bells
+- [RFC 1995](https://www.rfc-editor.org/rfc/rfc1995): Incremental Zone Transfer
+- [RFC 1996](https://www.rfc-editor.org/rfc/rfc1996): Notify secondaries of update
+- [Update Leases](https://datatracker.ietf.org/doc/html/draft-sekar-dns-ul-01): Dynamic DNS Update Leases
+- [Long-Lived Queries](https://datatracker.ietf.org/doc/html/draft-sekar-dns-llq-01): Notify with bells
 
 ### Secure DNS operations
 
-- [RFC 5155](https://tools.ietf.org/html/rfc5155): DNSSEC Hashed Authenticated Denial of Existence
+- [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155): DNSSEC Hashed Authenticated Denial of Existence
 - [DNSCrypt](https://dnscrypt.org): Trusted DNS queries
-- [S/MIME](https://tools.ietf.org/html/draft-ietf-dane-smime-09): Domain Names For S/MIME
+- [S/MIME](https://datatracker.ietf.org/doc/html/draft-ietf-dane-smime-09): Domain Names For S/MIME
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -85,17 +85,19 @@ allows for the `DNSKEY` to exist for some unspecified period of time during
 key rotation. Rotating the key currently is not available online and requires
 a restart of the server process.
 
-### DNS over TLS and DNS over HTTPS on the Server
+### DNS over QUIC, DNS over TLS and DNS over HTTPS on the Server
 
 Support of TLS on the Server is managed through a pkcs12 der file. The documentation is captured in the example test config file, [example.toml](https://github.com/bluejekyll/trust-dns/blob/main/tests/test-data/named_test_configs/example.toml). A registered certificate to the server can be pinned to the Client with the `add_ca()` method. Alternatively, as the client uses the rust-native-tls library, it should work with certificate signed by any standard CA.
 
-## DNS over TLS and DNS over HTTPS
+## DNS over QUIC, DNS over TLS and DNS over HTTPS
 
-DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires only requires valid DoT or DoH resolvers being registered in order to be used.
+DoQ, DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires only valid DoQ, DoT or DoH resolvers being registered in order to be used.
 
 To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` should be used. Similarly, to use with the tokio `AsyncClient` the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
+
+To enable DoQ, the feature `dns-over-quic` must be enabled.
 
 ## DNSSEC status
 
@@ -121,7 +123,7 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 - [RFC 6761](https://www.rfc-editor.org/rfc/rfc6761): Special-Use Domain Names (resolver)
 - [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762): mDNS Multicast DNS (experimental feature: `mdns`)
 - [RFC 6763](https://www.rfc-editor.org/rfc/rfc6763): DNS-SD Service Discovery (experimental feature: `mdns`)
-- [RFC ANAME](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-aname-02): Address-specific DNS aliases (`ANAME`)
+- [Internet Draft (version 04)](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-aname-04): Address-specific DNS aliases (`ANAME`)
 
 ### Update operations
 
@@ -135,14 +137,14 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 - [RFC 4035](https://www.rfc-editor.org/rfc/rfc4035): Protocol Modifications for DNSSEC
 - [RFC 4509](https://www.rfc-editor.org/rfc/rfc4509): SHA-256 in DNSSEC Delegation Signer
 - [RFC 5702](https://www.rfc-editor.org/rfc/rfc5702): SHA-2 Algorithms with RSA in DNSKEY and RRSIG for DNSSEC
-- [RFC 6844](https://www.rfc-editor.org/rfc/rfc6844): DNS Certification Authority Authorization (CAA) Resource Record
 - [RFC 6698](https://www.rfc-editor.org/rfc/rfc6698): The DNS-Based Authentication of Named Entities (DANE) Transport Layer Security (TLS) Protocol: TLSA
 - [RFC 6840](https://www.rfc-editor.org/rfc/rfc6840): Clarifications and Implementation Notes for DNSSEC
-- [RFC 6844](https://www.rfc-editor.org/rfc/rfc6844): DNS Certification Authority Authorization Resource Record
+- [RFC 6844](https://www.rfc-editor.org/rfc/rfc6844): DNS Certification Authority Authorization (CAA) Resource Record
 - [RFC 6944](https://www.rfc-editor.org/rfc/rfc6944): DNSKEY Algorithm Implementation Status
 - [RFC 6975](https://www.rfc-editor.org/rfc/rfc6975): Signaling Cryptographic Algorithm Understanding
 - [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858): DNS over TLS (feature: `dns-over-rustls`, `dns-over-native-tls`, or `dns-over-openssl`)
-- [RFC DoH](https://datatracker.ietf.org/doc/html/draft-ietf-doh-dns-over-https-14): DNS over HTTPS, DoH (feature: `dns-over-https-rustls`)
+- [RFC 8484](https://www.rfc-editor.org/rfc/rfc8484): DNS over HTTPS, DoH (feature: `dns-over-https-rustls`)
+- [RFC 9250](https://www.rfc-editor.org/rfc/rfc9250): DNS over QUIC, DoQ (feature: `dns-over-quic`)
 
 ## RFCs in progress or not yet implemented
 
@@ -154,14 +156,14 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 
 - [RFC 1995](https://www.rfc-editor.org/rfc/rfc1995): Incremental Zone Transfer
 - [RFC 1996](https://www.rfc-editor.org/rfc/rfc1996): Notify secondaries of update
-- [Update Leases](https://datatracker.ietf.org/doc/html/draft-sekar-dns-ul-01): Dynamic DNS Update Leases
-- [Long-Lived Queries](https://datatracker.ietf.org/doc/html/draft-sekar-dns-llq-01): Notify with bells
+- [Internet Draft (version 03)](https://datatracker.ietf.org/doc/html/draft-sekar-dns-ul-03): Dynamic DNS Update Leases
+- [RFC 8764](https://www.rfc-editor.org/rfc/rfc8764): Notify with bells
 
 ### Secure DNS operations
 
 - [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155): DNSSEC Hashed Authenticated Denial of Existence
 - [DNSCrypt](https://dnscrypt.org): Trusted DNS queries
-- [S/MIME](https://datatracker.ietf.org/doc/html/draft-ietf-dane-smime-09): Domain Names For S/MIME
+- [S/MIME](https://www.rfc-editor.org/rfc/rfc8162): Domain Names For S/MIME
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ allows for the `DNSKEY` to exist for some unspecified period of time during
 key rotation. Rotating the key currently is not available online and requires
 a restart of the server process.
 
-### DNS-over-TLS and DNS-over-HTTPS on the Server
+### DNS over TLS and DNS over HTTPS on the Server
 
 Support of TLS on the Server is managed through a pkcs12 der file. The documentation is captured in the example test config file, [example.toml](https://github.com/bluejekyll/trust-dns/blob/main/tests/test-data/named_test_configs/example.toml). A registered certificate to the server can be pinned to the Client with the `add_ca()` method. Alternatively, as the client uses the rust-native-tls library, it should work with certificate signed by any standard CA.
 
-## DNS-over-TLS and DNS-over-HTTPS
+## DNS over TLS and DNS over HTTPS
 
 DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires only requires valid DoT or DoH resolvers being registered in order to be used.
 
@@ -303,16 +303,16 @@ The Client has a few features which can be disabled for different reasons when e
   Ring support can be used for RSA and ED25519 DNSSEC validation.
 
 - `dns-over-native-tls`
-  Uses `native-tls` for DNS-over-TLS implementation, only supported in client and resolver, not server.
+  Uses `native-tls` for DNS over TLS implementation, only supported in client and resolver, not server.
 
 - `dns-over-openssl`
-  Uses `openssl` for DNS-over-TLS implementation supported in server and client, resolver does not have default CA chains.
+  Uses `openssl` for DNS over TLS implementation supported in server and client, resolver does not have default CA chains.
 
 - `dns-over-rustls`
-  Uses `rustls` for DNS-over-TLS implementation, only supported in client and resolver, not server. This is the best option where a pure Rust toolchain is desired. Supported in client, resolver, and server.
+  Uses `rustls` for DNS over TLS implementation, only supported in client and resolver, not server. This is the best option where a pure Rust toolchain is desired. Supported in client, resolver, and server.
 
 - `dns-over-https-rustls`
-  Uses `rustls` for DNS-over-HTTPS (and DNS-over-TLS will be enabled) implementation, only supported in client, resolver, and server. This is the best option where a pure Rust toolchain is desired.
+  Uses `rustls` for DNS over HTTPS (and DNS over TLS will be enabled) implementation, only supported in client, resolver, and server. This is the best option where a pure Rust toolchain is desired.
 
 - `mdns` _EXPERIMENTAL_
   Enables the experimental mDNS features as well as DNS-SD. This currently has known issues.

--- a/bin/README.md
+++ b/bin/README.md
@@ -8,6 +8,7 @@ This a named implementation for DNS zone hosting. It is capable of performing si
 
 - Dynamic Update with sqlite journaling backend (SIG0)
 - DNSSEC online signing (NSEC not NSEC3)
+- DNS over QUIC (DoQ)
 - DNS over TLS (DoT)
 - DNS over HTTPS (DoH)
 - Forwarding stub resolver

--- a/bin/README.md
+++ b/bin/README.md
@@ -15,15 +15,17 @@ This a named implementation for DNS zone hosting. It is capable of performing si
 - ANAME resolution, for zone mapping aliass to A and AAAA records
 - Additionals section generation for aliasing record types
 
-## DNS over TLS and DNS over HTTPS
+## DNS over QUIC, DNS over TLS and DNS over HTTPS
 
 Support of TLS on the Server is managed through a pkcs12 der file. The documentation is captured in the example test config file, [example.toml](https://github.com/bluejekyll/trust-dns/blob/main/tests/test-data/named_test_configs/example.toml). A registered certificate to the server can be pinned to the Client with the `add_ca()` method. Alternatively, as the client uses the rust-native-tls library, it should work with certificate signed by any standard CA.
 
-DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires only requires valid DoT or DoH resolvers being registered in order to be used.
+DoQ, DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires only valid DoQ, DoT or DoH resolvers being registered in order to be used.
 
 To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` should be used. Similarly, to use with the tokio `AsyncClient` the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
+
+To enable DoQ, the feature `dns-over-quic` must be enabled.
 
 ## DNSSEC status
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -15,7 +15,7 @@ This a named implementation for DNS zone hosting. It is capable of performing si
 - ANAME resolution, for zone mapping aliass to A and AAAA records
 - Additionals section generation for aliasing record types
 
-## DNS-over-TLS and DNS-over-HTTPS
+## DNS over TLS and DNS over HTTPS
 
 Support of TLS on the Server is managed through a pkcs12 der file. The documentation is captured in the example test config file, [example.toml](https://github.com/bluejekyll/trust-dns/blob/main/tests/test-data/named_test_configs/example.toml). A registered certificate to the server can be pinned to the Client with the `add_ca()` method. Alternatively, as the client uses the rust-native-tls library, it should work with certificate signed by any standard CA.
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -54,13 +54,15 @@ if let Some(RData::A(ref ip)) = answers[0].data() {
 }
 ```
 
-## DNS over TLS and DNS over HTTPS
+## DNS over QUIC, DNS over TLS and DNS over HTTPS
 
-DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH).
+DoQ, DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH).
 
 To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` should be used. Similarly, to use with the tokio `AsyncClient` the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
+
+To enable DoQ, the feature `dns-over-quic` must be enabled.
 
 ## DNSSEC status
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -54,7 +54,7 @@ if let Some(RData::A(ref ip)) = answers[0].data() {
 }
 ```
 
-## DNS-over-TLS and DNS-over-HTTPS
+## DNS over TLS and DNS over HTTPS
 
 DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH).
 

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -182,7 +182,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
 
     /// Sends a NOTIFY message to the remote system
     ///
-    /// [RFC 1996](https://tools.ietf.org/html/rfc1996), DNS NOTIFY, August 1996
+    /// [RFC 1996](https://www.rfc-editor.org/rfc/rfc1996), DNS NOTIFY, August 1996
     ///
     ///
     /// ```text
@@ -283,7 +283,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
             .set_query_type(query_type);
         message.add_query(query);
 
-        // add the notify message, see https://tools.ietf.org/html/rfc1996, section 3.7
+        // add the notify message, see https://www.rfc-editor.org/rfc/rfc1996, section 3.7
         if let Some(rrset) = rrset {
             message.add_answers(rrset.into());
         }
@@ -294,7 +294,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
     /// Sends a record to create on the server, this will fail if the record exists (atomicity
     ///  depends on the server)
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///  2.4.3 - RRset Does Not Exist
@@ -341,7 +341,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
     /// Appends a record to an existing rrset, optionally require the rrset to exist (atomicity
     ///  depends on the server)
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 2.4.1 - RRset Exists (Value Independent)
@@ -448,7 +448,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
 
     /// Deletes a record (by rdata) from an rrset, optionally require the rrset to exist.
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 2.4.1 - RRset Exists (Value Independent)
@@ -498,7 +498,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
 
     /// Deletes an entire rrset, optionally require the rrset to exist.
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 2.4.1 - RRset Exists (Value Independent)
@@ -543,7 +543,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
 
     /// Deletes all records at the specified name
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 2.5.3 - Delete All RRsets From A Name

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -154,7 +154,7 @@ pub trait Client {
     /// Sends a record to create on the server, this will fail if the record exists (atomicity
     ///  depends on the server)
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///  2.4.3 - RRset Does Not Exist
@@ -196,7 +196,7 @@ pub trait Client {
     /// Appends a record to an existing rrset, optionally require the rrset to exist (atomicity
     ///  depends on the server)
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 2.4.1 - RRset Exists (Value Independent)
@@ -294,7 +294,7 @@ pub trait Client {
 
     /// Deletes a record (by rdata) from an rrset, optionally require the rrset to exist.
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 2.4.1 - RRset Exists (Value Independent)
@@ -338,7 +338,7 @@ pub trait Client {
 
     /// Deletes an entire rrset, optionally require the rrset to exist.
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 2.4.1 - RRset Exists (Value Independent)
@@ -379,7 +379,7 @@ pub trait Client {
 
     /// Deletes all records at the specified name
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 2.5.3 - Delete All RRsets From A Name

--- a/crates/client/src/op/update_message.rs
+++ b/crates/client/src/op/update_message.rs
@@ -131,7 +131,7 @@ impl UpdateMessage for Message {
 /// Sends a record to create on the server, this will fail if the record exists (atomicity
 ///  depends on the server)
 ///
-/// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+/// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
 ///
 /// ```text
 ///  2.4.3 - RRset Does Not Exist
@@ -200,7 +200,7 @@ pub fn create(rrset: RecordSet, zone_origin: Name, use_edns: bool) -> Message {
 /// Appends a record to an existing rrset, optionally require the rrset to exist (atomicity
 ///  depends on the server)
 ///
-/// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+/// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
 ///
 /// ```text
 /// 2.4.1 - RRset Exists (Value Independent)
@@ -364,7 +364,7 @@ pub fn compare_and_swap(
 
 /// Deletes a record (by rdata) from an rrset, optionally require the rrset to exist.
 ///
-/// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+/// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
 ///
 /// ```text
 /// 2.4.1 - RRset Exists (Value Independent)
@@ -436,7 +436,7 @@ pub fn delete_by_rdata(mut rrset: RecordSet, zone_origin: Name, use_edns: bool) 
 
 /// Deletes an entire rrset, optionally require the rrset to exist.
 ///
-/// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+/// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
 ///
 /// ```text
 /// 2.4.1 - RRset Exists (Value Independent)
@@ -508,7 +508,7 @@ pub fn delete_rrset(mut record: Record, zone_origin: Name, use_edns: bool) -> Me
 
 /// Deletes all records at the specified name
 ///
-/// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+/// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
 ///
 /// ```text
 /// 2.5.3 - Delete All RRsets From A Name

--- a/crates/client/src/rr/dnssec/keypair.rs
+++ b/crates/client/src/rr/dnssec/keypair.rs
@@ -190,7 +190,7 @@ impl<K: HasPublic> KeyPair<K> {
 
     /// The key tag is calculated as a hash to more quickly lookup a DNSKEY.
     ///
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
     ///
     /// ```text
     /// RFC 2535                DNS Security Extensions               March 1999

--- a/crates/client/src/rr/dnssec/signer.rs
+++ b/crates/client/src/rr/dnssec/signer.rs
@@ -28,7 +28,7 @@ use {
 ///
 /// TODO: warning this struct and it's impl are under high volatility, expect breaking changes
 ///
-/// [RFC 4035](https://tools.ietf.org/html/rfc4035), DNSSEC Protocol Modifications, March 2005
+/// [RFC 4035](https://www.rfc-editor.org/rfc/rfc4035), DNSSEC Protocol Modifications, March 2005
 ///
 /// ```text
 /// 5.3.  Authenticating an RRset with an RRSIG RR
@@ -370,7 +370,7 @@ impl SigSigner {
     // TODO: move this to DNSKEY/KEY?
     /// The key tag is calculated as a hash to more quickly lookup a DNSKEY.
     ///
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
     ///
     /// ```text
     /// RFC 2535                DNS Security Extensions               March 1999
@@ -436,7 +436,7 @@ impl SigSigner {
     ///
     /// * `message` - the message to sign
     ///
-    /// [rfc2535](https://tools.ietf.org/html/rfc2535#section-4.1.8.1), Domain Name System Security Extensions, 1999
+    /// [rfc2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.8.1), Domain Name System Security Extensions, 1999
     ///
     /// ```text
     /// 4.1.8.1 Calculating Transaction and Request SIGs

--- a/crates/client/src/rr/dnssec/tsig.rs
+++ b/crates/client/src/rr/dnssec/tsig.rs
@@ -133,7 +133,7 @@ impl TSigner {
             unreachable!("tsig::signed_message_to_buff always returns a TSIG record")
         };
 
-        // https://tools.ietf.org/html/rfc8945#section-5.2
+        // https://www.rfc-editor.org/rfc/rfc8945#section-5.2
         // 1.  Check key
         if record.name() != &self.0.signer_name || tsig.algorithm() != &self.0.algorithm {
             return Err(ProtoErrorKind::TsigWrongKey.into());

--- a/crates/client/src/rr/zone.rs
+++ b/crates/client/src/rr/zone.rs
@@ -9,7 +9,7 @@ use radix_trie::{Trie, TrieKey};
 
 // Reserved reverse IPs
 //
-// [Special-Use Domain Names](https://tools.ietf.org/html/rfc6761), RFC 6761 February, 2013
+// [Special-Use Domain Names](https://www.rfc-editor.org/rfc/rfc6761), RFC 6761 February, 2013
 //
 // ```text
 // 6.1.  Domain Name Reservation Considerations for Private Addresses
@@ -70,7 +70,7 @@ lazy_static! {
 
 // example., example.com., example.net., and example.org.
 //
-// [Special-Use Domain Names](https://tools.ietf.org/html/rfc6761), RFC 6761 February, 2013
+// [Special-Use Domain Names](https://www.rfc-editor.org/rfc/rfc6761), RFC 6761 February, 2013
 //
 // ```text
 // 6.5.  Domain Name Reservation Considerations for Example Domains
@@ -97,7 +97,7 @@ lazy_static! {
 
 // test.
 //
-// [Special-Use Domain Names](https://tools.ietf.org/html/rfc6761), RFC 6761 February, 2013
+// [Special-Use Domain Names](https://www.rfc-editor.org/rfc/rfc6761), RFC 6761 February, 2013
 //
 // ```text
 // 6.2.  Domain Name Reservation Considerations for "test."

--- a/crates/client/src/serialize/txt/rdata_parsers/caa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/caa.rs
@@ -26,7 +26,7 @@ use crate::rr::rdata::CAA;
 
 /// Parse the RData from a set of Tokens
 ///
-/// [RFC 6844, DNS Certification Authority Authorization, January 2013](https://tools.ietf.org/html/rfc6844#section-5.1)
+/// [RFC 6844, DNS Certification Authority Authorization, January 2013](https://www.rfc-editor.org/rfc/rfc6844#section-5.1)
 ///
 /// ```text
 /// 5.1.1.  Canonical Presentation Format

--- a/crates/client/src/serialize/txt/rdata_parsers/openpgpkey.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/openpgpkey.rs
@@ -12,7 +12,7 @@ use crate::rr::rdata::OPENPGPKEY;
 
 /// Parse the RData from a set of tokens.
 ///
-/// [RFC 7929](https://tools.ietf.org/html/rfc7929#section-2.3)
+/// [RFC 7929](https://www.rfc-editor.org/rfc/rfc7929#section-2.3)
 ///
 /// ```text
 /// 2.3.  The OPENPGPKEY RDATA Presentation Format

--- a/crates/client/src/serialize/txt/rdata_parsers/sshfp.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/sshfp.rs
@@ -12,7 +12,7 @@ use crate::rr::rdata::{sshfp, SSHFP};
 
 /// Parse the RData from a set of Tokens
 ///
-/// [RFC 4255](https://tools.ietf.org/html/rfc4255#section-3.2)
+/// [RFC 4255](https://www.rfc-editor.org/rfc/rfc4255#section-3.2)
 ///
 /// ```text
 /// 3.2.  Presentation Format of the SSHFP RR

--- a/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/tlsa.rs
@@ -18,7 +18,7 @@ fn to_u8(data: &str) -> ParseResult<u8> {
 
 /// Parse the RData from a set of Tokens
 ///
-/// [RFC 6698, DNS-Based Authentication for TLS](https://tools.ietf.org/html/rfc6698#section-2.2)
+/// [RFC 6698, DNS-Based Authentication for TLS](https://www.rfc-editor.org/rfc/rfc6698#section-2.2)
 ///
 /// ```text
 /// 2.2.  TLSA RR Presentation Format

--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -372,7 +372,7 @@ impl Parser {
     }
 
     /// parses the string following the rules from:
-    ///  <https://tools.ietf.org/html/rfc2308> (NXCaching RFC) and
+    ///  <https://www.rfc-editor.org/rfc/rfc2308> (NXCaching RFC) and
     ///  <http://www.zytrax.com/books/dns/apa/time.html>
     ///
     /// default is seconds

--- a/crates/proto/src/https/https_client_stream.rs
+++ b/crates/proto/src/https/https_client_stream.rs
@@ -35,7 +35,7 @@ use crate::xfer::{DnsRequest, DnsRequestSender, DnsResponse, DnsResponseStream, 
 
 const ALPN_H2: &[u8] = b"h2";
 
-/// A DNS client connection for DNS-over-HTTPS
+/// A DNS client connection for DNS over HTTPS
 #[derive(Clone)]
 #[must_use = "futures do nothing unless polled"]
 pub struct HttpsClientStream {
@@ -278,7 +278,7 @@ impl Stream for HttpsClientStream {
     }
 }
 
-/// A HTTPS connection builder for DNS-over-HTTPS
+/// A HTTPS connection builder for DNS over HTTPS
 #[derive(Clone)]
 pub struct HttpsClientStreamBuilder {
     client_config: Arc<ClientConfig>,

--- a/crates/proto/src/https/request.rs
+++ b/crates/proto/src/https/request.rs
@@ -19,7 +19,7 @@ use crate::https::HttpsResult;
 /// Create a new Request for an http/2 dns-message request
 ///
 /// ```text
-/// https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-10#section-5.1
+/// https://datatracker.ietf.org/doc/html/draft-ietf-doh-dns-over-https-10#section-5.1
 /// The URI Template defined in this document is processed without any
 /// variables when the HTTP method is POST.  When the HTTP method is GET
 /// the single variable "dns" is defined as the content of the DNS

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -81,7 +81,7 @@ impl MdnsStream {
     /// This method is available for specifying a custom Multicast address to use.
     ///
     /// In general this operates nearly identically to UDP, except that it automatically joins
-    ///  the default multicast DNS addresses. See <https://tools.ietf.org/html/rfc6762#section-5>
+    ///  the default multicast DNS addresses. See <https://www.rfc-editor.org/rfc/rfc6762#section-5>
     ///  for details.
     ///
     /// When sending ipv6 multicast packets, the interface being used is required,
@@ -389,7 +389,7 @@ impl Future for NextRandomUdpSocket {
             for attempt in 0..10 {
                 let port = rand_port_range.sample(&mut rand);
 
-                // see one_shot usage info: https://tools.ietf.org/html/rfc6762#section-5
+                // see one_shot usage info: https://www.rfc-editor.org/rfc/rfc6762#section-5
                 //  the MDNS_PORT is used to signal to remote processes that this is capable of receiving multicast packets
                 //  i.e. is joined to the multicast address.
                 if port == MDNS_PORT {

--- a/crates/proto/src/multicast/mod.rs
+++ b/crates/proto/src/multicast/mod.rs
@@ -17,7 +17,7 @@ pub use self::mdns_client_stream::{MdnsClientConnect, MdnsClientStream};
 #[cfg(feature = "tokio-runtime")]
 pub use self::mdns_stream::{MdnsStream, MDNS_IPV4, MDNS_IPV6};
 
-/// See [rfc6762](https://tools.ietf.org/html/rfc6762#section-5) details on these different types.
+/// See [rfc6762](https://www.rfc-editor.org/rfc/rfc6762#section-5) details on these different types.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MdnsQueryType {
     /// The querier using this socket will only perform standard DNS queries over multicast. (clients only)
@@ -25,7 +25,7 @@ pub enum MdnsQueryType {
     /// Effectively treats mDNS as essentially no different than any other DNS query; one request followed by one response.
     ///   Only one UDP socket will be created.
     OneShot,
-    /// The querier is fully compliant with [rfc6762](https://tools.ietf.org/html/rfc6762#section-5). (servers, clients)
+    /// The querier is fully compliant with [rfc6762](https://www.rfc-editor.org/rfc/rfc6762#section-5). (servers, clients)
     ///
     /// mDNS capable clients will sent messages with many queries, and they will expect many responses. Two UDP sockets will be
     ///   created, one for receiving multicast traffic, the other used for sending queries and direct responses. This requires

--- a/crates/proto/src/native_tls/tls_stream.rs
+++ b/crates/proto/src/native_tls/tls_stream.rs
@@ -102,7 +102,7 @@ impl<S: Connect> TlsStreamBuilder<S> {
 
     /// Creates a new TlsStream to the specified name_server
     ///
-    /// [RFC 7858](https://tools.ietf.org/html/rfc7858), DNS over TLS, May 2016
+    /// [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858), DNS over TLS, May 2016
     ///
     /// ```text
     /// 3.2.  TLS Handshake and Authentication

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -17,7 +17,7 @@ use crate::{
 
 /// Metadata for the `Message` struct.
 ///
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// 4.1.1. Header section format
@@ -395,7 +395,7 @@ impl Header {
         self.recursion_available
     }
 
-    /// [RFC 4035, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4035#section-3.1.6)
+    /// [RFC 4035, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4035#section-3.1.6)
     ///
     /// ```text
     ///

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -21,7 +21,7 @@ use crate::{
 
 /// The basic request and response data structure, used for all DNS protocols.
 ///
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// 4.1. Format
@@ -500,7 +500,7 @@ impl Message {
             .chain(self.additionals.iter())
     }
 
-    /// [RFC 6891, EDNS(0) Extensions, April 2013](https://tools.ietf.org/html/rfc6891#section-6.1.1)
+    /// [RFC 6891, EDNS(0) Extensions, April 2013](https://www.rfc-editor.org/rfc/rfc6891#section-6.1.1)
     ///
     /// ```text
     /// 6.1.1.  Basic Elements
@@ -574,7 +574,7 @@ impl Message {
         self.edns.as_ref().map_or(0, Edns::version)
     }
 
-    /// [RFC 2535, Domain Name System Security Extensions, March 1999](https://tools.ietf.org/html/rfc2535#section-4)
+    /// [RFC 2535, Domain Name System Security Extensions, March 1999](https://www.rfc-editor.org/rfc/rfc2535#section-4)
     ///
     /// ```text
     /// A DNS request may be optionally signed by including one or more SIGs
@@ -594,7 +594,7 @@ impl Message {
         &self.signature
     }
 
-    /// [RFC 2535, Domain Name System Security Extensions, March 1999](https://tools.ietf.org/html/rfc2535#section-4)
+    /// [RFC 2535, Domain Name System Security Extensions, March 1999](https://www.rfc-editor.org/rfc/rfc2535#section-4)
     ///
     /// ```text
     /// A DNS request may be optionally signed by including one or more SIGs

--- a/crates/proto/src/op/op_code.rs
+++ b/crates/proto/src/op/op_code.rs
@@ -13,7 +13,7 @@ use crate::error::*;
 
 /// Operation code for queries, updates, and responses
 ///
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// OPCODE          A four bit field that specifies kind of query in this
@@ -31,16 +31,16 @@ use crate::error::*;
 #[derive(Debug, PartialEq, Eq, PartialOrd, Copy, Clone, Hash)]
 #[allow(dead_code)]
 pub enum OpCode {
-    /// Query request [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    /// Query request [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035)
     Query,
 
-    /// Status message [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    /// Status message [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035)
     Status,
 
-    /// Notify of change [RFC 1996](https://tools.ietf.org/html/rfc1996)
+    /// Notify of change [RFC 1996](https://www.rfc-editor.org/rfc/rfc1996)
     Notify,
 
-    /// Update message [RFC 2136](https://tools.ietf.org/html/rfc2136)
+    /// Update message [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136)
     Update,
 }
 

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -26,7 +26,7 @@ use crate::rr::record_type::RecordType;
 use crate::serialize::binary::*;
 
 #[cfg(feature = "mdns")]
-/// From [RFC 6762](https://tools.ietf.org/html/rfc6762#section-5.4)
+/// From [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762#section-5.4)
 /// ```text
 // To avoid large floods of potentially unnecessary responses in these
 // cases, Multicast DNS defines the top bit in the class field of a DNS
@@ -36,7 +36,7 @@ const MDNS_UNICAST_RESPONSE: u16 = 1 << 15;
 
 /// Query struct for looking up resource records, basically a resource record without RDATA.
 ///
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// 4.1.2. Question section format
@@ -117,7 +117,7 @@ impl Query {
     }
 
     /// Changes mDNS unicast-response bit
-    /// See [RFC 6762](https://tools.ietf.org/html/rfc6762#section-5.4)
+    /// See [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762#section-5.4)
     #[cfg(feature = "mdns")]
     #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
     pub fn set_mdns_unicast_response(&mut self, flag: bool) -> &mut Self {
@@ -156,7 +156,7 @@ impl Query {
     }
 
     /// Returns if the mDNS unicast-response bit is set or not
-    /// See [RFC 6762](https://tools.ietf.org/html/rfc6762#section-5.4)
+    /// See [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762#section-5.4)
     #[cfg(feature = "mdns")]
     #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
     pub fn mdns_unicast_response(&self) -> bool {

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -23,7 +23,7 @@ use std::fmt::{Display, Formatter};
 
 /// The status code of the response to a query.
 ///
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// RCODE           Response code - this 4 bit field is set as part of
@@ -62,41 +62,41 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug, Eq, PartialEq, PartialOrd, Copy, Clone, Hash)]
 #[allow(dead_code)]
 pub enum ResponseCode {
-    /// No Error [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    /// No Error [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035)
     NoError,
 
-    /// Format Error [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    /// Format Error [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035)
     FormErr,
 
-    /// Server Failure [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    /// Server Failure [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035)
     ServFail,
 
-    /// Non-Existent Domain [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    /// Non-Existent Domain [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035)
     NXDomain,
 
-    /// Not Implemented [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    /// Not Implemented [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035)
     NotImp,
 
-    /// Query Refused [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    /// Query Refused [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035)
     Refused,
 
-    /// Name Exists when it should not [RFC 2136](https://tools.ietf.org/html/rfc2136)
+    /// Name Exists when it should not [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136)
     YXDomain,
 
-    /// RR Set Exists when it should not [RFC 2136](https://tools.ietf.org/html/rfc2136)
+    /// RR Set Exists when it should not [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136)
     YXRRSet,
 
-    /// RR Set that should exist does not [RFC 2136](https://tools.ietf.org/html/rfc2136)
+    /// RR Set that should exist does not [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136)
     NXRRSet,
 
-    /// Server Not Authoritative for zone [RFC 2136](https://tools.ietf.org/html/rfc2136)
+    /// Server Not Authoritative for zone [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136)
     /// or Not Authorized [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945)
     NotAuth,
 
-    /// Name not contained in zone [RFC 2136](https://tools.ietf.org/html/rfc2136)
+    /// Name not contained in zone [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136)
     NotZone,
 
-    /// Bad OPT Version [RFC 6891](https://tools.ietf.org/html/rfc6891#section-9)
+    /// Bad OPT Version [RFC 6891](https://www.rfc-editor.org/rfc/rfc6891#section-9)
     BADVERS,
 
     /// TSIG Signature Failure [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945)
@@ -108,19 +108,19 @@ pub enum ResponseCode {
     /// Signature out of time window [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945)
     BADTIME,
 
-    /// Bad TKEY Mode [RFC 2930](https://tools.ietf.org/html/rfc2930#section-2.6)
+    /// Bad TKEY Mode [RFC 2930](https://www.rfc-editor.org/rfc/rfc2930#section-2.6)
     BADMODE,
 
-    /// Duplicate key name [RFC 2930](https://tools.ietf.org/html/rfc2930#section-2.6)
+    /// Duplicate key name [RFC 2930](https://www.rfc-editor.org/rfc/rfc2930#section-2.6)
     BADNAME,
 
-    /// Algorithm not supported [RFC 2930](https://tools.ietf.org/html/rfc2930#section-2.6)
+    /// Algorithm not supported [RFC 2930](https://www.rfc-editor.org/rfc/rfc2930#section-2.6)
     BADALG,
 
-    /// Bad Truncation [RFC 4635](https://tools.ietf.org/html/rfc4635#section-4)
+    /// Bad Truncation [RFC 4635](https://www.rfc-editor.org/rfc/rfc4635#section-4)
     BADTRUNC,
 
-    /// Bad/missing server cookie [draft-ietf-dnsop-cookies](https://tools.ietf.org/html/draft-ietf-dnsop-cookies-10)
+    /// Bad/missing server cookie [draft-ietf-dnsop-cookies](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-cookies-10)
     BADCOOKIE,
     // 24-3840      Unassigned
     // 3841-4095    Reserved for Private Use                        [RFC6895]

--- a/crates/proto/src/openssl/tls_stream.rs
+++ b/crates/proto/src/openssl/tls_stream.rs
@@ -192,7 +192,7 @@ impl<S: Connect> TlsStreamBuilder<S> {
 
     /// Creates a new TlsStream to the specified name_server
     ///
-    /// [RFC 7858](https://tools.ietf.org/html/rfc7858), DNS over TLS, May 2016
+    /// [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858), DNS over TLS, May 2016
     ///
     /// ```text
     /// 3.2.  TLS Handshake and Authentication

--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -27,7 +27,7 @@ use crate::{
 
 use super::{quic_config, quic_stream};
 
-/// A DNS client connection for DNS-over-QUIC
+/// A DNS client connection for DNS over QUIC
 #[must_use = "futures do nothing unless polled"]
 pub struct QuicClientStream {
     quic_connection: Connection,
@@ -144,7 +144,7 @@ impl Stream for QuicClientStream {
     }
 }
 
-/// A QUIC connection builder for DNS-over-QUIC
+/// A QUIC connection builder for DNS over QUIC
 #[derive(Clone)]
 pub struct QuicClientStreamBuilder {
     crypto_config: TlsClientConfig,

--- a/crates/proto/src/quic/quic_config.rs
+++ b/crates/proto/src/quic/quic_config.rs
@@ -7,7 +7,7 @@
 
 use quinn::{EndpointConfig, TransportConfig, VarInt};
 
-/// Returns a default endpoint configuration for DNS-over-QUIC
+/// Returns a default endpoint configuration for DNS over QUIC
 pub(crate) fn endpoint() -> EndpointConfig {
     // set some better EndpointConfig defaults for DoQ
     let mut endpoint_config = EndpointConfig::default();
@@ -21,7 +21,7 @@ pub(crate) fn endpoint() -> EndpointConfig {
     endpoint_config
 }
 
-/// Returns a default endpoint configuration for DNS-over-QUIC
+/// Returns a default endpoint configuration for DNS over QUIC
 pub(crate) fn transport() -> TransportConfig {
     let mut transport_config = TransportConfig::default();
 

--- a/crates/proto/src/quic/quic_server.rs
+++ b/crates/proto/src/quic/quic_server.rs
@@ -17,7 +17,7 @@ use super::{
     quic_stream::{self, QuicStream},
 };
 
-/// A DNS-over-QUIC Server, see QuicClientStream for the client counterpart
+/// A DNS over QUIC Server, see QuicClientStream for the client counterpart
 pub struct QuicServer {
     endpoint: Endpoint,
 }

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -146,7 +146,7 @@ impl From<DNSClass> for u16 {
             DNSClass::HS => 4,
             DNSClass::NONE => 254,
             DNSClass::ANY => 255,
-            // see https://tools.ietf.org/html/rfc6891#section-6.1.2
+            // see https://www.rfc-editor.org/rfc/rfc6891#section-6.1.2
             DNSClass::OPT(max_payload_len) => max_payload_len.max(512),
         }
     }

--- a/crates/proto/src/rr/dnssec/algorithm.rs
+++ b/crates/proto/src/rr/dnssec/algorithm.rs
@@ -23,7 +23,7 @@ use crate::serialize::binary::*;
 /// For [reference](http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml)
 ///  the iana documents have all the officially registered algorithms.
 ///
-/// [RFC 6944](https://tools.ietf.org/html/rfc6944), DNSSEC DNSKEY Algorithm Status, April 2013
+/// [RFC 6944](https://www.rfc-editor.org/rfc/rfc6944), DNSSEC DNSKEY Algorithm Status, April 2013
 ///
 /// ```text
 ///
@@ -127,11 +127,11 @@ pub enum Algorithm {
     RSASHA256,
     /// RSA public key with SHA512 hash
     RSASHA512,
-    /// [rfc6605](https://tools.ietf.org/html/rfc6605)
+    /// [rfc6605](https://www.rfc-editor.org/rfc/rfc6605)
     ECDSAP256SHA256,
-    /// [rfc6605](https://tools.ietf.org/html/rfc6605)
+    /// [rfc6605](https://www.rfc-editor.org/rfc/rfc6605)
     ECDSAP384SHA384,
-    /// [draft-ietf-curdle-dnskey-eddsa-03](https://tools.ietf.org/html/draft-ietf-curdle-dnskey-eddsa-03)
+    /// [draft-ietf-curdle-dnskey-eddsa-03](https://datatracker.ietf.org/doc/html/draft-ietf-curdle-dnskey-eddsa-03)
     ED25519,
     /// An unknown algorithm identifier
     Unknown(u8),

--- a/crates/proto/src/rr/dnssec/digest_type.rs
+++ b/crates/proto/src/rr/dnssec/digest_type.rs
@@ -37,13 +37,13 @@ use super::Digest;
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[non_exhaustive]
 pub enum DigestType {
-    /// [RFC 3658](https://tools.ietf.org/html/rfc3658)
+    /// [RFC 3658](https://www.rfc-editor.org/rfc/rfc3658)
     SHA1,
-    /// [RFC 4509](https://tools.ietf.org/html/rfc4509)
+    /// [RFC 4509](https://www.rfc-editor.org/rfc/rfc4509)
     SHA256,
-    /// [RFC 5933](https://tools.ietf.org/html/rfc5933)
+    /// [RFC 5933](https://www.rfc-editor.org/rfc/rfc5933)
     GOSTR34_11_94,
-    /// [RFC 6605](https://tools.ietf.org/html/rfc6605)
+    /// [RFC 6605](https://www.rfc-editor.org/rfc/rfc6605)
     SHA384,
     /// Undefined
     SHA512,

--- a/crates/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -29,7 +29,7 @@ use crate::serialize::binary::{
     BinDecodable, BinDecoder, BinEncodable, BinEncoder, Restrict, RestrictedMath,
 };
 
-/// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-2), DNSSEC Resource Records, March 2005
+/// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-2), DNSSEC Resource Records, March 2005
 ///
 /// ```text
 /// 2.  The DNSKEY Resource Record
@@ -115,7 +115,7 @@ impl DNSKEY {
         }
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-2.1.1)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-2.1.1)
     ///
     /// ```text
     /// 2.1.1.  The Flags Field
@@ -134,7 +134,7 @@ impl DNSKEY {
         self.zone_key
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-2.1.1)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-2.1.1)
     ///
     /// ```text
     /// 2.1.1.  The Flags Field
@@ -155,7 +155,7 @@ impl DNSKEY {
         self.secure_entry_point
     }
 
-    /// [RFC 5011, Trust Anchor Update, September 2007](https://tools.ietf.org/html/rfc5011#section-3)
+    /// [RFC 5011, Trust Anchor Update, September 2007](https://www.rfc-editor.org/rfc/rfc5011#section-3)
     ///
     /// ```text
     /// RFC 5011                  Trust Anchor Update             September 2007
@@ -169,7 +169,7 @@ impl DNSKEY {
         self.revoke
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-2.1.3)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-2.1.3)
     ///
     /// ```text
     /// 2.1.3.  The Algorithm Field
@@ -182,7 +182,7 @@ impl DNSKEY {
         self.algorithm
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-2.1.4)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-2.1.4)
     ///
     /// ```text
     /// 2.1.4.  The Public Key Field
@@ -266,7 +266,7 @@ impl DNSKEY {
 
     /// The key tag is calculated as a hash to more quickly lookup a DNSKEY.
     ///
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// RFC 2535                DNS Security Extensions               March 1999
@@ -404,7 +404,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &DNSKEY) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-2.2)
+/// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-2.2)
 ///
 /// ```text
 /// 2.2.  The DNSKEY RR Presentation Format

--- a/crates/proto/src/rr/dnssec/rdata/ds.rs
+++ b/crates/proto/src/rr/dnssec/rdata/ds.rs
@@ -28,7 +28,7 @@ use crate::serialize::binary::*;
 use crate::rr::dnssec::rdata::DNSKEY;
 use crate::rr::Name;
 
-/// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-5)
+/// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-5)
 ///
 /// ```text
 /// 5.1.  DS RDATA Wire Format
@@ -107,7 +107,7 @@ impl DS {
         }
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-5.1.1)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-5.1.1)
     ///
     /// ```text
     /// 5.1.1.  The Key Tag Field
@@ -122,7 +122,7 @@ impl DS {
         self.key_tag
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-5.1.1)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-5.1.1)
     ///
     /// ```text
     /// 5.1.2.  The Algorithm Field
@@ -138,7 +138,7 @@ impl DS {
         self.algorithm
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-5.1.1)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-5.1.1)
     ///
     /// ```text
     /// 5.1.3.  The Digest Type Field
@@ -151,7 +151,7 @@ impl DS {
         self.digest_type
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-5.1.1)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-5.1.1)
     ///
     /// ```text
     /// 5.1.4.  The Digest Field
@@ -228,7 +228,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &DS) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-5.3)
+/// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-5.3)
 ///
 /// ```text
 /// 5.3.  The DS RR Presentation Format

--- a/crates/proto/src/rr/dnssec/rdata/key.rs
+++ b/crates/proto/src/rr/dnssec/rdata/key.rs
@@ -27,7 +27,7 @@ use crate::rr::dnssec::Algorithm;
 use crate::rr::record_data::RData;
 use crate::serialize::binary::*;
 
-/// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-3), Domain Name System Security Extensions, March 1999
+/// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-3), Domain Name System Security Extensions, March 1999
 ///
 /// ```text
 /// 3. The KEY Resource Record
@@ -315,7 +315,7 @@ fn test_key_usage() {
     );
 }
 
-/// [RFC 2137](https://tools.ietf.org/html/rfc2137#section-3.1), Secure Domain Name System Dynamic Update, April 1997
+/// [RFC 2137](https://www.rfc-editor.org/rfc/rfc2137#section-3.1), Secure Domain Name System Dynamic Update, April 1997
 ///
 /// ```text
 /// 3.1.1 Update Key Name Scope
@@ -399,7 +399,7 @@ fn test_key_usage() {
 ///    sections 3.1.1 and 3.1.2.
 /// ```
 ///
-/// [RFC 3007](https://tools.ietf.org/html/rfc3007#section-1.5), Secure Dynamic Update, November 2000
+/// [RFC 3007](https://www.rfc-editor.org/rfc/rfc3007#section-1.5), Secure Dynamic Update, November 2000
 ///
 /// ```text
 ///    [RFC2535, section 3.1.2] defines the signatory field of a key as the
@@ -515,7 +515,7 @@ fn test_update_scope() {
     assert_eq!(update_scope, UpdateScope::from(u16::from(update_scope)));
 }
 
-/// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-3.1.3), Domain Name System Security Extensions, March 1999
+/// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-3.1.3), Domain Name System Security Extensions, March 1999
 ///
 /// ```text
 /// 3.1.3 The Protocol Octet
@@ -561,7 +561,7 @@ fn test_update_scope() {
 ///           different keys for different protocols is encouraged.
 /// ```
 ///
-/// [RFC3445](https://tools.ietf.org/html/rfc3445#section-4), Limiting the KEY Resource Record (RR), December 2002
+/// [RFC3445](https://www.rfc-editor.org/rfc/rfc3445#section-4), Limiting the KEY Resource Record (RR), December 2002
 ///
 /// ```text
 /// All Protocol Octet values except DNSSEC (3) are eliminated
@@ -682,7 +682,7 @@ impl KEY {
         self.protocol
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-2.1.3)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-2.1.3)
     ///
     /// ```text
     /// 2.1.3.  The Algorithm Field
@@ -695,7 +695,7 @@ impl KEY {
         self.algorithm
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-2.1.4)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-2.1.4)
     ///
     /// ```text
     /// 2.1.4.  The Public Key Field
@@ -825,7 +825,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &KEY) -> ProtoResult<()> {
 
 /// Note that KEY is a deprecated type in DNS
 ///
-/// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-7.1), Domain Name System Security Extensions, March 1999
+/// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-7.1), Domain Name System Security Extensions, March 1999
 ///
 /// ```text
 /// 7.1 Presentation of KEY RRs

--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -419,7 +419,7 @@ pub enum DNSSECRData {
     /// ```
     SIG(SIG),
 
-    /// [RFC 8945, Secret Key Transaction Authentication for DNS](https://tools.ietf.org/html/rfc8945#section-4.2)
+    /// [RFC 8945, Secret Key Transaction Authentication for DNS](https://www.rfc-editor.org/rfc/rfc8945#section-4.2)
     ///
     /// ```text
     /// 4.2.  TSIG Record Format

--- a/crates/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec.rs
@@ -25,7 +25,7 @@ use crate::rr::type_bit_map::{decode_type_bit_maps, encode_type_bit_maps};
 use crate::rr::{Name, RecordType};
 use crate::serialize::binary::*;
 
-/// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-4), DNSSEC Resource Records, March 2005
+/// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-4), DNSSEC Resource Records, March 2005
 ///
 /// ```text
 /// 4.1.  NSEC RDATA Wire Format
@@ -92,7 +92,7 @@ impl NSEC {
         Self::new(next_domain_name, type_bit_maps)
     }
 
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-4.1.1), DNSSEC Resource Records, March 2005
+    /// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-4.1.1), DNSSEC Resource Records, March 2005
     ///
     /// ```text
     /// 4.1.1.  The Next Domain Name Field
@@ -117,7 +117,7 @@ impl NSEC {
         &self.next_domain_name
     }
 
-    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://tools.ietf.org/html/rfc4034#section-4.1.2)
+    /// [RFC 4034, DNSSEC Resource Records, March 2005](https://www.rfc-editor.org/rfc/rfc4034#section-4.1.2)
     ///
     /// ```text
     /// 4.1.2.  The Type Bit Maps Field
@@ -148,7 +148,7 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
     Ok(NSEC::new(next_domain_name, record_types))
 }
 
-/// [RFC 6840](https://tools.ietf.org/html/rfc6840#section-6)
+/// [RFC 6840](https://www.rfc-editor.org/rfc/rfc6840#section-6)
 ///
 /// ```text
 /// 5.1.  Errors in Canonical Form Type Code List
@@ -165,7 +165,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &NSEC) -> ProtoResult<()> {
     })
 }
 
-/// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-4.2), DNSSEC Resource Records, March 2005
+/// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-4.2), DNSSEC Resource Records, March 2005
 ///
 /// ```text
 /// 4.2.  The NSEC RR Presentation Format

--- a/crates/proto/src/rr/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3.rs
@@ -27,7 +27,7 @@ use crate::rr::type_bit_map::*;
 use crate::rr::RecordType;
 use crate::serialize::binary::*;
 
-/// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-3), NSEC3, March 2008
+/// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-3), NSEC3, March 2008
 ///
 /// ```text
 /// 3.  The NSEC3 Resource Record
@@ -143,7 +143,7 @@ impl NSEC3 {
         }
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-3.1.1), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-3.1.1), NSEC3, March 2008
     ///
     /// ```text
     /// 3.1.1.  Hash Algorithm
@@ -158,7 +158,7 @@ impl NSEC3 {
         self.hash_algorithm
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-3.1.2), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-3.1.2), NSEC3, March 2008
     ///
     /// ```text
     /// 3.1.2.  Flags
@@ -183,7 +183,7 @@ impl NSEC3 {
         self.opt_out
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-3.1.3), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-3.1.3), NSEC3, March 2008
     ///
     /// ```text
     /// 3.1.3.  Iterations
@@ -199,7 +199,7 @@ impl NSEC3 {
         self.iterations
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-3.1.5), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-3.1.5), NSEC3, March 2008
     ///
     /// ```text
     /// 3.1.5.  Salt
@@ -212,7 +212,7 @@ impl NSEC3 {
         &self.salt
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-3.1.7), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-3.1.7), NSEC3, March 2008
     ///
     /// ```text
     /// 3.1.7.  Next Hashed Owner Name
@@ -231,7 +231,7 @@ impl NSEC3 {
         &self.next_hashed_owner_name
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-3.1.8), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-3.1.8), NSEC3, March 2008
     ///
     /// ```text
     /// 3.1.8.  Type Bit Maps
@@ -326,7 +326,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &NSEC3) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-3.3), NSEC3, March 2008
+/// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-3.3), NSEC3, March 2008
 ///
 /// ```text
 /// 3.3.  Presentation Format

--- a/crates/proto/src/rr/dnssec/rdata/nsec3param.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3param.rs
@@ -25,7 +25,7 @@ use crate::error::*;
 use crate::rr::dnssec::Nsec3HashAlgorithm;
 use crate::serialize::binary::*;
 
-/// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-4), NSEC3, March 2008
+/// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-4), NSEC3, March 2008
 ///
 /// ```text
 /// 4.  The NSEC3PARAM Resource Record
@@ -106,7 +106,7 @@ impl NSEC3PARAM {
         }
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-4.1.1), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-4.1.1), NSEC3, March 2008
     ///
     /// ```text
     /// 4.1.1.  Hash Algorithm
@@ -121,7 +121,7 @@ impl NSEC3PARAM {
         self.hash_algorithm
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-4.1.2), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-4.1.2), NSEC3, March 2008
     ///
     /// ```text
     /// 4.1.2.  Flag Fields
@@ -137,7 +137,7 @@ impl NSEC3PARAM {
         self.opt_out
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-4.1.3), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-4.1.3), NSEC3, March 2008
     ///
     /// ```text
     /// 4.1.3.  Iterations
@@ -152,7 +152,7 @@ impl NSEC3PARAM {
         self.iterations
     }
 
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-4.1.5), NSEC3, March 2008
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-4.1.5), NSEC3, March 2008
     ///
     /// ```text
     /// 4.1.5.  Salt
@@ -205,7 +205,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, rdata: &NSEC3PARAM) -> ProtoResult<()>
     Ok(())
 }
 
-/// [RFC 5155](https://tools.ietf.org/html/rfc5155#section-4), NSEC3, March 2008
+/// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155#section-4), NSEC3, March 2008
 ///
 /// ```text
 /// 4.3.  Presentation Format

--- a/crates/proto/src/rr/dnssec/rdata/sig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/sig.rs
@@ -25,7 +25,7 @@ use crate::rr::dnssec::Algorithm;
 use crate::rr::{Name, RecordType};
 use crate::serialize::binary::*;
 
-/// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4), Domain Name System Security Extensions, March 1999
+/// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4), Domain Name System Security Extensions, March 1999
 ///
 /// NOTE: RFC 2535 was obsoleted with 4034+, with the exception of the
 ///  usage for UPDATE, which is what this implementation is for.
@@ -57,7 +57,7 @@ use crate::serialize::binary::*;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///
 /// ```
-/// [RFC 2931](https://tools.ietf.org/html/rfc2931), DNS Request and Transaction Signatures, September 2000
+/// [RFC 2931](https://www.rfc-editor.org/rfc/rfc2931), DNS Request and Transaction Signatures, September 2000
 ///
 /// NOTE: 2931 updates SIG0 to clarify certain particulars...
 ///
@@ -265,7 +265,7 @@ impl SIG {
         }
     }
 
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.1), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.1), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// 4.1.1 Type Covered Field
@@ -276,7 +276,7 @@ impl SIG {
         self.type_covered
     }
 
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.2), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.2), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// 4.1.2 Algorithm Number Field
@@ -287,7 +287,7 @@ impl SIG {
         self.algorithm
     }
 
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.3), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.3), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// 4.1.3 Labels Field
@@ -323,7 +323,7 @@ impl SIG {
         self.num_labels
     }
 
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.4), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.4), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// 4.1.4 Original TTL Field
@@ -344,7 +344,7 @@ impl SIG {
         self.original_ttl
     }
 
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.5), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.5), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// 4.1.5 Signature Expiration and Inception Fields
@@ -382,7 +382,7 @@ impl SIG {
         self.sig_inception
     }
 
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.6), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.6), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// 4.1.6 Key Tag Field
@@ -402,7 +402,7 @@ impl SIG {
         self.key_tag
     }
 
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.7), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.7), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// 4.1.7 Signer's Name Field
@@ -420,7 +420,7 @@ impl SIG {
         &self.signer_name
     }
 
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.8), Domain Name System Security Extensions, March 1999
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-4.1.8), Domain Name System Security Extensions, March 1999
     ///
     /// ```text
     /// 4.1.8 Signature Field
@@ -492,7 +492,7 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
     ))
 }
 
-/// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005
+/// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-6), DNSSEC Resource Records, March 2005
 ///
 /// This is accurate for all currently known name records.
 ///
@@ -550,7 +550,7 @@ pub fn emit_pre_sig(
     Ok(())
 }
 
-/// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-7.2), Domain Name System Security Extensions, March 1999
+/// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535#section-7.2), Domain Name System Security Extensions, March 1999
 ///
 /// ```text
 /// 7.2 Presentation of SIG RRs

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -25,7 +25,7 @@ use crate::rr::record_type::RecordType;
 use crate::rr::{Name, Record};
 use crate::serialize::binary::*;
 
-/// [RFC 8945, Secret Key Transaction Authentication for DNS](https://tools.ietf.org/html/rfc8945#section-4.2)
+/// [RFC 8945, Secret Key Transaction Authentication for DNS](https://www.rfc-editor.org/rfc/rfc8945#section-4.2)
 ///
 /// ```text
 ///   4.2.  TSIG Record Format
@@ -151,7 +151,7 @@ pub struct TSIG {
 
 /// Algorithm used to authenticate communication
 ///
-/// [RFC8945 Secret Key Transaction Authentication for DNS](https://tools.ietf.org/html/rfc8945#section-6)
+/// [RFC8945 Secret Key Transaction Authentication for DNS](https://www.rfc-editor.org/rfc/rfc8945#section-6)
 /// ```text
 ///      +==========================+================+=================+
 ///      | Algorithm Name           | Implementation | Use             |
@@ -207,7 +207,7 @@ pub enum TsigAlgorithm {
 impl TSIG {
     /// Constructs a new TSIG
     ///
-    /// [RFC 8945, Secret Key Transaction Authentication for DNS](https://tools.ietf.org/html/rfc8945#section-4.1)
+    /// [RFC 8945, Secret Key Transaction Authentication for DNS](https://www.rfc-editor.org/rfc/rfc8945#section-4.1)
     ///
     /// ```text
     /// 4.1.  TSIG RR Type
@@ -771,7 +771,7 @@ pub fn signed_bitmessage_to_buf(
 
 /// Helper function to make a TSIG record from the name of the key, and the TSIG RData
 pub fn make_tsig_record(name: Name, rdata: TSIG) -> Record {
-    // https://tools.ietf.org/html/rfc8945#section-4.2
+    // https://www.rfc-editor.org/rfc/rfc8945#section-4.2
 
     let mut tsig = Record::new();
 

--- a/crates/proto/src/rr/dnssec/tbs.rs
+++ b/crates/proto/src/rr/dnssec/tbs.rs
@@ -225,7 +225,7 @@ pub fn rrset_tbs_with_sig(
     )
 }
 
-/// [RFC 4035](https://tools.ietf.org/html/rfc4035), DNSSEC Protocol Modifications, March 2005
+/// [RFC 4035](https://www.rfc-editor.org/rfc/rfc4035), DNSSEC Protocol Modifications, March 2005
 ///
 /// ```text
 ///

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -468,7 +468,7 @@ impl Name {
         Self::from_encoded_str::<LabelEncAscii>(name.as_ref(), None)
     }
 
-    // TODO: currently reserved to be private to the crate, due to confusion of IDNA vs. utf8 in https://tools.ietf.org/html/rfc6762#appendix-F
+    // TODO: currently reserved to be private to the crate, due to confusion of IDNA vs. utf8 in https://www.rfc-editor.org/rfc/rfc6762#appendix-F
     /// Will convert the string to a name using IDNA, punycode, to encode the UTF8 as necessary
     ///
     /// When making names IDNA compatible, there is a side-effect of lowercasing the name.

--- a/crates/proto/src/rr/domain/usage.rs
+++ b/crates/proto/src/rr/domain/usage.rs
@@ -7,7 +7,7 @@
 
 //! Reserved zone names.
 //!
-//! see [Special-Use Domain Names](https://tools.ietf.org/html/rfc6761), RFC 6761 February, 2013
+//! see [Special-Use Domain Names](https://www.rfc-editor.org/rfc/rfc6761), RFC 6761 February, 2013
 
 use std::ops::Deref;
 
@@ -31,7 +31,7 @@ lazy_static! {
 lazy_static! {
     /// localhost.
     ///
-    /// [Special-Use Domain Names](https://tools.ietf.org/html/rfc6761), RFC 6761 February, 2013
+    /// [Special-Use Domain Names](https://www.rfc-editor.org/rfc/rfc6761), RFC 6761 February, 2013
     ///
     /// ```text
     /// 6.3.  Domain Name Reservation Considerations for "localhost."
@@ -53,7 +53,7 @@ lazy_static! {
 lazy_static! {
     /// .local.
     ///
-    /// [Multicast DNS](https://tools.ietf.org/html/rfc6762), RFC 6762  February 2013
+    /// [Multicast DNS](https://www.rfc-editor.org/rfc/rfc6762), RFC 6762  February 2013
     ///
     /// ```text
     /// This document specifies that the DNS top-level domain ".local." is a
@@ -97,7 +97,7 @@ lazy_static! {
 lazy_static! {
     /// invalid.
     ///
-    /// [Special-Use Domain Names](https://tools.ietf.org/html/rfc6761), RFC 6761 February, 2013
+    /// [Special-Use Domain Names](https://www.rfc-editor.org/rfc/rfc6761), RFC 6761 February, 2013
     ///
     /// ```text
     /// 6.4.  Domain Name Reservation Considerations for "invalid."
@@ -115,7 +115,7 @@ lazy_static! {
 lazy_static! {
     /// invalid.
     ///
-    /// [The ".onion" Special-Use Domain Name](https://tools.ietf.org/html/rfc7686), RFC 7686 October, 2015
+    /// [The ".onion" Special-Use Domain Name](https://www.rfc-editor.org/rfc/rfc7686), RFC 7686 October, 2015
     ///
     /// ```text
     /// 1.  Introduction

--- a/crates/proto/src/rr/rdata/a.rs
+++ b/crates/proto/src/rr/rdata/a.rs
@@ -16,7 +16,7 @@
 
 //! IPv4 address record data
 //!
-//! [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+//! [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 //!
 //! ```text
 //! 3.4. Internet specific RRs

--- a/crates/proto/src/rr/rdata/aaaa.rs
+++ b/crates/proto/src/rr/rdata/aaaa.rs
@@ -16,7 +16,7 @@
 
 //! IPv6 address record data
 //!
-//! [RFC 3596, DNS Extensions to Support IPv6, October 2003](https://tools.ietf.org/html/rfc3596)
+//! [RFC 3596, DNS Extensions to Support IPv6, October 2003](https://www.rfc-editor.org/rfc/rfc3596)
 //!
 //! ```text
 //! 2.1 AAAA record type

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -35,7 +35,7 @@ use crate::serialize::binary::*;
 ///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// [rfc7477]: https://tools.ietf.org/html/rfc7477
+/// [rfc7477]: https://www.rfc-editor.org/rfc/rfc7477
 #[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CSYNC {
@@ -72,7 +72,7 @@ impl CSYNC {
         }
     }
 
-    /// [RFC 7477](https://tools.ietf.org/html/rfc7477#section-2.1.1.2.1), Child-to-Parent Synchronization in DNS, March 2015
+    /// [RFC 7477](https://www.rfc-editor.org/rfc/rfc7477#section-2.1.1.2.1), Child-to-Parent Synchronization in DNS, March 2015
     ///
     /// ```text
     /// 2.1.1.2.1.  The Type Bit Map Field
@@ -91,7 +91,7 @@ impl CSYNC {
         &self.type_bit_maps
     }
 
-    /// [RFC 7477](https://tools.ietf.org/html/rfc7477#section-2.1.1.2), Child-to-Parent Synchronization in DNS, March 2015
+    /// [RFC 7477](https://www.rfc-editor.org/rfc/rfc7477#section-2.1.1.2), Child-to-Parent Synchronization in DNS, March 2015
     ///
     /// ```text
     /// 2.1.1.2.  The Flags Field

--- a/crates/proto/src/rr/rdata/hinfo.rs
+++ b/crates/proto/src/rr/rdata/hinfo.rs
@@ -40,7 +40,7 @@ use crate::serialize::binary::*;
 /// when talking between machines or operating systems of the same type.
 /// ```
 ///
-/// [rfc1035]: https://tools.ietf.org/html/rfc1035
+/// [rfc1035]: https://www.rfc-editor.org/rfc/rfc1035
 #[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct HINFO {
@@ -114,7 +114,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, hinfo: &HINFO) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 1033](https://tools.ietf.org/html/rfc1033), DOMAIN OPERATIONS GUIDE, November 1987
+/// [RFC 1033](https://www.rfc-editor.org/rfc/rfc1033), DOMAIN OPERATIONS GUIDE, November 1987
 ///
 /// ```text
 /// HINFO (Host Info)

--- a/crates/proto/src/rr/rdata/mx.rs
+++ b/crates/proto/src/rr/rdata/mx.rs
@@ -25,7 +25,7 @@ use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
 
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// 3.3.9. MX RDATA format
@@ -67,7 +67,7 @@ impl MX {
         }
     }
 
-    /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+    /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
     ///
     /// ```text
     /// PREFERENCE      A 16 bit integer which specifies the preference given to
@@ -78,7 +78,7 @@ impl MX {
         self.preference
     }
 
-    /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+    /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
     ///
     /// ```text
     /// EXCHANGE        A <domain-name> which specifies a host willing to act as
@@ -97,7 +97,7 @@ pub fn read(decoder: &mut BinDecoder<'_>) -> ProtoResult<MX> {
     ))
 }
 
-/// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005
+/// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-6), DNSSEC Resource Records, March 2005
 ///
 /// ```text
 /// 6.2.  Canonical RR Form
@@ -121,7 +121,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, mx: &MX) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 1033](https://tools.ietf.org/html/rfc1033), DOMAIN OPERATIONS GUIDE, November 1987
+/// [RFC 1033](https://www.rfc-editor.org/rfc/rfc1033), DOMAIN OPERATIONS GUIDE, November 1987
 
 /// ```text
 ///   MX (Mail Exchanger)  (See RFC-974 for more details.)

--- a/crates/proto/src/rr/rdata/name.rs
+++ b/crates/proto/src/rr/rdata/name.rs
@@ -19,7 +19,7 @@
 //! A generic struct for all {*}NAME pointer RData records, CNAME, NS, and PTR. Here is the text for
 //! CNAME from RFC 1035, Domain Implementation and Specification, November 1987:
 //!
-//! [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+//! [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 //!
 //! ```text
 //! 3.3.1. CNAME RDATA format
@@ -48,7 +48,7 @@ pub fn read(decoder: &mut BinDecoder<'_>) -> ProtoResult<Name> {
     Name::read(decoder)
 }
 
-/// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005
+/// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-6), DNSSEC Resource Records, March 2005
 ///
 /// This is accurate for all currently known name records.
 ///

--- a/crates/proto/src/rr/rdata/naptr.rs
+++ b/crates/proto/src/rr/rdata/naptr.rs
@@ -16,7 +16,7 @@ use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
 
-/// [RFC 3403 DDDS DNS Database, October 2002](https://tools.ietf.org/html/rfc3403#section-4)
+/// [RFC 3403 DDDS DNS Database, October 2002](https://www.rfc-editor.org/rfc/rfc3403#section-4)
 ///
 /// ```text
 /// 4.1 Packet Format
@@ -233,7 +233,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, naptr: &NAPTR) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 2915](https://tools.ietf.org/html/rfc2915), NAPTR DNS RR, September 2000
+/// [RFC 2915](https://www.rfc-editor.org/rfc/rfc2915), NAPTR DNS RR, September 2000
 ///
 /// ```text
 /// Master File Format

--- a/crates/proto/src/rr/rdata/null.rs
+++ b/crates/proto/src/rr/rdata/null.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::*;
 use crate::serialize::binary::*;
 
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// 3.3.10. NULL RDATA format (EXPERIMENTAL)

--- a/crates/proto/src/rr/rdata/openpgpkey.rs
+++ b/crates/proto/src/rr/rdata/openpgpkey.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::*;
 use crate::serialize::binary::*;
 
-/// [RFC 7929](https://tools.ietf.org/html/rfc7929#section-2.1)
+/// [RFC 7929](https://www.rfc-editor.org/rfc/rfc7929#section-2.1)
 ///
 /// ```text
 /// The RDATA portion of an OPENPGPKEY resource record contains a single
@@ -60,7 +60,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, openpgpkey: &OPENPGPKEY) -> ProtoResul
 
 /// Parse the RData from a set of tokens.
 ///
-/// [RFC 7929](https://tools.ietf.org/html/rfc7929#section-2.3)
+/// [RFC 7929](https://www.rfc-editor.org/rfc/rfc7929#section-2.3)
 ///
 /// ```text
 /// 2.3.  The OPENPGPKEY RDATA Presentation Format

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -35,7 +35,7 @@ use crate::rr::dnssec::SupportedAlgorithms;
 /// These allow for additional information to be associated with the DNS request that otherwise
 /// would require changes to the DNS protocol.
 ///
-/// [RFC 6891, EDNS(0) Extensions, April 2013](https://tools.ietf.org/html/rfc6891#section-6)
+/// [RFC 6891, EDNS(0) Extensions, April 2013](https://www.rfc-editor.org/rfc/rfc6891#section-6)
 ///
 /// ```text
 /// 6.1.  OPT Record Definition
@@ -321,43 +321,43 @@ enum OptReadState {
 #[derive(Hash, Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EdnsCode {
-    /// [RFC 6891, Reserved](https://tools.ietf.org/html/rfc6891)
+    /// [RFC 6891, Reserved](https://www.rfc-editor.org/rfc/rfc6891)
     Zero,
 
-    /// [RFC 8764l, Apple's Long-Lived Queries, Optional](https://tools.ietf.org/html/rfc8764)
+    /// [RFC 8764l, Apple's Long-Lived Queries, Optional](https://www.rfc-editor.org/rfc/rfc8764)
     LLQ,
 
     /// [UL On-hold](http://files.dns-sd.org/draft-sekar-dns-ul.txt)
     UL,
 
-    /// [RFC 5001, NSID](https://tools.ietf.org/html/rfc5001)
+    /// [RFC 5001, NSID](https://www.rfc-editor.org/rfc/rfc5001)
     NSID,
     // 4 Reserved [draft-cheshire-edns0-owner-option] -EXPIRED-
-    /// [RFC 6975, DNSSEC Algorithm Understood](https://tools.ietf.org/html/rfc6975)
+    /// [RFC 6975, DNSSEC Algorithm Understood](https://www.rfc-editor.org/rfc/rfc6975)
     DAU,
 
-    /// [RFC 6975, DS Hash Understood](https://tools.ietf.org/html/rfc6975)
+    /// [RFC 6975, DS Hash Understood](https://www.rfc-editor.org/rfc/rfc6975)
     DHU,
 
-    /// [RFC 6975, NSEC3 Hash Understood](https://tools.ietf.org/html/rfc6975)
+    /// [RFC 6975, NSEC3 Hash Understood](https://www.rfc-editor.org/rfc/rfc6975)
     N3U,
 
-    /// [RFC 7871, Client Subnet, Optional](https://tools.ietf.org/html/rfc7871)
+    /// [RFC 7871, Client Subnet, Optional](https://www.rfc-editor.org/rfc/rfc7871)
     Subnet,
 
-    /// [RFC 7314, EDNS EXPIRE, Optional](https://tools.ietf.org/html/rfc7314)
+    /// [RFC 7314, EDNS EXPIRE, Optional](https://www.rfc-editor.org/rfc/rfc7314)
     Expire,
 
-    /// [RFC 7873, DNS Cookies](https://tools.ietf.org/html/rfc7873)
+    /// [RFC 7873, DNS Cookies](https://www.rfc-editor.org/rfc/rfc7873)
     Cookie,
 
-    /// [RFC 7828, edns-tcp-keepalive](https://tools.ietf.org/html/rfc7828)
+    /// [RFC 7828, edns-tcp-keepalive](https://www.rfc-editor.org/rfc/rfc7828)
     Keepalive,
 
-    /// [RFC 7830, The EDNS(0) Padding](https://tools.ietf.org/html/rfc7830)
+    /// [RFC 7830, The EDNS(0) Padding](https://www.rfc-editor.org/rfc/rfc7830)
     Padding,
 
-    /// [RFC 7901, CHAIN Query Requests in DNS, Optional](https://tools.ietf.org/html/rfc7901)
+    /// [RFC 7901, CHAIN Query Requests in DNS, Optional](https://www.rfc-editor.org/rfc/rfc7901)
     Chain,
 
     /// Unknown, used to deal with unknown or unsupported codes
@@ -418,17 +418,17 @@ impl From<EdnsCode> for u16 {
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Hash)]
 #[non_exhaustive]
 pub enum EdnsOption {
-    /// [RFC 6975, DNSSEC Algorithm Understood](https://tools.ietf.org/html/rfc6975)
+    /// [RFC 6975, DNSSEC Algorithm Understood](https://www.rfc-editor.org/rfc/rfc6975)
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
     DAU(SupportedAlgorithms),
 
-    /// [RFC 6975, DS Hash Understood](https://tools.ietf.org/html/rfc6975)
+    /// [RFC 6975, DS Hash Understood](https://www.rfc-editor.org/rfc/rfc6975)
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
     DHU(SupportedAlgorithms),
 
-    /// [RFC 6975, NSEC3 Hash Understood](https://tools.ietf.org/html/rfc6975)
+    /// [RFC 6975, NSEC3 Hash Understood](https://www.rfc-editor.org/rfc/rfc6975)
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
     N3U(SupportedAlgorithms),

--- a/crates/proto/src/rr/rdata/soa.rs
+++ b/crates/proto/src/rr/rdata/soa.rs
@@ -25,7 +25,7 @@ use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
 
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// 3.3.13. SOA RDATA format
@@ -228,7 +228,7 @@ pub fn read(decoder: &mut BinDecoder<'_>) -> ProtoResult<SOA> {
     })
 }
 
-/// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005
+/// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-6), DNSSEC Resource Records, March 2005
 ///
 /// This is accurate for all currently known name records.
 ///
@@ -259,7 +259,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, soa: &SOA) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 1033](https://tools.ietf.org/html/rfc1033), DOMAIN OPERATIONS GUIDE, November 1987
+/// [RFC 1033](https://www.rfc-editor.org/rfc/rfc1033), DOMAIN OPERATIONS GUIDE, November 1987
 ///
 /// ```text
 /// SOA  (Start Of Authority)

--- a/crates/proto/src/rr/rdata/srv.rs
+++ b/crates/proto/src/rr/rdata/srv.rs
@@ -24,7 +24,7 @@ use crate::error::*;
 use crate::rr::domain::Name;
 use crate::serialize::binary::*;
 
-/// [RFC 2782, DNS SRV RR, February 2000](https://tools.ietf.org/html/rfc2782)
+/// [RFC 2782, DNS SRV RR, February 2000](https://www.rfc-editor.org/rfc/rfc2782)
 ///
 /// ```text
 /// Introductory example
@@ -208,7 +208,7 @@ pub fn read(decoder: &mut BinDecoder<'_>) -> ProtoResult<SRV> {
     ))
 }
 
-/// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005
+/// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-6), DNSSEC Resource Records, March 2005
 ///
 /// This is accurate for all currently known name records.
 ///
@@ -237,7 +237,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, srv: &SRV) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 2782, DNS SRV RR, February 2000](https://tools.ietf.org/html/rfc2782)
+/// [RFC 2782, DNS SRV RR, February 2000](https://www.rfc-editor.org/rfc/rfc2782)
 ///
 /// ```text
 /// The format of the SRV RR

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -31,7 +31,7 @@ lazy_static! {
     };
 }
 
-/// [RFC 4255](https://tools.ietf.org/html/rfc4255#section-3.1)
+/// [RFC 4255](https://www.rfc-editor.org/rfc/rfc4255#section-3.1)
 ///
 /// ```text
 /// 3.1.  The SSHFP RDATA Format
@@ -117,9 +117,9 @@ impl SSHFP {
 /// ```
 ///
 /// The algorithm values have been updated in
-/// [RFC 6594](https://tools.ietf.org/html/rfc6594) and
-/// [RFC 7479](https://tools.ietf.org/html/rfc7479) and
-/// [RFC 8709](https://tools.ietf.org/html/rfc8709).
+/// [RFC 6594](https://www.rfc-editor.org/rfc/rfc6594) and
+/// [RFC 7479](https://www.rfc-editor.org/rfc/rfc7479) and
+/// [RFC 8709](https://www.rfc-editor.org/rfc/rfc8709).
 #[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Algorithm {
@@ -193,7 +193,7 @@ impl From<Algorithm> for u8 {
 /// ```
 ///
 /// The fingerprint type values have been updated in
-/// [RFC 6594](https://tools.ietf.org/html/rfc6594).
+/// [RFC 6594](https://www.rfc-editor.org/rfc/rfc6594).
 #[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum FingerprintType {
@@ -252,7 +252,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, sshfp: &SSHFP) -> ProtoResult<()> {
     encoder.emit_vec(sshfp.fingerprint())
 }
 
-/// [RFC 4255](https://tools.ietf.org/html/rfc4255#section-3.2)
+/// [RFC 4255](https://www.rfc-editor.org/rfc/rfc4255#section-3.2)
 ///
 /// ```text
 /// 3.2.  Presentation Format of the SSHFP RR

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -972,7 +972,7 @@ where
 {
     ///   The presentation "value" SHALL be a comma-separated list
     ///   (Appendix A.1) of one or more IP addresses of the appropriate family
-    ///   in standard textual format [RFC 5952](https://tools.ietf.org/html/rfc5952).  To enable simpler parsing,
+    ///   in standard textual format [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952).  To enable simpler parsing,
     ///   this SvcParamValue MUST NOT contain escape sequences.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         for ip in self.0.iter() {

--- a/crates/proto/src/rr/rdata/tlsa.rs
+++ b/crates/proto/src/rr/rdata/tlsa.rs
@@ -18,7 +18,7 @@ use super::sshfp;
 use crate::error::*;
 use crate::serialize::binary::*;
 
-/// [RFC 6698, DNS-Based Authentication for TLS](https://tools.ietf.org/html/rfc6698#section-2.1)
+/// [RFC 6698, DNS-Based Authentication for TLS](https://www.rfc-editor.org/rfc/rfc6698#section-2.1)
 ///
 /// ```text
 /// 2.1.  TLSA RDATA Wire Format
@@ -46,7 +46,7 @@ pub struct TLSA {
     cert_data: Vec<u8>,
 }
 
-/// [RFC 6698, DNS-Based Authentication for TLS](https://tools.ietf.org/html/rfc6698#section-2.1.1)
+/// [RFC 6698, DNS-Based Authentication for TLS](https://www.rfc-editor.org/rfc/rfc6698#section-2.1.1)
 ///
 /// ```text
 /// 2.1.1.  The Certificate Usage Field
@@ -165,7 +165,7 @@ impl From<CertUsage> for u8 {
     }
 }
 
-/// [RFC 6698, DNS-Based Authentication for TLS](https://tools.ietf.org/html/rfc6698#section-2.1.1)
+/// [RFC 6698, DNS-Based Authentication for TLS](https://www.rfc-editor.org/rfc/rfc6698#section-2.1.1)
 ///
 /// ```text
 /// 2.1.2.  The Selector Field
@@ -186,10 +186,10 @@ impl From<CertUsage> for u8 {
 #[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Selector {
-    /// Full certificate: the Certificate binary structure as defined in [RFC5280](https://tools.ietf.org/html/rfc5280)
+    /// Full certificate: the Certificate binary structure as defined in [RFC5280](https://www.rfc-editor.org/rfc/rfc5280)
     Full,
 
-    /// SubjectPublicKeyInfo: DER-encoded binary structure as defined in [RFC5280](https://tools.ietf.org/html/rfc5280)
+    /// SubjectPublicKeyInfo: DER-encoded binary structure as defined in [RFC5280](https://www.rfc-editor.org/rfc/rfc5280)
     Spki,
 
     /// Unassigned at the time of this writing
@@ -221,7 +221,7 @@ impl From<Selector> for u8 {
     }
 }
 
-/// [RFC 6698, DNS-Based Authentication for TLS](https://tools.ietf.org/html/rfc6698#section-2.1.3)
+/// [RFC 6698, DNS-Based Authentication for TLS](https://www.rfc-editor.org/rfc/rfc6698#section-2.1.3)
 ///
 /// ```text
 /// 2.1.3.  The Matching Type Field
@@ -248,10 +248,10 @@ pub enum Matching {
     /// Exact match on selected content
     Raw,
 
-    /// SHA-256 hash of selected content [RFC6234](https://tools.ietf.org/html/rfc6234)
+    /// SHA-256 hash of selected content [RFC6234](https://www.rfc-editor.org/rfc/rfc6234)
     Sha256,
 
-    /// SHA-512 hash of selected content [RFC6234](https://tools.ietf.org/html/rfc6234)
+    /// SHA-512 hash of selected content [RFC6234](https://www.rfc-editor.org/rfc/rfc6234)
     Sha512,
 
     /// Unassigned at the time of this writing
@@ -288,7 +288,7 @@ impl From<Matching> for u8 {
 impl TLSA {
     /// Constructs a new TLSA
     ///
-    /// [RFC 6698, DNS-Based Authentication for TLS](https://tools.ietf.org/html/rfc6698#section-2)
+    /// [RFC 6698, DNS-Based Authentication for TLS](https://www.rfc-editor.org/rfc/rfc6698#section-2)
     ///
     /// ```text
     /// 2.  The TLSA Resource Record
@@ -382,7 +382,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, tlsa: &TLSA) -> ProtoResult<()> {
     Ok(())
 }
 
-/// [RFC 6698, DNS-Based Authentication for TLS](https://tools.ietf.org/html/rfc6698#section-2.2)
+/// [RFC 6698, DNS-Based Authentication for TLS](https://www.rfc-editor.org/rfc/rfc6698#section-2.2)
 ///
 /// ```text
 /// 2.2.  TLSA RR Presentation Format

--- a/crates/proto/src/rr/rdata/txt.rs
+++ b/crates/proto/src/rr/rdata/txt.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::*;
 use crate::serialize::binary::*;
 
-/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
+/// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://www.rfc-editor.org/rfc/rfc1035)
 ///
 /// ```text
 /// 3.3.14. TXT RDATA format

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -34,7 +34,7 @@ use super::dnssec::rdata::DNSSECRData;
 
 /// Record data enum variants
 ///
-/// [RFC 1035](https://tools.ietf.org/html/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
+/// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
 ///
 /// ```text
 /// 3.3. Standard RRs
@@ -210,7 +210,7 @@ pub enum RData {
     /// when talking between machines or operating systems of the same type.
     /// ```
     ///
-    /// `HINFO` is also used by [RFC 8482](https://tools.ietf.org/html/rfc8482)
+    /// `HINFO` is also used by [RFC 8482](https://www.rfc-editor.org/rfc/rfc8482)
     HINFO(HINFO),
 
     /// [RFC draft-ietf-dnsop-svcb-https-03, DNS SVCB and HTTPS RRs](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-8)
@@ -261,7 +261,7 @@ pub enum RData {
     /// ```
     MX(MX),
 
-    /// [RFC 3403 DDDS DNS Database, October 2002](https://tools.ietf.org/html/rfc3403#section-4)
+    /// [RFC 3403 DDDS DNS Database, October 2002](https://www.rfc-editor.org/rfc/rfc3403#section-4)
     ///
     /// ```text
     /// 4.1 Packet Format
@@ -415,7 +415,7 @@ pub enum RData {
     /// ```
     NS(Name),
 
-    /// [RFC 7929](https://tools.ietf.org/html/rfc7929#section-2.1)
+    /// [RFC 7929](https://www.rfc-editor.org/rfc/rfc7929#section-2.1)
     ///
     /// ```text
     /// The RDATA portion of an OPENPGPKEY resource record contains a single
@@ -553,7 +553,7 @@ pub enum RData {
     /// ```
     SRV(SRV),
 
-    /// [RFC 4255](https://tools.ietf.org/html/rfc4255#section-3.1)
+    /// [RFC 4255](https://www.rfc-editor.org/rfc/rfc4255#section-3.1)
     ///
     /// ```text
     /// 3.1.  The SSHFP RDATA Format
@@ -611,8 +611,8 @@ pub enum RData {
     /// ```
     ///
     /// The algorithm and fingerprint type values have been updated in
-    /// [RFC 6594](https://tools.ietf.org/html/rfc6594) and
-    /// [RFC 7479](https://tools.ietf.org/html/rfc7479).
+    /// [RFC 6594](https://www.rfc-editor.org/rfc/rfc6594) and
+    /// [RFC 7479](https://www.rfc-editor.org/rfc/rfc7479).
     SSHFP(SSHFP),
 
     /// [RFC draft-ietf-dnsop-svcb-https-03, DNS SVCB and HTTPS RRs](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-2)
@@ -640,7 +640,7 @@ pub enum RData {
     /// ```
     SVCB(SVCB),
 
-    /// [RFC 6698, DNS-Based Authentication for TLS](https://tools.ietf.org/html/rfc6698#section-2.1)
+    /// [RFC 6698, DNS-Based Authentication for TLS](https://www.rfc-editor.org/rfc/rfc6698#section-2.1)
     ///
     /// ```text
     ///                         1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
@@ -835,7 +835,7 @@ impl RData {
         result
     }
 
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005
+    /// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-6), DNSSEC Resource Records, March 2005
     ///
     /// ```text
     /// 6.2.  Canonical RR Form
@@ -853,7 +853,7 @@ impl RData {
     /// ```
     ///
     /// Canonical name form for all non-1035 records:
-    ///   [RFC 3579](https://tools.ietf.org/html/rfc3597)
+    ///   [RFC 3579](https://www.rfc-editor.org/rfc/rfc3597)
     /// ```text
     ///  4.  Domain Name Compression
     ///

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::*;
 use crate::serialize::binary::*;
 
-// TODO: adopt proper restrictions on usage: https://tools.ietf.org/html/rfc6895 section 3.1
+// TODO: adopt proper restrictions on usage: https://www.rfc-editor.org/rfc/rfc6895 section 3.1
 //  add the data TYPEs, QTYPEs, and Meta-TYPEs
 //
 
@@ -32,88 +32,88 @@ use crate::serialize::binary::*;
 #[allow(dead_code)]
 #[non_exhaustive]
 pub enum RecordType {
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) IPv4 Address record
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) IPv4 Address record
     A,
-    /// [RFC 3596](https://tools.ietf.org/html/rfc3596) IPv6 address record
+    /// [RFC 3596](https://www.rfc-editor.org/rfc/rfc3596) IPv6 address record
     AAAA,
-    /// [ANAME draft-ietf-dnsop-aname](https://tools.ietf.org/html/draft-ietf-dnsop-aname-04)
+    /// [ANAME draft-ietf-dnsop-aname](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-aname-04)
     ANAME,
     //  AFSDB,      //	18	RFC 1183	AFS database record
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) All cached records, aka ANY
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) All cached records, aka ANY
     ANY,
     //  APL,        //	42	RFC 3123	Address Prefix List
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) Authoritative Zone Transfer
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) Authoritative Zone Transfer
     AXFR,
-    /// [RFC 6844](https://tools.ietf.org/html/rfc6844) Certification Authority Authorization
+    /// [RFC 6844](https://www.rfc-editor.org/rfc/rfc6844) Certification Authority Authorization
     CAA,
-    /// [RFC 7344](https://tools.ietf.org/html/rfc7344) Child DS
+    /// [RFC 7344](https://www.rfc-editor.org/rfc/rfc7344) Child DS
     CDS,
-    /// [RFC 7344](https://tools.ietf.org/html/rfc7344) Child DNSKEY
+    /// [RFC 7344](https://www.rfc-editor.org/rfc/rfc7344) Child DNSKEY
     CDNSKEY,
     //  CERT,       // 37 RFC 4398 Certificate record
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) Canonical name record
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) Canonical name record
     CNAME,
     //  DHCID,      // 49 RFC 4701 DHCP identifier
     //  DLV,        //	32769	RFC 4431	DNSSEC Lookaside Validation record
     //  DNAME,      // 39 RFC 2672 Delegation Name
-    /// [RFC 7477](https://tools.ietf.org/html/rfc4034) Child-to-parent synchronization record
+    /// [RFC 7477](https://www.rfc-editor.org/rfc/rfc4034) Child-to-parent synchronization record
     CSYNC,
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034) DNS Key record: RSASHA256 and RSASHA512, RFC5702
+    /// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034) DNS Key record: RSASHA256 and RSASHA512, RFC5702
     DNSKEY,
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034) Delegation signer: RSASHA256 and RSASHA512, RFC5702
+    /// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034) Delegation signer: RSASHA256 and RSASHA512, RFC5702
     DS,
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) host information
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) host information
     HINFO,
     //  HIP,        // 55 RFC 5205 Host Identity Protocol
-    /// [RFC draft-ietf-dnsop-svcb-https-03](https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-03) DNS SVCB and HTTPS RRs
+    /// [RFC draft-ietf-dnsop-svcb-https-03](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-httpssvc-03) DNS SVCB and HTTPS RRs
     HTTPS,
     //  IPSECKEY,   // 45 RFC 4025 IPsec Key
-    /// [RFC 1996](https://tools.ietf.org/html/rfc1996) Incremental Zone Transfer
+    /// [RFC 1996](https://www.rfc-editor.org/rfc/rfc1996) Incremental Zone Transfer
     IXFR,
     //  KX,         // 36 RFC 2230 Key eXchanger record
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535) and [RFC 2930](https://tools.ietf.org/html/rfc2930) Key record
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535) and [RFC 2930](https://www.rfc-editor.org/rfc/rfc2930) Key record
     KEY,
     //  LOC,        // 29 RFC 1876 Location record
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) Mail exchange record
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) Mail exchange record
     MX,
-    /// [RFC 3403](https://tools.ietf.org/html/rfc3403) Naming Authority Pointer
+    /// [RFC 3403](https://www.rfc-editor.org/rfc/rfc3403) Naming Authority Pointer
     NAPTR,
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) Name server record
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) Name server record
     NS,
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034) Next-Secure record
+    /// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034) Next-Secure record
     NSEC,
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155) NSEC record version 3
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155) NSEC record version 3
     NSEC3,
-    /// [RFC 5155](https://tools.ietf.org/html/rfc5155) NSEC3 parameters
+    /// [RFC 5155](https://www.rfc-editor.org/rfc/rfc5155) NSEC3 parameters
     NSEC3PARAM,
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) Null server record, for testing
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) Null server record, for testing
     NULL,
-    /// [RFC 7929](https://tools.ietf.org/html/rfc7929) OpenPGP public key
+    /// [RFC 7929](https://www.rfc-editor.org/rfc/rfc7929) OpenPGP public key
     OPENPGPKEY,
-    /// [RFC 6891](https://tools.ietf.org/html/rfc6891) Option
+    /// [RFC 6891](https://www.rfc-editor.org/rfc/rfc6891) Option
     OPT,
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) Pointer record
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) Pointer record
     PTR,
     //  RP,         // 17 RFC 1183 Responsible person
-    /// [RFC 4034](https://tools.ietf.org/html/rfc4034) DNSSEC signature: RSASHA256 and RSASHA512, RFC5702
+    /// [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034) DNSSEC signature: RSASHA256 and RSASHA512, RFC5702
     RRSIG,
-    /// [RFC 2535](https://tools.ietf.org/html/rfc2535) (and [RFC 2931](https://tools.ietf.org/html/rfc2931)) Signature, to support [RFC 2137](https://tools.ietf.org/html/rfc2137) Update.
+    /// [RFC 2535](https://www.rfc-editor.org/rfc/rfc2535) (and [RFC 2931](https://www.rfc-editor.org/rfc/rfc2931)) Signature, to support [RFC 2137](https://www.rfc-editor.org/rfc/rfc2137) Update.
     SIG,
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) and [RFC 2308](https://tools.ietf.org/html/rfc2308) Start of [a zone of] authority record
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) and [RFC 2308](https://www.rfc-editor.org/rfc/rfc2308) Start of [a zone of] authority record
     SOA,
-    /// [RFC 2782](https://tools.ietf.org/html/rfc2782) Service locator
+    /// [RFC 2782](https://www.rfc-editor.org/rfc/rfc2782) Service locator
     SRV,
-    /// [RFC 4255](https://tools.ietf.org/html/rfc4255) SSH Public Key Fingerprint
+    /// [RFC 4255](https://www.rfc-editor.org/rfc/rfc4255) SSH Public Key Fingerprint
     SSHFP,
-    /// [RFC draft-ietf-dnsop-svcb-https-03](https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-03) DNS SVCB and HTTPS RRs
+    /// [RFC draft-ietf-dnsop-svcb-https-03](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-httpssvc-03) DNS SVCB and HTTPS RRs
     SVCB,
     //  TA,         // 32768 N/A DNSSEC Trust Authorities
     //  TKEY,       // 249 RFC 2930 Secret key record
-    /// [RFC 6698](https://tools.ietf.org/html/rfc6698) TLSA certificate association
+    /// [RFC 6698](https://www.rfc-editor.org/rfc/rfc6698) TLSA certificate association
     TLSA,
-    /// [RFC 8945](https://tools.ietf.org/html/rfc8945) Transaction Signature
+    /// [RFC 8945](https://www.rfc-editor.org/rfc/rfc8945) Transaction Signature
     TSIG,
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035) Text record
+    /// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) Text record
     TXT,
     /// Unknown Record type, or unsupported
     Unknown(u16),
@@ -422,14 +422,14 @@ impl From<RecordType> for u16 {
     }
 }
 
-/// [Canonical DNS Name Order](https://tools.ietf.org/html/rfc4034#section-6)
+/// [Canonical DNS Name Order](https://www.rfc-editor.org/rfc/rfc4034#section-6)
 impl PartialOrd<Self> for RecordType {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-/// [Canonical DNS Name Order](https://tools.ietf.org/html/rfc4034#section-6)
+/// [Canonical DNS Name Order](https://www.rfc-editor.org/rfc/rfc4034#section-6)
 impl Ord for RecordType {
     fn cmp(&self, other: &Self) -> Ordering {
         u16::from(*self).cmp(&u16::from(*other))

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -34,7 +34,7 @@ use crate::rr::RecordType;
 use crate::serialize::binary::*;
 
 #[cfg(feature = "mdns")]
-/// From [RFC 6762](https://tools.ietf.org/html/rfc6762#section-10.2)
+/// From [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762#section-10.2)
 /// ```text
 /// The cache-flush bit is the most significant bit of the second
 /// 16-bit word of a resource record in a Resource Record Section of a
@@ -47,7 +47,7 @@ const MDNS_ENABLE_CACHE_FLUSH: u16 = 1 << 15;
 const NULL_RDATA: &RData = &RData::NULL(NULL::new());
 /// Resource records are storage value in DNS, into which all key/value pair data is stored.
 ///
-/// [RFC 1035](https://tools.ietf.org/html/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
+/// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
 ///
 /// ```text
 /// 4.1.3. Resource record format
@@ -234,7 +234,7 @@ impl Record {
     }
 
     /// Changes mDNS cache-flush bit
-    /// See [RFC 6762](https://tools.ietf.org/html/rfc6762#section-10.2)
+    /// See [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762#section-10.2)
     #[cfg(feature = "mdns")]
     #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
     pub fn set_mdns_cache_flush(&mut self, flag: bool) -> &mut Self {
@@ -284,7 +284,7 @@ impl Record {
     }
 
     /// Returns if the mDNS cache-flush bit is set or not
-    /// See [RFC 6762](https://tools.ietf.org/html/rfc6762#section-10.2)
+    /// See [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762#section-10.2)
     #[cfg(feature = "mdns")]
     #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
     pub fn mdns_cache_flush(&self) -> bool {
@@ -500,7 +500,7 @@ impl<'r> BinDecodable<'r> for Record {
     }
 }
 
-/// [RFC 1033](https://tools.ietf.org/html/rfc1033), DOMAIN OPERATIONS GUIDE, November 1987
+/// [RFC 1033](https://www.rfc-editor.org/rfc/rfc1033), DOMAIN OPERATIONS GUIDE, November 1987
 ///
 /// ```text
 ///   RESOURCE RECORDS
@@ -563,7 +563,7 @@ impl fmt::Display for Record {
 
 impl PartialEq for Record {
     /// Equality or records, as defined by
-    ///  [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    ///  [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///   1.1.1. Two RRs are considered equal if their NAME, CLASS, TYPE,
@@ -594,7 +594,7 @@ macro_rules! compare_or_equal {
 
 impl Ord for Record {
     /// Canonical ordering as defined by
-    ///  [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005
+    ///  [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-6), DNSSEC Resource Records, March 2005
     ///
     /// ```text
     /// 6.2.  Canonical RR Form
@@ -639,7 +639,7 @@ impl Ord for Record {
 
 impl PartialOrd<Self> for Record {
     /// Canonical ordering as defined by
-    ///  [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6), DNSSEC Resource Records, March 2005
+    ///  [RFC 4034](https://www.rfc-editor.org/rfc/rfc4034#section-6), DNSSEC Resource Records, March 2005
     ///
     /// ```text
     /// 6.2.  Canonical RR Form

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -326,7 +326,7 @@ impl RecordSet {
             //         to have more than one CNAME RR, even if their data fields
             //         differ.
             //
-            // ANAME https://tools.ietf.org/html/draft-ietf-dnsop-aname-02
+            // ANAME https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-aname-02
             //    2.2.  Coexistence with other types
             //
             //   Only one ANAME <target> can be defined per <owner>.  An ANAME RRset

--- a/crates/proto/src/rustls/tls_stream.rs
+++ b/crates/proto/src/rustls/tls_stream.rs
@@ -48,7 +48,7 @@ pub fn tls_from_stream<S: DnsTcpStream>(
 
 /// Creates a new TlsStream to the specified name_server
 ///
-/// [RFC 7858](https://tools.ietf.org/html/rfc7858), DNS over TLS, May 2016
+/// [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858), DNS over TLS, May 2016
 ///
 /// ```text
 /// 3.2.  TLS Handshake and Authentication

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -195,7 +195,7 @@ impl<'a> BinEncoder<'a> {
         self.canonical_names
     }
 
-    /// Emit all names in canonical form, useful for <https://tools.ietf.org/html/rfc3597>
+    /// Emit all names in canonical form, useful for <https://www.rfc-editor.org/rfc/rfc3597>
     pub fn with_canonical_names<F: FnOnce(&mut Self) -> ProtoResult<()>>(
         &mut self,
         f: F,

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -141,7 +141,7 @@ impl DnsResponse {
     /// Looks in the authority section for an SOA record from the response, and returns the negative_ttl, None if not available.
     ///
     /// ```text
-    /// [RFC 2308](https://tools.ietf.org/html/rfc2308#section-5) DNS NCACHE March 1998
+    /// [RFC 2308](https://www.rfc-editor.org/rfc/rfc2308#section-5) DNS NCACHE March 1998
     ///
     /// 5 - Caching Negative Answers
     ///
@@ -313,7 +313,7 @@ impl From<Message> for DnsResponse {
 }
 
 /// ```text
-/// [RFC 2308](https://tools.ietf.org/html/rfc2308#section-2) DNS NCACHE March 1998
+/// [RFC 2308](https://www.rfc-editor.org/rfc/rfc2308#section-2) DNS NCACHE March 1998
 ///
 ///
 /// 2 - Negative Responses

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -44,7 +44,7 @@ if address.is_ipv4() {
 }
 ```
 
-## DNS-over-TLS and DNS-over-HTTPS
+## DNS over TLS and DNS over HTTPS
 
 DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires only requires valid DoT or DoH resolvers being registered in order to be used.
 

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -17,6 +17,7 @@ This library contains implementations for IPv4 (A) and IPv6 (AAAA) resolution, m
 - _experimental_ mDNS support (enable with `mdns` feature)
 - DNS over TLS (utilizing `native-tls`, `rustls`, and `openssl`; `native-tls` or `rustls` are recommended)
 - DNS over HTTPS (currently only supports `rustls`)
+- DNS over QUIC
 
 ## Example
 
@@ -44,13 +45,15 @@ if address.is_ipv4() {
 }
 ```
 
-## DNS over TLS and DNS over HTTPS
+## DNS over QUIC, DNS over TLS and DNS over HTTPS
 
-DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires only requires valid DoT or DoH resolvers being registered in order to be used.
+DoQ, DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires only valid DoQ, DoT or DoH resolvers being registered in order to be used.
 
 To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` should be used. Similarly, to use with the tokio `AsyncClient` the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
+
+To enable DoQ, the feature `dns-over-quic` must be enabled.
 
 ### Example
 

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -110,7 +110,7 @@ where
         mut client: Self,
         preserved_records: Vec<(Record, u32)>,
     ) -> Result<Lookup, ResolveError> {
-        // see https://tools.ietf.org/html/rfc6761
+        // see https://www.rfc-editor.org/rfc/rfc6761
         //
         // ```text
         // Name resolution APIs and libraries SHOULD recognize localhost
@@ -247,7 +247,7 @@ where
         self.lru.get(query, Instant::now())
     }
 
-    /// See https://tools.ietf.org/html/rfc2308
+    /// See https://www.rfc-editor.org/rfc/rfc2308
     ///
     /// For now we will regard NXDomain to strictly mean the query failed
     ///  and a record for the name, regardless of CNAME presence, what have you
@@ -438,7 +438,7 @@ where
                 min_ttl: cname_ttl,
             })
         } else {
-            // TODO: review See https://tools.ietf.org/html/rfc2308 for NoData section
+            // TODO: review See https://www.rfc-editor.org/rfc/rfc2308 for NoData section
             // Note on DNSSEC, in secure_client_handle, if verify_nsec fails then the request fails.
             //   this will mean that no unverified negative caches will make it to this point and be stored
             Err(Self::handle_nxdomain(

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -561,7 +561,7 @@ impl NameServerConfigGroup {
         name_servers
     }
 
-    /// Configure a NameServer address and port for DNS-over-TLS
+    /// Configure a NameServer address and port for DNS over TLS
     ///
     /// This will create a TLS connections.
     #[cfg(feature = "dns-over-tls")]
@@ -575,7 +575,7 @@ impl NameServerConfigGroup {
         Self::from_ips_encrypted(ips, port, tls_dns_name, Protocol::Tls, trust_nx_responses)
     }
 
-    /// Configure a NameServer address and port for DNS-over-HTTPS
+    /// Configure a NameServer address and port for DNS over HTTPS
     ///
     /// This will create a HTTPS connections.
     #[cfg(feature = "dns-over-https")]

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -22,7 +22,7 @@ use crate::config;
 use crate::error::*;
 use crate::lookup::Lookup;
 
-/// Maximum TTL as defined in https://tools.ietf.org/html/rfc2181, 2147483647
+/// Maximum TTL as defined in https://www.rfc-editor.org/rfc/rfc2181, 2147483647
 ///   Setting this to a value of 1 day, in seconds
 pub(crate) const MAX_TTL: u32 = 86400_u32;
 

--- a/crates/resolver/src/dns_sd.rs
+++ b/crates/resolver/src/dns_sd.rs
@@ -29,14 +29,14 @@ use crate::AsyncResolver;
 pub trait DnsSdHandle {
     /// List all services available
     ///
-    /// <https://tools.ietf.org/html/rfc6763#section-4.1>
+    /// <https://www.rfc-editor.org/rfc/rfc6763#section-4.1>
     ///
     /// For registered service types, see: <https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml>
     fn list_services(&self, name: Name) -> ListServicesFuture;
 
     /// Retrieve service information
     ///
-    /// <https://tools.ietf.org/html/rfc6763#section-6>
+    /// <https://www.rfc-editor.org/rfc/rfc6763#section-6>
     fn service_info(&self, name: Name) -> ServiceInfoFuture;
 }
 
@@ -131,7 +131,7 @@ pub struct ServiceInfo(TxtLookup);
 impl ServiceInfo {
     /// Returns this as a map, this allocates a new hashmap
     ///
-    /// This converts the DNS-SD TXT record into a map following the rules specified in <https://tools.ietf.org/html/rfc6763#section-6.4>
+    /// This converts the DNS-SD TXT record into a map following the rules specified in <https://www.rfc-editor.org/rfc/rfc6763#section-6.4>
     pub fn to_map(&self) -> HashMap<Cow<'_, str>, Option<Cow<'_, str>>> {
         self.0
             .iter()

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -173,25 +173,25 @@
 //! Inside the `Future::poll` method would be the place to implement a loop over the different IP
 //! addresses.
 //!
-//! ## DNS over TLS and DNS over HTTPS
+//! ## DNS over QUIC, DNS over TLS and DNS over HTTPS
 //!
-//! DNS over TLS and DNS over HTTPS are supported in the Trust-DNS Resolver library. The underlying
-//! implementations are available as addon libraries. *WARNING* The trust-dns developers make no
-//! claims on the security and/or privacy guarantees of this implementation.
+//! DNS over QUIC, DNS over TLS and DNS over HTTPS are supported in the Trust-DNS Resolver library. 
+//! The underlying implementations are available as addon libraries. *WARNING* The trust-dns developers
+//! make no claims on the security and/or privacy guarantees of this implementation.
 //!
 //! To use DNS over TLS one of the `dns-over-tls` features must be enabled at compile time. There
-//! are three: `dns-over-openssl`, `dns-over-native-tls`, and `dns-over-rustls`. For DNS over HTTPS
-//! only rustls is supported with the `dns-over-https-rustls`, this implicitly enables support for
-//! DNS over TLS as well. The reason for each is to make the Trust-DNS libraries flexible for
-//! different deployments, and/or security concerns. The easiest to use will generally be
-//! `dns-over-rustls` which utilizes the `*ring*` Rust cryptography library (a rework of the
-//! `boringssl` project), this should compile and be usable on most ARM and x86 platforms.
-//! `dns-over-native-tls` will utilize the hosts TLS implementation where available or fallback to
-//! `openssl` where not supported. `dns-over-openssl` will specify that `openssl` should be used
-//! (which is a perfectly fine option if required). If more than one is specified, the precedence
-//! will be in this order (i.e. only one can be used at a time) `dns-over-rustls`,
-//! `dns-over-native-tls`, and then `dns-over-openssl`. *NOTICE* the trust-dns developers are not
-//! responsible for any choice of library that does not meet required security requirements.
+//! are three: `dns-over-openssl`, `dns-over-native-tls`, and `dns-over-rustls`. For DNS over QUIC,
+//! the `dns-over-quic` feature must be enabled. For DNS over HTTPS only rustls is supported with 
+//! the `dns-over-https-rustls`, this implicitly enables support for DNS over TLS as well. The reason
+//! for each is to make the Trust-DNS libraries flexible for different deployments, and/or security 
+//! concerns. The easiest to use will generally be `dns-over-rustls` which utilizes the `*ring*` Rust
+//! cryptography library (a rework of the `boringssl` project), this should compile and be usable on 
+//! most ARM and x86 platforms. `dns-over-native-tls` will utilize the hosts TLS implementation where
+//! available or fallback to `openssl` where not supported. `dns-over-openssl` will specify that 
+//! `openssl` should be used (which is a perfectly fine option if required). If more than one is 
+//! specified, the precedence will be in this order (i.e. only one can be used at a time) 
+//! `dns-over-rustls`, `dns-over-native-tls`, and then `dns-over-openssl`. *NOTICE* the trust-dns 
+//! developers are not responsible for any choice of library that does not meet required security requirements.
 //!
 //! ### Example
 //!

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -173,16 +173,16 @@
 //! Inside the `Future::poll` method would be the place to implement a loop over the different IP
 //! addresses.
 //!
-//! ## DNS-over-TLS and DNS-over-HTTPS
+//! ## DNS over TLS and DNS over HTTPS
 //!
-//! DNS-over-TLS and DNS-over-HTTPS are supported in the Trust-DNS Resolver library. The underlying
+//! DNS over TLS and DNS over HTTPS are supported in the Trust-DNS Resolver library. The underlying
 //! implementations are available as addon libraries. *WARNING* The trust-dns developers make no
 //! claims on the security and/or privacy guarantees of this implementation.
 //!
-//! To use DNS-over-TLS one of the `dns-over-tls` features must be enabled at compile time. There
-//! are three: `dns-over-openssl`, `dns-over-native-tls`, and `dns-over-rustls`. For DNS-over-HTTPS
+//! To use DNS over TLS one of the `dns-over-tls` features must be enabled at compile time. There
+//! are three: `dns-over-openssl`, `dns-over-native-tls`, and `dns-over-rustls`. For DNS over HTTPS
 //! only rustls is supported with the `dns-over-https-rustls`, this implicitly enables support for
-//! DNS-over-TLS as well. The reason for each is to make the Trust-DNS libraries flexible for
+//! DNS over TLS as well. The reason for each is to make the Trust-DNS libraries flexible for
 //! different deployments, and/or security concerns. The easiest to use will generally be
 //! `dns-over-rustls` which utilizes the `*ring*` Rust cryptography library (a rework of the
 //! `boringssl` project), this should compile and be usable on most ARM and x86 platforms.

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -8,6 +8,7 @@ This library contains basic implementations for DNS zone hosting. It is capable 
 
 - Dynamic Update with sqlite journaling backend (SIG0)
 - DNSSEC online signing (NSEC not NSEC3)
+- DNS over QUIC (DoQ)
 - DNS over TLS (DoT)
 - DNS over HTTPS (DoH)
 - Forwarding stub resolver

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -201,7 +201,7 @@ impl Catalog {
 
     /// Update the zone given the Update request.
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     /// 3.1 - Process Zone Section

--- a/crates/server/src/authority/message_request.rs
+++ b/crates/server/src/authority/message_request.rs
@@ -122,7 +122,7 @@ impl MessageRequest {
         &self.additionals
     }
 
-    /// [RFC 6891, EDNS(0) Extensions, April 2013](https://tools.ietf.org/html/rfc6891#section-6.1.1)
+    /// [RFC 6891, EDNS(0) Extensions, April 2013](https://www.rfc-editor.org/rfc/rfc6891#section-6.1.1)
     ///
     /// ```text
     /// 6.1.1.  Basic Elements

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -928,7 +928,7 @@ impl Authority for InMemoryAuthority {
 
     /// Takes the UpdateMessage, extracts the Records, and applies the changes to the record set.
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -226,7 +226,7 @@ impl SqliteAuthority {
         self.in_memory.serial().await
     }
 
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///
@@ -423,7 +423,7 @@ impl SqliteAuthority {
         Ok(())
     }
 
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///
@@ -535,7 +535,7 @@ impl SqliteAuthority {
         Err(ResponseCode::Refused)
     }
 
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///
@@ -632,7 +632,7 @@ impl SqliteAuthority {
 
     /// Updates the specified records according to the update section.
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///
@@ -862,7 +862,7 @@ impl Authority for SqliteAuthority {
 
     /// Takes the UpdateMessage, extracts the Records, and applies the changes to the record set.
     ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
+    /// [RFC 2136](https://www.rfc-editor.org/rfc/rfc2136), DNS Update, April 1997
     ///
     /// ```text
     ///


### PR DESCRIPTION
This PR:
 - shows the support for DNS over QUIC in comments and README files ;
 - fixes DNS-over-* typos: RFCs shows _DNS over TLS_, _DNS over HTTPS_, _DNS over QUIC_ without dashes ;
 - update URLs for RFCs and Internet Drafts because of [the transition from tools.ietf.org](https://github.com/ietf-tools/tools-transition-plan).

----

fixes: #1837