### PR TITLE
authority: parse with default record class IN.

### DIFF
--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -488,4 +488,37 @@ mod tests {
             result
         );
     }
+
+    #[test]
+    fn test_zone_parse_default_class() {
+        let domain = Name::from_str("example.com.").unwrap();
+
+        let zone_data = r#"example.com.  	3600	SOA	ns1.example.com. contact.example.com. 2022100601 3600 900 1209600 86400"#;
+        let lexer = Lexer::new(zone_data);
+        // NOTE: We specify a default class of DNSClass:IN, so no error should occur even though the
+        // zone data doesn't provide one.
+        let result = Parser::new().parse(lexer, Some(domain), Option::Some(DNSClass::IN));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_zone_parse_missing_class() {
+        let domain = Name::from_str("example.com.").unwrap();
+
+        let zone_data = r#"example.com.  	3600	SOA	ns1.example.com. contact.example.com. 2022100601 3600 900 1209600 86400"#;
+        let lexer = Lexer::new(zone_data);
+        // NOTE: We specify no default class, so an error should occur since the zone data does not
+        // provide one.
+        let result = Parser::new().parse(lexer, Some(domain), None);
+        assert!(
+            result.is_err()
+                & result
+                    .as_ref()
+                    .unwrap_err()
+                    .to_string()
+                    .contains("record class not specified"),
+            "unexpected success: {:#?}",
+            result
+        );
+    }
 }

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 use tracing::{debug, info};
+use trust_dns_proto::rr::DNSClass;
 
 #[cfg(feature = "dnssec")]
 use crate::{
@@ -197,7 +198,7 @@ impl FileAuthority {
 
         let lexer = Lexer::new(&buf);
         let (origin, records) = Parser::new()
-            .parse(lexer, Some(origin), None)
+            .parse(lexer, Some(origin), Some(DNSClass::IN))
             .map_err(|e| format!("failed to parse {}: {:?}", config.zone_file_path, e))?;
 
         info!(

--- a/crates/server/tests/store_file_tests.rs
+++ b/crates/server/tests/store_file_tests.rs
@@ -48,6 +48,22 @@ fn test_all_lines_are_loaded() {
     assert!(authority.records_get_mut().get(&rrkey).is_some())
 }
 
+#[test]
+fn test_implicit_in_class() {
+    let config = FileConfig {
+        zone_file_path: "../../tests/test-data/test_configs/default/implicitclass.zone".to_string(),
+    };
+
+    let authority = FileAuthority::try_from_config(
+        Name::from_str("example.com.").unwrap(),
+        ZoneType::Primary,
+        false,
+        None,
+        &config,
+    );
+    assert!(authority.is_ok());
+}
+
 #[tokio::test]
 async fn test_ttl_wilcard() {
     let config = FileConfig {

--- a/tests/test-data/test_configs/default/implicitclass.zone
+++ b/tests/test-data/test_configs/default/implicitclass.zone
@@ -1,0 +1,13 @@
+; replace the trust-dns.org with your own name
+$TTL 3D
+@               SOA     trust-dns.org. root.trust-dns.org. (
+                                199609203       ; Serial
+                                28800   ; Refresh
+                                7200    ; Retry
+                                604800  ; Expire
+                                86400)  ; Minimum TTL
+
+nonewline.              A        127.0.0.1
+                        AAAA     ::1
+
+ensure.nonewline.       A        127.0.0.1


### PR DESCRIPTION
#### Description

Prior to this branch parsing a zone file with `trust-dns` that did not specify a record class on one or more records would panic with an error with the message "record class not specified":

<details>
<summary>min.toml</summary>

```toml
directory = "/home/daniel/Code/Rust/trust-dns-experiments/zones"

[[zones]]
zone = "example.com"
zone_type = "Primary"
file = "example.com.zone"
```
</details>

<details>
<summary>zones/example.com</summary>

```
example.com.  	3600	SOA	ns1.example.com. contact.example.com. 2022100601 3600 900 1209600 86400
```
</details>

<details>
<summary>trust-dns -c ./min.toml</summary>

```bash
$> trust-dns -c ./min.toml
1673213115:INFO:trust_dns:335:Trust-DNS 0.22.0 starting
1673213115:INFO:trust_dns:340:loading configuration from: "./min.toml"
1673213115:INFO:trust_dns_server::store::file::authority:189:loading zone file: "/home/daniel/Code/Rust/trust-dns-experiments/zones/example.com.zone"
thread 'main' panicked at 'could not load zone example.com.: failed to parse example.com.zone: Error { kind: Message("record class not specified") }', bin/src/named.rs:366:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
</summary>
</details>

On the topic of whether class is optional or not, [RFC1035 5.1](https://datatracker.ietf.org/doc/html/rfc1035#section-5.1) says:
> The RR begins with optional TTL and class fields, followed by a type and RDATA field appropriate to the type and class.  Class and type use the standard mnemonics, TTL is a decimal integer.  Omitted class and TTL values are default to the last explicitly stated values.

Unfortunately this is somewhat ambiguous for the case where no explicit class value has been stated. It appears other software like BIND, knot, and bwesterb/go-zonefile will all assume a class of IN and parse the zone successfully but I can't find chapter and verse in the RFC to justify this.

#### Change

Assuming the internet class and parsing the zone seems like sensible behaviour, so this branch updates the `try_from_config` function's call to `parse` such that it defaults to the IN class when not specified, matching the behaviour of other software. 

Anecdotally I've carried my zone files through ~3 generations of different authoritative DNS servers and this is the first time one has balked. :-) While I can fix my own zones to specify the class I thought it might help others to support an implicit class natively.

I've added a couple small unit tests in [736d0b6](https://github.com/bluejekyll/trust-dns/pull/1874/commits/736d0b6c9f2fe00655452a98c0edaede612d5743) and 2db6212. They're in separate commits to make iteration easier (_I'm generally new to working in Rust on larger codebases_).

