### PR TITLE
API-breaking change: Deprecate ConnectionProvider with new RuntimeProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47085d44ed35b0f4499a88e47d689a411d483845966124e187a8f3cbb39eeebb"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
  "libc",
  "quinn-proto",
@@ -1921,6 +1921,7 @@ dependencies = [
  "native-tls",
  "openssl",
  "quinn",
+ "quinn-udp",
  "rand",
  "ring",
  "rustls",

--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -96,9 +96,7 @@
 
 use trust_dns_resolver::AsyncResolver;
 
-pub use crate::runtime::AsyncStdConnection;
-pub use crate::runtime::AsyncStdConnectionProvider;
-use crate::runtime::AsyncStdRuntimeHandle;
+use crate::runtime::AsyncStdRuntimeProvider;
 
 mod net;
 mod runtime;
@@ -106,6 +104,7 @@ mod runtime;
 mod tests;
 mod time;
 
+use crate::proto::Executor;
 pub use trust_dns_resolver::config;
 pub use trust_dns_resolver::error::ResolveError;
 pub use trust_dns_resolver::lookup;
@@ -113,7 +112,7 @@ pub use trust_dns_resolver::lookup_ip;
 pub use trust_dns_resolver::proto;
 
 /// An AsyncResolver used with async_std
-pub type AsyncStdResolver = AsyncResolver<AsyncStdConnection, AsyncStdConnectionProvider>;
+pub type AsyncStdResolver = AsyncResolver<AsyncStdRuntimeProvider>;
 
 /// Construct a new async-std based `AsyncResolver` with the provided configuration.
 ///
@@ -132,7 +131,7 @@ pub async fn resolver(
     config: config::ResolverConfig,
     options: config::ResolverOpts,
 ) -> Result<AsyncStdResolver, ResolveError> {
-    AsyncStdResolver::new(config, options, AsyncStdRuntimeHandle)
+    AsyncStdResolver::new(config, options, AsyncStdRuntimeProvider::new())
 }
 
 /// Constructs a new async-std based Resolver with the system configuration.
@@ -141,5 +140,5 @@ pub async fn resolver(
 #[cfg(any(unix, target_os = "windows"))]
 #[cfg(feature = "system-config")]
 pub async fn resolver_from_system_conf() -> Result<AsyncStdResolver, ResolveError> {
-    AsyncStdResolver::from_system_conf(AsyncStdRuntimeHandle)
+    AsyncStdResolver::from_system_conf(AsyncStdRuntimeProvider::new())
 }

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -10,6 +10,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use crate::proto::quic::QuicLocalAddr;
 use crate::proto::udp::DnsUdpSocket;
 use async_std::task::spawn_blocking;
 use async_trait::async_trait;
@@ -56,6 +57,12 @@ impl DnsUdpSocket for AsyncStdUdpSocket {
 
     async fn send_to(&self, buf: &[u8], target: SocketAddr) -> io::Result<usize> {
         self.0.send_to(buf, target).await
+    }
+}
+
+impl QuicLocalAddr for AsyncStdUdpSocket {
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.0.local_addr()
     }
 }
 

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -10,6 +10,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use crate::proto::udp::DnsUdpSocket;
 use async_std::task::spawn_blocking;
 use async_trait::async_trait;
 use futures_io::{AsyncRead, AsyncWrite};
@@ -18,7 +19,6 @@ use pin_utils::pin_mut;
 use socket2::{Domain, Protocol, Socket, Type};
 use trust_dns_resolver::proto::tcp::{Connect, DnsTcpStream};
 use trust_dns_resolver::proto::udp::UdpSocket;
-use crate::proto::udp::DnsUdpSocket;
 
 use crate::time::AsyncStdTime;
 
@@ -59,9 +59,8 @@ impl DnsUdpSocket for AsyncStdUdpSocket {
     }
 }
 
-
 #[async_trait]
-impl UdpSocket for AsyncStdUdpSocket{
+impl UdpSocket for AsyncStdUdpSocket {
     async fn connect(addr: SocketAddr) -> io::Result<Self> {
         let bind_addr: SocketAddr = match addr {
             SocketAddr::V4(_addr) => (Ipv4Addr::UNSPECIFIED, 0).into(),
@@ -84,7 +83,6 @@ impl UdpSocket for AsyncStdUdpSocket{
             .await
             .map(AsyncStdUdpSocket)
     }
-
 }
 
 pub struct AsyncStdTcpStream(async_std::net::TcpStream);

--- a/crates/async-std-resolver/src/net.rs
+++ b/crates/async-std-resolver/src/net.rs
@@ -10,8 +10,6 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::proto::quic::QuicLocalAddr;
-use crate::proto::udp::DnsUdpSocket;
 use async_std::task::spawn_blocking;
 use async_trait::async_trait;
 use futures_io::{AsyncRead, AsyncWrite};
@@ -19,7 +17,7 @@ use futures_util::future::FutureExt;
 use pin_utils::pin_mut;
 use socket2::{Domain, Protocol, Socket, Type};
 use trust_dns_resolver::proto::tcp::{Connect, DnsTcpStream};
-use trust_dns_resolver::proto::udp::UdpSocket;
+use trust_dns_resolver::proto::udp::{DnsUdpSocket, QuicLocalAddr, UdpSocket};
 
 use crate::time::AsyncStdTime;
 

--- a/crates/async-std-resolver/src/runtime.rs
+++ b/crates/async-std-resolver/src/runtime.rs
@@ -94,10 +94,3 @@ impl RuntimeProvider for AsyncStdRuntimeProvider {
         Box::pin(AsyncStdUdpSocket::bind(local_addr))
     }
 }
-
-impl AsyncStdRuntimeProvider {
-    #[cfg(test)]
-    pub(crate) fn handle(&self) -> AsyncStdRuntimeHandle {
-        AsyncStdRuntimeHandle
-    }
-}

--- a/crates/async-std-resolver/src/runtime.rs
+++ b/crates/async-std-resolver/src/runtime.rs
@@ -90,6 +90,7 @@ impl RuntimeProvider for AsyncStdRuntimeProvider {
     fn bind_udp(
         &self,
         local_addr: SocketAddr,
+        _server_addr: SocketAddr,
     ) -> Pin<Box<dyn Send + Future<Output = std::io::Result<Self::Udp>>>> {
         Box::pin(AsyncStdUdpSocket::bind(local_addr))
     }

--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -1,3 +1,4 @@
+use trust_dns_resolver::name_server::GenericConnection;
 use trust_dns_resolver::testing;
 
 use crate::config::{ResolverConfig, ResolverOpts};
@@ -5,7 +6,7 @@ use crate::lookup::LookupFuture;
 use crate::lookup_ip::LookupIpFuture;
 use crate::proto::xfer::DnsRequest;
 use crate::proto::Executor;
-use crate::runtime::{AsyncStdConnection, AsyncStdRuntimeProvider};
+use crate::runtime::AsyncStdRuntimeProvider;
 use crate::AsyncStdResolver;
 use crate::ResolveError;
 
@@ -28,15 +29,15 @@ fn test_send_sync() {
     assert!(is_sync_t::<AsyncStdResolver>());
 
     assert!(is_send_t::<DnsRequest>());
-    assert!(is_send_t::<LookupIpFuture<AsyncStdConnection, ResolveError>>());
-    assert!(is_send_t::<LookupFuture<AsyncStdConnection, ResolveError>>());
+    assert!(is_send_t::<LookupIpFuture<GenericConnection, ResolveError>>());
+    assert!(is_send_t::<LookupFuture<GenericConnection, ResolveError>>());
 }
 
 #[test]
 fn test_lookup_google() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         ResolverConfig::google(),
         io_loop,
@@ -48,7 +49,7 @@ fn test_lookup_google() {
 fn test_lookup_cloudflare() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         ResolverConfig::cloudflare(),
         io_loop,
@@ -60,7 +61,7 @@ fn test_lookup_cloudflare() {
 fn test_lookup_quad9() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         ResolverConfig::quad9(),
         io_loop,
@@ -72,7 +73,7 @@ fn test_lookup_quad9() {
 fn test_ip_lookup() {
     use testing::ip_lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     ip_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle)
 }
 
@@ -80,7 +81,7 @@ fn test_ip_lookup() {
 fn test_ip_lookup_across_threads() {
     use testing::ip_lookup_across_threads_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     ip_lookup_across_threads_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(handle)
 }
 
@@ -89,7 +90,7 @@ fn test_ip_lookup_across_threads() {
 fn test_sec_lookup() {
     use testing::sec_lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     sec_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -98,7 +99,7 @@ fn test_sec_lookup() {
 fn test_sec_lookup_fails() {
     use testing::sec_lookup_fails_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     sec_lookup_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -109,7 +110,7 @@ fn test_sec_lookup_fails() {
 fn test_system_lookup() {
     use testing::system_lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     system_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -121,7 +122,7 @@ fn test_system_lookup() {
 fn test_hosts_lookup() {
     use testing::hosts_lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     hosts_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -129,7 +130,7 @@ fn test_hosts_lookup() {
 fn test_fqdn() {
     use testing::fqdn_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     fqdn_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -137,7 +138,7 @@ fn test_fqdn() {
 fn test_ndots() {
     use testing::ndots_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -145,7 +146,7 @@ fn test_ndots() {
 fn test_large_ndots() {
     use testing::large_ndots_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -153,7 +154,7 @@ fn test_large_ndots() {
 fn test_domain_search() {
     use testing::domain_search_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     domain_search_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -161,7 +162,7 @@ fn test_domain_search() {
 fn test_search_list() {
     use testing::search_list_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     search_list_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -169,7 +170,7 @@ fn test_search_list() {
 fn test_idna() {
     use testing::idna_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     idna_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -177,7 +178,7 @@ fn test_idna() {
 fn test_localhost_ipv4() {
     use testing::localhost_ipv4_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     localhost_ipv4_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -185,7 +186,7 @@ fn test_localhost_ipv4() {
 fn test_localhost_ipv6() {
     use testing::localhost_ipv6_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     localhost_ipv6_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
@@ -193,7 +194,7 @@ fn test_localhost_ipv6() {
 fn test_search_ipv4_large_ndots() {
     use testing::search_ipv4_large_ndots_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     search_ipv4_large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         io_loop, handle,
     );
@@ -203,7 +204,7 @@ fn test_search_ipv4_large_ndots() {
 fn test_search_ipv6_large_ndots() {
     use testing::search_ipv6_large_ndots_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     search_ipv6_large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         io_loop, handle,
     );
@@ -213,7 +214,7 @@ fn test_search_ipv6_large_ndots() {
 fn test_search_ipv6_name_parse_fails() {
     use testing::search_ipv6_name_parse_fails_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.handle();
+    let handle = io_loop.clone();
     search_ipv6_name_parse_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         io_loop, handle,
     );

--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -5,7 +5,7 @@ use crate::lookup::LookupFuture;
 use crate::lookup_ip::LookupIpFuture;
 use crate::proto::xfer::DnsRequest;
 use crate::proto::Executor;
-use crate::runtime::{AsyncStdConnection, AsyncStdRuntime};
+use crate::runtime::{AsyncStdConnection, AsyncStdRuntimeProvider};
 use crate::AsyncStdResolver;
 use crate::ResolveError;
 
@@ -35,59 +35,71 @@ fn test_send_sync() {
 #[test]
 fn test_lookup_google() {
     use testing::lookup_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::google(), io_loop, handle)
+    lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+        ResolverConfig::google(),
+        io_loop,
+        handle,
+    )
 }
 
 #[test]
 fn test_lookup_cloudflare() {
     use testing::lookup_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::cloudflare(), io_loop, handle)
+    lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+        ResolverConfig::cloudflare(),
+        io_loop,
+        handle,
+    )
 }
 
 #[test]
 fn test_lookup_quad9() {
     use testing::lookup_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(ResolverConfig::quad9(), io_loop, handle)
+    lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+        ResolverConfig::quad9(),
+        io_loop,
+        handle,
+    )
 }
 
 #[test]
 fn test_ip_lookup() {
     use testing::ip_lookup_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    ip_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle)
+    ip_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle)
 }
 
 #[test]
 fn test_ip_lookup_across_threads() {
     use testing::ip_lookup_across_threads_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    ip_lookup_across_threads_test::<AsyncStdRuntime, AsyncStdRuntime>(handle)
+    ip_lookup_across_threads_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(handle)
 }
 
 #[test]
 #[cfg(feature = "dnssec")]
 fn test_sec_lookup() {
     use testing::sec_lookup_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    sec_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    sec_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 #[cfg(feature = "dnssec")]
 fn test_sec_lookup_fails() {
     use testing::sec_lookup_fails_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    sec_lookup_fails_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    sec_lookup_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
@@ -96,9 +108,9 @@ fn test_sec_lookup_fails() {
 #[cfg(feature = "system-config")]
 fn test_system_lookup() {
     use testing::system_lookup_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    system_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    system_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
@@ -108,95 +120,101 @@ fn test_system_lookup() {
 #[cfg(unix)]
 fn test_hosts_lookup() {
     use testing::hosts_lookup_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    hosts_lookup_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    hosts_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_fqdn() {
     use testing::fqdn_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    fqdn_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    fqdn_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_ndots() {
     use testing::ndots_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_large_ndots() {
     use testing::large_ndots_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_domain_search() {
     use testing::domain_search_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    domain_search_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    domain_search_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_search_list() {
     use testing::search_list_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    search_list_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    search_list_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_idna() {
     use testing::idna_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    idna_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    idna_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_localhost_ipv4() {
     use testing::localhost_ipv4_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    localhost_ipv4_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    localhost_ipv4_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_localhost_ipv6() {
     use testing::localhost_ipv6_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    localhost_ipv6_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    localhost_ipv6_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
 }
 
 #[test]
 fn test_search_ipv4_large_ndots() {
     use testing::search_ipv4_large_ndots_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    search_ipv4_large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    search_ipv4_large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+        io_loop, handle,
+    );
 }
 
 #[test]
 fn test_search_ipv6_large_ndots() {
     use testing::search_ipv6_large_ndots_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    search_ipv6_large_ndots_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    search_ipv6_large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+        io_loop, handle,
+    );
 }
 
 #[test]
 fn test_search_ipv6_name_parse_fails() {
     use testing::search_ipv6_name_parse_fails_test;
-    let io_loop = AsyncStdRuntime::new();
+    let io_loop = AsyncStdRuntimeProvider::new();
     let handle = io_loop.handle();
-    search_ipv6_name_parse_fails_test::<AsyncStdRuntime, AsyncStdRuntime>(io_loop, handle);
+    search_ipv6_name_parse_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+        io_loop, handle,
+    );
 }

--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -37,11 +37,11 @@ fn test_send_sync() {
 fn test_lookup_google() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
+
     lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         ResolverConfig::google(),
         io_loop,
-        handle,
+        io_loop,
     )
 }
 
@@ -49,11 +49,10 @@ fn test_lookup_google() {
 fn test_lookup_cloudflare() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
     lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         ResolverConfig::cloudflare(),
         io_loop,
-        handle,
+        io_loop,
     )
 }
 
@@ -61,11 +60,10 @@ fn test_lookup_cloudflare() {
 fn test_lookup_quad9() {
     use testing::lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
     lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
         ResolverConfig::quad9(),
         io_loop,
-        handle,
+        io_loop,
     )
 }
 
@@ -73,16 +71,14 @@ fn test_lookup_quad9() {
 fn test_ip_lookup() {
     use testing::ip_lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    ip_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle)
+    ip_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop)
 }
 
 #[test]
 fn test_ip_lookup_across_threads() {
     use testing::ip_lookup_across_threads_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    ip_lookup_across_threads_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(handle)
+    ip_lookup_across_threads_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop)
 }
 
 #[test]
@@ -90,8 +86,7 @@ fn test_ip_lookup_across_threads() {
 fn test_sec_lookup() {
     use testing::sec_lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    sec_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    sec_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
@@ -99,8 +94,7 @@ fn test_sec_lookup() {
 fn test_sec_lookup_fails() {
     use testing::sec_lookup_fails_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    sec_lookup_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    sec_lookup_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
@@ -110,8 +104,7 @@ fn test_sec_lookup_fails() {
 fn test_system_lookup() {
     use testing::system_lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    system_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    system_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
@@ -122,81 +115,74 @@ fn test_system_lookup() {
 fn test_hosts_lookup() {
     use testing::hosts_lookup_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    hosts_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    hosts_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_fqdn() {
     use testing::fqdn_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    fqdn_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    fqdn_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_ndots() {
     use testing::ndots_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_large_ndots() {
     use testing::large_ndots_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_domain_search() {
     use testing::domain_search_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    domain_search_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    domain_search_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_search_list() {
     use testing::search_list_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    search_list_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    search_list_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_idna() {
     use testing::idna_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    idna_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+    idna_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_localhost_ipv4() {
     use testing::localhost_ipv4_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    localhost_ipv4_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+
+    localhost_ipv4_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_localhost_ipv6() {
     use testing::localhost_ipv6_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
-    localhost_ipv6_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, handle);
+
+    localhost_ipv6_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
 }
 
 #[test]
 fn test_search_ipv4_large_ndots() {
     use testing::search_ipv4_large_ndots_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
+
     search_ipv4_large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
-        io_loop, handle,
+        io_loop, io_loop,
     );
 }
 
@@ -204,9 +190,9 @@ fn test_search_ipv4_large_ndots() {
 fn test_search_ipv6_large_ndots() {
     use testing::search_ipv6_large_ndots_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
+
     search_ipv6_large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
-        io_loop, handle,
+        io_loop, io_loop,
     );
 }
 
@@ -214,8 +200,8 @@ fn test_search_ipv6_large_ndots() {
 fn test_search_ipv6_name_parse_fails() {
     use testing::search_ipv6_name_parse_fails_test;
     let io_loop = AsyncStdRuntimeProvider::new();
-    let handle = io_loop.clone();
+
     search_ipv6_name_parse_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
-        io_loop, handle,
+        io_loop, io_loop,
     );
 }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -45,7 +45,7 @@ dns-over-openssl = ["dns-over-tls", "openssl", "tokio-openssl", "tokio-runtime"]
 dns-over-https-rustls = ["dns-over-https"]
 dns-over-https = ["bytes", "h2", "http", "dns-over-rustls", "webpki-roots", "tokio-runtime"]
 
-dns-over-quic = ["quinn", "rustls/quic", "dns-over-rustls", "bytes", "webpki-roots", "tokio-runtime"]
+dns-over-quic = ["quinn", "quinn-udp","rustls/quic", "dns-over-rustls", "bytes", "webpki-roots", "tokio-runtime"]
 
 dnssec-openssl = ["dnssec", "openssl"]
 dnssec-ring = ["dnssec", "ring"]
@@ -90,6 +90,7 @@ lazy_static = "1.2.0"
 native-tls = { version = "0.2", optional = true }
 openssl = { version = "0.10", features = ["v102", "v110"], optional = true }
 quinn = { version = "0.9", optional = true }
+quinn-udp = {version ="0.3.2", optional = true}
 rand = "0.8"
 ring = { version = "0.16", optional = true, features = ["std"] }
 rustls = { version = "0.20.0", optional = true }

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -317,7 +317,6 @@ struct NextRandomUdpSocket {
     packet_ttl: Option<u32>,
     ipv4_if: Option<Ipv4Addr>,
     ipv6_if: Option<u32>,
-    closure: Box<dyn Fn(&SocketAddr) -> dyn Future<Output = std::io::Result<std::net::UdpSocket>>>,
 }
 
 impl NextRandomUdpSocket {

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -317,6 +317,7 @@ struct NextRandomUdpSocket {
     packet_ttl: Option<u32>,
     ipv4_if: Option<Ipv4Addr>,
     ipv6_if: Option<u32>,
+    closure: Box<dyn Fn(&SocketAddr) -> dyn Future<Output = std::io::Result<std::net::UdpSocket>>>,
 }
 
 impl NextRandomUdpSocket {

--- a/crates/proto/src/openssl/tls_client_stream.rs
+++ b/crates/proto/src/openssl/tls_client_stream.rs
@@ -19,7 +19,7 @@ use tokio_openssl::SslStream as TokioTlsStream;
 use crate::error::ProtoError;
 use crate::iocompat::AsyncIoStdAsTokio;
 use crate::iocompat::AsyncIoTokioAsStd;
-use crate::tcp::{Connect, TcpClientStream};
+use crate::tcp::{Connect, DnsTcpStream, TcpClientStream};
 use crate::xfer::BufDnsStreamHandle;
 
 use super::TlsStreamBuilder;
@@ -31,7 +31,7 @@ pub type TlsClientStream<S> =
 /// A Builder for the TlsClientStream
 pub struct TlsClientStreamBuilder<S>(TlsStreamBuilder<S>);
 
-impl<S: Connect> TlsClientStreamBuilder<S> {
+impl<S: DnsTcpStream> TlsClientStreamBuilder<S> {
     /// Creates a builder for the construction of a TlsClientStream.
     pub fn new() -> Self {
         Self(TlsStreamBuilder::new())
@@ -65,6 +65,45 @@ impl<S: Connect> TlsClientStreamBuilder<S> {
         self.0.bind_addr(bind_addr);
     }
 
+    /// Creates a new TlsStream to the specified name_server with future
+    ///
+    /// # Arguments
+    ///
+    /// * `future` - future for underlying tcp stream
+    /// * `name_server` - IP and Port for the remote DNS resolver
+    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    #[allow(clippy::type_complexity)]
+    pub fn build_with_future<F>(
+        self,
+        future: F,
+        name_server: SocketAddr,
+        dns_name: String,
+    ) -> (
+        Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
+        BufDnsStreamHandle,
+    )
+    where
+        F: Future<Output = io::Result<S>> + Send + Unpin + 'static,
+    {
+        let (stream_future, sender) = self.0.build_with_future(future, name_server, dns_name);
+
+        let new_future = Box::pin(
+            stream_future
+                .map_ok(TcpClientStream::from_stream)
+                .map_err(ProtoError::from),
+        );
+
+        (new_future, sender)
+    }
+}
+
+impl<S: DnsTcpStream> Default for TlsClientStreamBuilder<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S: Connect> TlsClientStreamBuilder<S> {
     /// Creates a new TlsStream to the specified name_server
     ///
     /// # Arguments
@@ -90,11 +129,5 @@ impl<S: Connect> TlsClientStreamBuilder<S> {
         );
 
         (new_future, sender)
-    }
-}
-
-impl<S: Connect> Default for TlsClientStreamBuilder<S> {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/proto/src/openssl/tls_stream.rs
+++ b/crates/proto/src/openssl/tls_stream.rs
@@ -20,8 +20,8 @@ use openssl::x509::{X509Ref, X509};
 use tokio_openssl::{self, SslStream as TokioTlsStream};
 
 use crate::iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd};
-use crate::tcp::Connect;
 use crate::tcp::TcpStream;
+use crate::tcp::{Connect, DnsTcpStream};
 use crate::xfer::BufDnsStreamHandle;
 
 pub(crate) trait TlsIdentityExt {
@@ -103,7 +103,7 @@ fn new(certs: Vec<X509>, pkcs12: Option<ParsedPkcs12>) -> io::Result<SslConnecto
 /// Initializes a TlsStream with an existing tokio_tls::TlsStream.
 ///
 /// This is intended for use with a TlsListener and Incoming connections
-pub fn tls_stream_from_existing_tls_stream<S: Connect>(
+pub fn tls_stream_from_existing_tls_stream<S: DnsTcpStream>(
     stream: AsyncIoTokioAsStd<TokioTlsStream<AsyncIoStdAsTokio<S>>>,
     peer_addr: SocketAddr,
 ) -> (CompatTlsStream<S>, BufDnsStreamHandle) {
@@ -112,13 +112,16 @@ pub fn tls_stream_from_existing_tls_stream<S: Connect>(
     (stream, message_sender)
 }
 
-async fn connect_tls<S: Connect>(
+async fn connect_tls<S, F>(
+    future: F,
     tls_config: ConnectConfiguration,
     dns_name: String,
-    name_server: SocketAddr,
-    bind_addr: Option<SocketAddr>,
-) -> Result<TokioTlsStream<AsyncIoStdAsTokio<S>>, io::Error> {
-    let tcp = S::connect_with_bind(name_server, bind_addr)
+) -> Result<TokioTlsStream<AsyncIoStdAsTokio<S>>, io::Error>
+where
+    S: DnsTcpStream,
+    F: Future<Output = std::io::Result<S>> + Send + Unpin + 'static,
+{
+    let tcp = future
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, format!("tls error: {e}")))?;
     let mut stream = tls_config
@@ -141,7 +144,7 @@ pub struct TlsStreamBuilder<S> {
     marker: PhantomData<S>,
 }
 
-impl<S: Connect> TlsStreamBuilder<S> {
+impl<S: DnsTcpStream> TlsStreamBuilder<S> {
     /// A builder for associating trust information to the `TlsStream`.
     pub fn new() -> Self {
         Self {
@@ -170,6 +173,63 @@ impl<S: Connect> TlsStreamBuilder<S> {
         self.bind_addr = Some(bind_addr);
     }
 
+    /// Similar to `build`, but with prebuilt tcp stream
+    #[allow(clippy::type_complexity)]
+    pub fn build_with_future<F>(
+        self,
+        future: F,
+        name_server: SocketAddr,
+        dns_name: String,
+    ) -> (
+        Pin<Box<dyn Future<Output = Result<CompatTlsStream<S>, io::Error>> + Send>>,
+        BufDnsStreamHandle,
+    )
+    where
+        F: Future<Output = std::io::Result<S>> + Send + Unpin + 'static,
+    {
+        let (message_sender, outbound_messages) = BufDnsStreamHandle::new(name_server);
+        let tls_config = match new(self.ca_chain, self.identity) {
+            Ok(c) => c,
+            Err(e) => {
+                return (
+                    Box::pin(future::err(e).map_err(|e| {
+                        io::Error::new(io::ErrorKind::ConnectionRefused, format!("tls error: {e}"))
+                    })),
+                    message_sender,
+                )
+            }
+        };
+
+        let tls_config = match tls_config.configure() {
+            Ok(c) => c,
+            Err(e) => {
+                return (
+                    Box::pin(future::err(e).map_err(|e| {
+                        io::Error::new(
+                            io::ErrorKind::ConnectionRefused,
+                            format!("tls config error: {e}"),
+                        )
+                    })),
+                    message_sender,
+                )
+            }
+        };
+
+        // This set of futures collapses the next tcp socket into a stream which can be used for
+        //  sending and receiving tcp packets.
+        let stream = Box::pin(connect_tls(future, tls_config, dns_name).map_ok(move |s| {
+            TcpStream::from_stream_with_receiver(
+                AsyncIoTokioAsStd(s),
+                name_server,
+                outbound_messages,
+            )
+        }));
+
+        (stream, message_sender)
+    }
+}
+
+impl<S: Connect> TlsStreamBuilder<S> {
     /// Creates a new TlsStream to the specified name_server
     ///
     /// [RFC 7858](https://tools.ietf.org/html/rfc7858), DNS over TLS, May 2016
@@ -204,46 +264,7 @@ impl<S: Connect> TlsStreamBuilder<S> {
         Pin<Box<dyn Future<Output = Result<CompatTlsStream<S>, io::Error>> + Send>>,
         BufDnsStreamHandle,
     ) {
-        let (message_sender, outbound_messages) = BufDnsStreamHandle::new(name_server);
-        let tls_config = match new(self.ca_chain, self.identity) {
-            Ok(c) => c,
-            Err(e) => {
-                return (
-                    Box::pin(future::err(e).map_err(|e| {
-                        io::Error::new(io::ErrorKind::ConnectionRefused, format!("tls error: {e}"))
-                    })),
-                    message_sender,
-                )
-            }
-        };
-
-        let tls_config = match tls_config.configure() {
-            Ok(c) => c,
-            Err(e) => {
-                return (
-                    Box::pin(future::err(e).map_err(|e| {
-                        io::Error::new(
-                            io::ErrorKind::ConnectionRefused,
-                            format!("tls config error: {e}"),
-                        )
-                    })),
-                    message_sender,
-                )
-            }
-        };
-
-        // This set of futures collapses the next tcp socket into a stream which can be used for
-        //  sending and receiving tcp packets.
-        let stream = Box::pin(
-            connect_tls(tls_config, dns_name, name_server, self.bind_addr).map_ok(move |s| {
-                TcpStream::from_stream_with_receiver(
-                    AsyncIoTokioAsStd(s),
-                    name_server,
-                    outbound_messages,
-                )
-            }),
-        );
-
-        (stream, message_sender)
+        let future = S::connect_with_bind(name_server, self.bind_addr);
+        self.build_with_future(future, name_server, dns_name)
     }
 }

--- a/crates/proto/src/quic/mod.rs
+++ b/crates/proto/src/quic/mod.rs
@@ -14,10 +14,11 @@ mod quic_stream;
 
 pub use self::quic_client_stream::{
     client_config_tls13_webpki_roots, QuicClientConnect, QuicClientResponse, QuicClientStream,
-    QuicClientStreamBuilder, QuicLocalAddr,
+    QuicClientStreamBuilder,
 };
 pub use self::quic_server::{QuicServer, QuicStreams};
 pub use self::quic_stream::{DoqErrorCode, QuicStream};
+pub use crate::udp::QuicLocalAddr;
 
 #[cfg(test)]
 mod tests;

--- a/crates/proto/src/quic/mod.rs
+++ b/crates/proto/src/quic/mod.rs
@@ -14,7 +14,7 @@ mod quic_stream;
 
 pub use self::quic_client_stream::{
     client_config_tls13_webpki_roots, QuicClientConnect, QuicClientResponse, QuicClientStream,
-    QuicClientStreamBuilder,
+    QuicClientStreamBuilder, QuicLocalAddr,
 };
 pub use self::quic_server::{QuicServer, QuicStreams};
 pub use self::quic_stream::{DoqErrorCode, QuicStream};

--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -19,7 +19,7 @@ use futures_util::{future::FutureExt, stream::Stream};
 use quinn::{AsyncUdpSocket, ClientConfig, Connection, Endpoint, TransportConfig, VarInt};
 use rustls::{version::TLS13, ClientConfig as TlsClientConfig};
 
-use crate::udp::DnsUdpSocket;
+use crate::udp::{DnsUdpSocket, QuicLocalAddr};
 use crate::{
     error::ProtoError,
     quic::quic_stream::{DoqErrorCode, QuicStream},
@@ -329,24 +329,6 @@ impl Future for QuicClientResponse {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.as_mut().poll(cx).map_err(ProtoError::from)
-    }
-}
-
-/// To implement quinn::AsyncUdpSocket, we need our custom socket capable of getting local address.
-pub trait QuicLocalAddr {
-    /// Get local address
-    fn local_addr(&self) -> std::io::Result<std::net::SocketAddr>;
-}
-
-#[cfg(feature = "tokio-runtime")]
-use tokio::net::UdpSocket as TokioUdpSocket;
-
-#[cfg(feature = "tokio-runtime")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
-#[allow(unreachable_pub)]
-impl QuicLocalAddr for TokioUdpSocket {
-    fn local_addr(&self) -> std::io::Result<SocketAddr> {
-        self.local_addr()
     }
 }
 

--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -177,7 +177,12 @@ impl QuicClientStreamBuilder {
         QuicClientConnect(Box::pin(self.connect(name_server, dns_name)) as _)
     }
 
-    pub fn build_with_future<S, F>(self, future: F) -> QuicClientConnect
+    pub fn build_with_future<S, F>(
+        self,
+        future: F,
+        name_server: SocketAddr,
+        dns_name: String,
+    ) -> QuicClientConnect
     where
         S: DnsUdpSocket + QuicLocalAddr,
         F: Future<Output = std::io::Result<S>> + Send,

--- a/crates/proto/src/rustls/tls_client_stream.rs
+++ b/crates/proto/src/rustls/tls_client_stream.rs
@@ -93,7 +93,7 @@ pub fn tls_client_connect_with_future<S, F>(
 )
 where
     S: DnsTcpStream,
-    F: Future<Output = io::Result<S>> + Send,
+    F: Future<Output = io::Result<S>> + Send + Unpin + 'static,
 {
     let (stream_future, sender) =
         tls_connect_with_future(future, socket_addr, dns_name, client_config);

--- a/crates/proto/src/rustls/tls_client_stream.rs
+++ b/crates/proto/src/rustls/tls_client_stream.rs
@@ -84,6 +84,7 @@ pub fn tls_client_connect_with_bind_addr<S: Connect>(
 #[allow(clippy::type_complexity)]
 pub fn tls_client_connect_with_future<S, F>(
     future: F,
+    socket_addr: SocketAddr,
     dns_name: String,
     client_config: Arc<ClientConfig>,
 ) -> (
@@ -94,7 +95,8 @@ where
     S: DnsTcpStream,
     F: Future<Output = io::Result<S>> + Send,
 {
-    let (stream_future, sender) = tls_connect_with_future(future, dns_name, client_config);
+    let (stream_future, sender) =
+        tls_connect_with_future(future, socket_addr, dns_name, client_config);
 
     let new_future = Box::pin(
         stream_future

--- a/crates/proto/src/rustls/tls_stream.rs
+++ b/crates/proto/src/rustls/tls_stream.rs
@@ -146,6 +146,7 @@ pub fn tls_connect_with_bind_addr<S: Connect>(
 #[allow(clippy::type_complexity)]
 pub fn tls_connect_with_future<S, F>(
     future: F,
+    name_server: SocketAddr,
     dns_name: String,
     client_config: Arc<ClientConfig>,
 ) -> (

--- a/crates/proto/src/rustls/tls_stream.rs
+++ b/crates/proto/src/rustls/tls_stream.rs
@@ -213,12 +213,7 @@ where
     let s = tls_connector
         .connect(dns_name, AsyncIoStdAsTokio(stream))
         .await
-        .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::ConnectionRefused,
-                format!("tls error: {e}"),
-            )
-        })?;
+        .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, format!("tls error: {e}")))?;
 
     Ok(TcpStream::from_stream_with_receiver(
         AsyncIoTokioAsStd(s),

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use std::fmt::{self, Display};
-#[cfg(feature = "tokio-runtime")]
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -97,7 +97,7 @@ impl<S: DnsTcpStream> TcpClientStream<S> {
     }
 
     #[allow(clippy::new_ret_no_self)]
-    pub fn with_future<F: Future<Output = io::Result<S>> + Send>(
+    pub fn with_future<F: Future<Output = io::Result<S>> + Send + 'static>(
         future: F,
         name_server: SocketAddr,
         timeout: Duration,

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -97,11 +97,12 @@ impl<S: DnsTcpStream> TcpClientStream<S> {
     }
 
     #[allow(clippy::new_ret_no_self)]
-    pub fn with_future<F: Future<Output = io::Result<S>>>(
+    pub fn with_future<F: Future<Output = io::Result<S>> + Send>(
         future: F,
+        name_server: SocketAddr,
         timeout: Duration,
     ) -> (TcpClientConnect<S>, BufDnsStreamHandle) {
-        let (stream_future, sender) = TcpStream::<S>::with_future(future, timeout);
+        let (stream_future, sender) = TcpStream::<S>::with_future(future, name_server, timeout);
 
         let new_future = Box::pin(
             stream_future

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -96,6 +96,13 @@ impl<S: DnsTcpStream> TcpClientStream<S> {
         Self { tcp_stream }
     }
 
+    /// Constructs a new TcpStream for a client to the specified SocketAddr.
+    ///
+    /// # Arguments
+    ///
+    /// * `future` - a future of a connecting tcp
+    /// * `name_server` - the IP and Port of the DNS server to connect to
+    /// * `timeout` - connection timeout
     #[allow(clippy::new_ret_no_self)]
     pub fn with_future<F: Future<Output = io::Result<S>> + Send + 'static>(
         future: F,

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -200,11 +200,10 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::tests::tcp_client_stream_test;
-    use crate::TokioTime;
     #[test]
     fn test_tcp_stream_ipv4() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_client_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime, TokioTime>(
+        tcp_client_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime>(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             io_loop,
         )
@@ -214,7 +213,7 @@ mod tests {
     #[cfg(not(target_os = "linux"))] // ignored until Travis-CI fixes IPv6
     fn test_tcp_stream_ipv6() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_client_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime, TokioTime>(
+        tcp_client_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime>(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
             io_loop,
         )

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -226,7 +226,7 @@ impl<S: DnsTcpStream> TcpStream<S> {
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn with_future<F: Future<Output = Result<S, io::Error>> + Send>(
+    pub fn with_future<F: Future<Output = Result<S, io::Error>> + Send + 'static>(
         future: F,
         name_server: SocketAddr,
         timeout: Duration,
@@ -240,7 +240,7 @@ impl<S: DnsTcpStream> TcpStream<S> {
         (stream_fut, message_sender)
     }
 
-    async fn connect_with_future<F: Future<Output = Result<S, io::Error>> + Send>(
+    async fn connect_with_future<F: Future<Output = Result<S, io::Error>> + Send + 'static>(
         future: F,
         name_server: SocketAddr,
         timeout: Duration,

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -225,6 +225,13 @@ impl<S: DnsTcpStream> TcpStream<S> {
         }
     }
 
+    /// Creates a new future of the eventually establish a IO stream connection or fail trying
+    ///
+    /// # Arguments
+    ///
+    /// * `future` - underlying stream future which this tcp stream relies on
+    /// * `name_server` - the IP and Port of the DNS server to connect to
+    /// * `timeout` - connection timeout
     #[allow(clippy::type_complexity)]
     pub fn with_future<F: Future<Output = Result<S, io::Error>> + Send + 'static>(
         future: F,

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -20,7 +20,6 @@ use futures_util::stream::Stream;
 use futures_util::{self, future::Future, ready, FutureExt};
 use tracing::debug;
 
-use crate::error::*;
 use crate::xfer::{SerialMessage, StreamReceiver};
 use crate::BufDnsStreamHandle;
 use crate::Time;
@@ -103,15 +102,12 @@ impl<S: Connect> TcpStream<S> {
     ///
     /// * `name_server` - the IP and Port of the DNS server to connect to
     #[allow(clippy::new_ret_no_self, clippy::type_complexity)]
-    pub fn new<E>(
+    pub fn new(
         name_server: SocketAddr,
     ) -> (
         impl Future<Output = Result<Self, io::Error>> + Send,
         BufDnsStreamHandle,
-    )
-    where
-        E: FromProtoError,
-    {
+    ) {
         Self::with_timeout(name_server, Duration::from_secs(5))
     }
 

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -491,13 +491,12 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::iocompat::AsyncIoTokioAsStd;
-    use crate::TokioTime;
 
     use crate::tests::tcp_stream_test;
     #[test]
     fn test_tcp_stream_ipv4() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime, TokioTime>(
+        tcp_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime>(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             io_loop,
         )
@@ -507,7 +506,7 @@ mod tests {
     #[cfg(not(target_os = "linux"))] // ignored until Travis-CI fixes IPv6
     fn test_tcp_stream_ipv6() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime, TokioTime>(
+        tcp_stream_test::<AsyncIoTokioAsStd<TokioTcpStream>, Runtime>(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
             io_loop,
         )

--- a/crates/proto/src/tests/tcp.rs
+++ b/crates/proto/src/tests/tcp.rs
@@ -4,11 +4,10 @@ use std::sync::{atomic::AtomicBool, Arc};
 
 use futures_util::stream::StreamExt;
 
-use crate::error::ProtoError;
 use crate::tcp::{Connect, TcpClientStream, TcpStream};
 use crate::xfer::dns_handle::DnsStreamHandle;
 use crate::xfer::SerialMessage;
-use crate::{Executor, Time};
+use crate::Executor;
 
 const TEST_BYTES: &[u8; 8] = b"DEADBEEF";
 const TEST_BYTES_LEN: usize = 8;
@@ -86,7 +85,7 @@ fn tcp_server_setup(
 }
 
 /// Test tcp_stream.
-pub fn tcp_stream_test<S: Connect, E: Executor, TE: Time>(server_addr: IpAddr, mut exec: E) {
+pub fn tcp_stream_test<S: Connect, E: Executor>(server_addr: IpAddr, mut exec: E) {
     let (succeeded, server_handle, server_addr) =
         tcp_server_setup("test_tcp_stream:server", server_addr);
 
@@ -95,7 +94,7 @@ pub fn tcp_stream_test<S: Connect, E: Executor, TE: Time>(server_addr: IpAddr, m
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5));
-    let (stream, mut sender) = TcpStream::<S>::new::<ProtoError>(server_addr);
+    let (stream, mut sender) = TcpStream::<S>::new(server_addr);
 
     let mut stream = exec.block_on(stream).expect("run failed to get stream");
 
@@ -118,10 +117,7 @@ pub fn tcp_stream_test<S: Connect, E: Executor, TE: Time>(server_addr: IpAddr, m
 }
 
 /// Test tcp_client_stream.
-pub fn tcp_client_stream_test<S: Connect, E: Executor, TE: Time + 'static>(
-    server_addr: IpAddr,
-    mut exec: E,
-) {
+pub fn tcp_client_stream_test<S: Connect, E: Executor>(server_addr: IpAddr, mut exec: E) {
     let (succeeded, server_handle, server_addr) =
         tcp_server_setup("test_tcp_client_stream:server", server_addr);
 

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 use crate::udp::{UdpClientStream, UdpSocket, UdpStream};
 use crate::xfer::dns_handle::DnsStreamHandle;
 use crate::xfer::{DnsRequestOptions, FirstAnswer};
-use crate::{Executor, Time};
+use crate::Executor;
 
 /// Test next random udpsocket.
 pub fn next_random_socket_test<S: UdpSocket + Send + 'static, E: Executor>(mut exec: E) {
@@ -114,7 +114,7 @@ pub async fn udp_stream_test<S: UdpSocket + Send + 'static>(server_addr: IpAddr)
 
 /// Test udp_client_stream.
 #[allow(clippy::print_stdout)]
-pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor, TE: Time>(
+pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor>(
     server_addr: IpAddr,
     mut exec: E,
 ) {

--- a/crates/proto/src/udp/mod.rs
+++ b/crates/proto/src/udp/mod.rs
@@ -20,4 +20,4 @@ mod udp_client_stream;
 mod udp_stream;
 
 pub use self::udp_client_stream::{UdpClientConnect, UdpClientStream};
-pub use self::udp_stream::{UdpSocket, UdpStream};
+pub use self::udp_stream::{UdpSocket, DnsUdpSocket, UdpStream};

--- a/crates/proto/src/udp/mod.rs
+++ b/crates/proto/src/udp/mod.rs
@@ -20,4 +20,4 @@ mod udp_client_stream;
 mod udp_stream;
 
 pub use self::udp_client_stream::{UdpClientConnect, UdpClientStream};
-pub use self::udp_stream::{UdpSocket, DnsUdpSocket, UdpStream};
+pub use self::udp_stream::{DnsUdpSocket, UdpSocket, UdpStream};

--- a/crates/proto/src/udp/mod.rs
+++ b/crates/proto/src/udp/mod.rs
@@ -20,4 +20,4 @@ mod udp_client_stream;
 mod udp_stream;
 
 pub use self::udp_client_stream::{UdpClientConnect, UdpClientStream};
-pub use self::udp_stream::{DnsUdpSocket, UdpSocket, UdpStream};
+pub use self::udp_stream::{DnsUdpSocket, QuicLocalAddr, UdpSocket, UdpStream};

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -102,7 +102,12 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> UdpClientStream<S, MF>
             name_server,
             timeout,
             signer,
-            creator: Arc::new(|addr: _| Box::pin(NextRandomUdpSocket::<S>::new(&addr, &None))),
+            creator: Arc::new(|local_addr: _, server_addr: _| {
+                Box::pin(NextRandomUdpSocket::<S>::new(
+                    &server_addr,
+                    &Some(local_addr),
+                ))
+            }),
             marker: PhantomData::<S>,
         }
     }
@@ -124,8 +129,11 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> UdpClientStream<S, MF>
             name_server,
             timeout,
             signer,
-            creator: Arc::new(move |addr: _| {
-                Box::pin(NextRandomUdpSocket::<S>::new(&addr, &bind_addr))
+            creator: Arc::new(move |local_addr: _, server_addr: _| {
+                Box::pin(NextRandomUdpSocket::<S>::new(
+                    &server_addr,
+                    &Some(bind_addr.unwrap_or(local_addr)),
+                ))
             }),
             marker: PhantomData::<S>,
         }

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -102,7 +102,7 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> UdpClientStream<S, MF>
             name_server,
             timeout,
             signer,
-            creator: Arc::new(|addr: _| Box::pin(NextRandomUdpSocket::<S>::new(addr, &None))),
+            creator: Arc::new(|addr: _| Box::pin(NextRandomUdpSocket::<S>::new(&addr, &None))),
             marker: PhantomData::<S>,
         }
     }
@@ -125,7 +125,7 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> UdpClientStream<S, MF>
             timeout,
             signer,
             creator: Arc::new(move |addr: _| {
-                Box::pin(NextRandomUdpSocket::<S>::new(addr, &bind_addr))
+                Box::pin(NextRandomUdpSocket::<S>::new(&addr, &bind_addr))
             }),
             marker: PhantomData::<S>,
         }
@@ -218,7 +218,7 @@ impl<S: DnsUdpSocket + Send + 'static, MF: MessageFinalizer> DnsRequestSender
         S::Time::timeout::<Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>>(
             self.timeout,
             Box::pin(async move {
-                let socket = (*creator)(&addr).await?;
+                let socket: S = NextRandomUdpSocket::new_with_closure(&addr, creator).await?;
                 send_serial_message_inner(message, message_id, verifier, socket).await
             }),
         )
@@ -277,27 +277,27 @@ impl<S: Send + Unpin, MF: MessageFinalizer> Future for UdpClientConnect<S, MF> {
     }
 }
 
-async fn send_serial_message<S: UdpSocket + Send + 'static>(
-    msg: SerialMessage,
-    msg_id: u16,
-    verifier: Option<MessageVerifier>,
-    bind_addr: Option<SocketAddr>,
-) -> Result<DnsResponse, ProtoError> {
-    let name_server = msg.addr();
-    let socket: S = NextRandomUdpSocket::new(&name_server, &bind_addr).await?;
-    send_serial_message_inner(msg, msg_id, verifier, socket).await
-}
-
-async fn send_serial_message_with_closure<S: DnsUdpSocket + Send>(
-    msg: SerialMessage,
-    msg_id: u16,
-    verifier: Option<MessageVerifier>,
-    creator: UdpCreator<S>,
-) -> Result<DnsResponse, ProtoError> {
-    let name_server = msg.addr();
-    let socket: S = NextRandomUdpSocket::new_with_closure(&name_server, creator).await?;
-    send_serial_message_inner(msg, msg_id, verifier, socket).await
-}
+// async fn send_serial_message<S: UdpSocket + Send + 'static>(
+//     msg: SerialMessage,
+//     msg_id: u16,
+//     verifier: Option<MessageVerifier>,
+//     bind_addr: Option<SocketAddr>,
+// ) -> Result<DnsResponse, ProtoError> {
+//     let name_server = msg.addr();
+//     let socket: S = NextRandomUdpSocket::new(&name_server, &bind_addr).await?;
+//     send_serial_message_inner(msg, msg_id, verifier, socket).await
+// }
+//
+// async fn send_serial_message_with_closure<S: DnsUdpSocket + Send>(
+//     msg: SerialMessage,
+//     msg_id: u16,
+//     verifier: Option<MessageVerifier>,
+//     creator: UdpCreator<S>,
+// ) -> Result<DnsResponse, ProtoError> {
+//     let name_server = msg.addr();
+//     let socket: S = NextRandomUdpSocket::new_with_closure(&name_server, creator).await?;
+//     send_serial_message_inner(msg, msg_id, verifier, socket).await
+// }
 
 async fn send_serial_message_inner<S: DnsUdpSocket + Send>(
     msg: SerialMessage,

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -293,28 +293,6 @@ impl<S: Send + Unpin, MF: MessageFinalizer> Future for UdpClientConnect<S, MF> {
     }
 }
 
-// async fn send_serial_message<S: UdpSocket + Send + 'static>(
-//     msg: SerialMessage,
-//     msg_id: u16,
-//     verifier: Option<MessageVerifier>,
-//     bind_addr: Option<SocketAddr>,
-// ) -> Result<DnsResponse, ProtoError> {
-//     let name_server = msg.addr();
-//     let socket: S = NextRandomUdpSocket::new(&name_server, &bind_addr).await?;
-//     send_serial_message_inner(msg, msg_id, verifier, socket).await
-// }
-//
-// async fn send_serial_message_with_closure<S: DnsUdpSocket + Send>(
-//     msg: SerialMessage,
-//     msg_id: u16,
-//     verifier: Option<MessageVerifier>,
-//     creator: UdpCreator<S>,
-// ) -> Result<DnsResponse, ProtoError> {
-//     let name_server = msg.addr();
-//     let socket: S = NextRandomUdpSocket::new_with_closure(&name_server, creator).await?;
-//     send_serial_message_inner(msg, msg_id, verifier, socket).await
-// }
-
 async fn send_serial_message_inner<S: DnsUdpSocket + Send>(
     msg: SerialMessage,
     msg_id: u16,

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -21,6 +21,7 @@ use crate::error::ProtoError;
 use crate::op::message::NoopMessageFinalizer;
 use crate::op::{Message, MessageFinalizer, MessageVerifier};
 use crate::udp::udp_stream::{NextRandomUdpSocket, UdpSocket};
+use crate::udp::DnsUdpSocket;
 use crate::xfer::{DnsRequest, DnsRequestSender, DnsResponse, DnsResponseStream, SerialMessage};
 use crate::Time;
 
@@ -276,11 +277,12 @@ where
     S: UdpSocket + Send,
     C: Fn(&SocketAddr) -> dyn Future<Output = Result<S, std::io::Error>>,
 {
-    let socket: S = NextRandomUdpSocket::new_with_closure(creator).await?;
+    let name_server = msg.addr();
+    let socket: S = NextRandomUdpSocket::new_with_closure(&name_server, creator).await?;
     send_serial_message_inner(msg, msg_id, verifier, socket).await
 }
 
-async fn send_serial_message_inner<S: UdpSocket + Send>(
+async fn send_serial_message_inner<S: DnsUdpSocket + Send>(
     msg: SerialMessage,
     msg_id: u16,
     verifier: Option<MessageVerifier>,

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -87,7 +87,7 @@ impl<S: UdpSocket + Send + 'static> UdpClientStream<S, NoopMessageFinalizer> {
 }
 
 impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> UdpClientStream<S, MF> {
-    /// Constructs a new TcpStream for a client to the specified SocketAddr.
+    /// Constructs a new UdpStream for a client to the specified SocketAddr.
     ///
     /// # Arguments
     ///
@@ -107,7 +107,7 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> UdpClientStream<S, MF>
         }
     }
 
-    /// Constructs a new TcpStream for a client to the specified SocketAddr.
+    /// Constructs a new UdpStream for a client to the specified SocketAddr.
     ///
     /// # Arguments
     ///
@@ -133,6 +133,14 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> UdpClientStream<S, MF>
 }
 
 impl<S: DnsUdpSocket + Send, MF: MessageFinalizer> UdpClientStream<S, MF> {
+    /// Constructs a new UdpStream for a client to the specified SocketAddr.
+    ///
+    /// # Arguments
+    ///
+    /// * `name_server` - the IP and Port of the DNS server to connect to
+    /// * `signer` - optional final amendment
+    /// * `timeout` - connection timeout
+    /// * `creator` - function that binds a local address to a newly created UDP socket
     pub fn with_creator(
         name_server: SocketAddr,
         signer: Option<Arc<MF>>,

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -124,7 +124,9 @@ impl<S: UdpSocket + Send + 'static, MF: MessageFinalizer> UdpClientStream<S, MF>
             name_server,
             timeout,
             signer,
-            creator: Arc::new(move |addr: _| Box::pin(NextRandomUdpSocket::<S>::new(addr, &bind_addr))),
+            creator: Arc::new(move |addr: _| {
+                Box::pin(NextRandomUdpSocket::<S>::new(addr, &bind_addr))
+            }),
             marker: PhantomData::<S>,
         }
     }
@@ -215,9 +217,9 @@ impl<S: DnsUdpSocket + Send + 'static, MF: MessageFinalizer> DnsRequestSender
 
         S::Time::timeout::<Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>>(
             self.timeout,
-            Box::pin(async move{
+            Box::pin(async move {
                 let socket = (*creator)(&addr).await?;
-                send_serial_message_inner(message,message_id,verifier,socket).await
+                send_serial_message_inner(message, message_id, verifier, socket).await
             }),
         )
         .into()
@@ -286,7 +288,7 @@ async fn send_serial_message<S: UdpSocket + Send + 'static>(
     send_serial_message_inner(msg, msg_id, verifier, socket).await
 }
 
-async fn send_serial_message_with_closure<S:DnsUdpSocket+Send>(
+async fn send_serial_message_with_closure<S: DnsUdpSocket + Send>(
     msg: SerialMessage,
     msg_id: u16,
     verifier: Option<MessageVerifier>,

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -372,7 +372,6 @@ async fn send_serial_message_inner<S: DnsUdpSocket + Send>(
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
     use crate::tests::udp_client_stream_test;
-    use crate::TokioTime;
     #[cfg(not(target_os = "linux"))]
     use std::net::Ipv6Addr;
     use std::net::{IpAddr, Ipv4Addr};
@@ -381,7 +380,7 @@ mod tests {
     #[test]
     fn test_udp_client_stream_ipv4() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        udp_client_stream_test::<TokioUdpSocket, Runtime, TokioTime>(
+        udp_client_stream_test::<TokioUdpSocket, Runtime>(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             io_loop,
         )
@@ -391,7 +390,7 @@ mod tests {
     #[cfg(not(target_os = "linux"))] // ignored until Travis-CI fixes IPv6
     fn test_udp_client_stream_ipv6() {
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        udp_client_stream_test::<TokioUdpSocket, Runtime, TokioTime>(
+        udp_client_stream_test::<TokioUdpSocket, Runtime>(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
             io_loop,
         )

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -25,7 +25,7 @@ use crate::Time;
 pub(crate) type UdpCreator<S> = Arc<
     dyn Send
         + Sync
-        + (Fn(&SocketAddr) -> Pin<Box<dyn Send + (Future<Output = Result<S, std::io::Error>>)>>),
+        + (Fn(SocketAddr) -> Pin<Box<dyn Send + (Future<Output = Result<S, std::io::Error>>)>>),
 >;
 
 /// Trait for UdpSocket
@@ -231,7 +231,7 @@ impl<S: UdpSocket + 'static> NextRandomUdpSocket<S> {
 
         Self {
             bind_address,
-            closure: Arc::new(|addr: _| S::bind(*addr)),
+            closure: Arc::new(|addr: _| S::bind(addr)),
             marker: PhantomData,
         }
     }
@@ -254,7 +254,7 @@ impl<S: DnsUdpSocket> NextRandomUdpSocket<S> {
     }
 
     async fn bind(&self, addr: SocketAddr) -> Result<S, io::Error> {
-        Box::pin((*self.closure)(&addr)).await
+        Box::pin((*self.closure)(addr)).await
     }
 }
 

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -85,6 +85,24 @@ pub struct UdpStream<S: Send> {
     outbound_messages: StreamReceiver,
 }
 
+/// To implement quinn::AsyncUdpSocket, we need our custom socket capable of getting local address.
+pub trait QuicLocalAddr {
+    /// Get local address
+    fn local_addr(&self) -> std::io::Result<std::net::SocketAddr>;
+}
+
+#[cfg(feature = "tokio-runtime")]
+use tokio::net::UdpSocket as TokioUdpSocket;
+
+#[cfg(feature = "tokio-runtime")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
+#[allow(unreachable_pub)]
+impl QuicLocalAddr for TokioUdpSocket {
+    fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        self.local_addr()
+    }
+}
+
 impl<S: UdpSocket + Send + 'static> UdpStream<S> {
     /// This method is intended for client connections, see `with_bound` for a method better for
     ///  straight listening. It is expected that the resolver wrapper will be responsible for

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -28,7 +28,7 @@ pub(crate) type UdpCreator<S> = Arc<
         + (Fn(SocketAddr) -> Pin<Box<dyn Send + (Future<Output = Result<S, std::io::Error>>)>>),
 >;
 
-/// Trait for UdpSocket
+/// Trait for DnsUdpSocket
 #[async_trait]
 pub trait DnsUdpSocket
 where
@@ -65,6 +65,7 @@ where
     }
 }
 
+/// Trait for UdpSocket
 #[async_trait]
 pub trait UdpSocket: DnsUdpSocket {
     /// setups up a "client" udp connection that will only receive packets from the associated address

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -22,8 +22,11 @@ use tracing::{debug, warn};
 use crate::xfer::{BufDnsStreamHandle, SerialMessage, StreamReceiver};
 use crate::Time;
 
-pub(crate) type UdpCreator<S> =
-    Arc<dyn Send+ Sync+ (Fn(&SocketAddr) -> Pin<Box<dyn Send+(Future<Output = Result<S, std::io::Error>>)>>)>;
+pub(crate) type UdpCreator<S> = Arc<
+    dyn Send
+        + Sync
+        + (Fn(&SocketAddr) -> Pin<Box<dyn Send + (Future<Output = Result<S, std::io::Error>>)>>),
+>;
 
 /// Trait for UdpSocket
 #[async_trait]
@@ -228,7 +231,7 @@ impl<S: UdpSocket + 'static> NextRandomUdpSocket<S> {
 
         Self {
             bind_address,
-            closure: Arc::new(|addr:_| S::bind(*addr)),
+            closure: Arc::new(|addr: _| S::bind(*addr)),
             marker: PhantomData,
         }
     }

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -1,7 +1,5 @@
 #![recursion_limit = "128"]
 
-use trust_dns_resolver::name_server::TokioRuntimeProvider;
-
 #[cfg(feature = "tokio-runtime")]
 fn main() {
     tokio::runtime::Builder::new_multi_thread()
@@ -15,6 +13,7 @@ fn main() {
 
 #[cfg(feature = "tokio-runtime")]
 async fn tokio_main() {
+    use trust_dns_resolver::name_server::TokioRuntimeProvider;
     use trust_dns_resolver::TokioAsyncResolver;
 
     let resolver = {

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -15,7 +15,7 @@ fn main() {
 
 #[cfg(feature = "tokio-runtime")]
 async fn tokio_main() {
-    use trust_dns_resolver::{TokioAsyncResolver, TokioHandle};
+    use trust_dns_resolver::TokioAsyncResolver;
 
     let resolver = {
         // To make this independent, if targeting macOS, BSD, Linux, or Windows, we can use the system's configuration:

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -1,5 +1,7 @@
 #![recursion_limit = "128"]
 
+use trust_dns_resolver::name_server::TokioRuntimeProvider;
+
 #[cfg(feature = "tokio-runtime")]
 fn main() {
     tokio::runtime::Builder::new_multi_thread()
@@ -20,7 +22,7 @@ async fn tokio_main() {
         #[cfg(any(unix, windows))]
         {
             // use the system resolver configuration
-            TokioAsyncResolver::from_system_conf(TokioHandle::default())
+            TokioAsyncResolver::from_system_conf(TokioRuntimeProvider::new())
         }
 
         // For other operating systems, we can use one of the preconfigured definitions
@@ -58,12 +60,9 @@ async fn tokio_main() {
 }
 
 #[cfg(feature = "tokio-runtime")]
-async fn resolve_list<
-    C: trust_dns_proto::DnsHandle<Error = trust_dns_resolver::error::ResolveError>,
-    P: trust_dns_resolver::ConnectionProvider<Conn = C>,
->(
+async fn resolve_list<P: trust_dns_resolver::name_server::RuntimeProvider>(
     names: &[&str],
-    resolver: &trust_dns_resolver::AsyncResolver<C, P>,
+    resolver: &trust_dns_resolver::AsyncResolver<P>,
 ) -> tokio::time::Duration {
     use tokio::time::Instant;
     let start_time = Instant::now();

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -12,10 +12,11 @@ use std::task::Poll;
 
 use futures_util::future;
 
+use trust_dns_resolver::name_server::TokioRuntimeProvider;
+#[cfg(feature = "tokio-runtime")]
+use trust_dns_resolver::TokioAsyncResolver;
 #[cfg(feature = "tokio-runtime")]
 use trust_dns_resolver::{IntoName, TryParseIp};
-#[cfg(feature = "tokio-runtime")]
-use trust_dns_resolver::{TokioAsyncResolver, TokioHandle};
 
 // This is an example of registering a static global resolver into any system.
 //
@@ -51,7 +52,7 @@ lazy_static! {
                 #[cfg(any(unix, windows))]
                 {
                     // use the system resolver configuration
-                    TokioAsyncResolver::from_system_conf(TokioHandle::default())
+                    TokioAsyncResolver::from_system_conf(TokioRuntimeProvider::new())
                 }
 
                 // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -12,9 +12,8 @@ use std::task::Poll;
 
 use futures_util::future;
 
-use trust_dns_resolver::name_server::TokioRuntimeProvider;
 #[cfg(feature = "tokio-runtime")]
-use trust_dns_resolver::TokioAsyncResolver;
+use trust_dns_resolver::{name_server::TokioRuntimeProvider, TokioAsyncResolver};
 #[cfg(feature = "tokio-runtime")]
 use trust_dns_resolver::{IntoName, TryParseIp};
 

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -3,10 +3,12 @@
 //! This example shows how to create a resolver that uses the tokio multithreaded runtime. This is how
 //! you might integrate the resolver into a more complex application.
 
+use trust_dns_resolver::name_server::TokioRuntimeProvider;
+
 #[cfg(feature = "tokio-runtime")]
 fn main() {
     use tokio::runtime::Runtime;
-    use trust_dns_resolver::{TokioAsyncResolver, TokioHandle};
+    use trust_dns_resolver::TokioAsyncResolver;
 
     tracing_subscriber::fmt::init();
 
@@ -18,7 +20,7 @@ fn main() {
         #[cfg(any(unix, windows))]
         {
             // use the system resolver configuration
-            TokioAsyncResolver::from_system_conf(TokioHandle::default())
+            TokioAsyncResolver::from_system_conf(TokioRuntimeProvider::new())
         }
 
         // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -3,11 +3,10 @@
 //! This example shows how to create a resolver that uses the tokio multithreaded runtime. This is how
 //! you might integrate the resolver into a more complex application.
 
-use trust_dns_resolver::name_server::TokioRuntimeProvider;
-
 #[cfg(feature = "tokio-runtime")]
 fn main() {
     use tokio::runtime::Runtime;
+    use trust_dns_resolver::name_server::TokioRuntimeProvider;
     use trust_dns_resolver::TokioAsyncResolver;
 
     tracing_subscriber::fmt::init();

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -1069,7 +1069,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioRuntimeProvider};
+    use crate::name_server::{GenericConnection, TokioRuntimeProvider};
 
     use super::*;
 
@@ -1088,23 +1088,19 @@ mod tests {
         assert!(is_send_t::<ResolverOpts>());
         assert!(is_sync_t::<ResolverOpts>());
 
-        assert!(is_send_t::<
-            AsyncResolver<TokioConnection, TokioConnectionProvider>,
-        >());
-        assert!(is_sync_t::<
-            AsyncResolver<TokioConnection, TokioConnectionProvider>,
-        >());
+        assert!(is_send_t::<AsyncResolver<TokioRuntimeProvider>>());
+        assert!(is_sync_t::<AsyncResolver<TokioRuntimeProvider>>());
 
         assert!(is_send_t::<DnsRequest>());
-        assert!(is_send_t::<LookupIpFuture<TokioConnection, ResolveError>>());
-        assert!(is_send_t::<LookupFuture<TokioConnection, ResolveError>>());
+        assert!(is_send_t::<LookupIpFuture<GenericConnection, ResolveError>>());
+        assert!(is_send_t::<LookupFuture<GenericConnection, ResolveError>>());
     }
 
     #[test]
     fn test_lookup_google() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider;
         lookup_test::<Runtime, TokioRuntimeProvider>(ResolverConfig::google(), io_loop, handle)
     }
 
@@ -1112,7 +1108,7 @@ mod tests {
     fn test_lookup_cloudflare() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider;
         lookup_test::<Runtime, TokioRuntimeProvider>(ResolverConfig::cloudflare(), io_loop, handle)
     }
 
@@ -1120,7 +1116,7 @@ mod tests {
     fn test_lookup_quad9() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         lookup_test::<Runtime, TokioRuntimeProvider>(ResolverConfig::quad9(), io_loop, handle)
     }
 
@@ -1128,7 +1124,7 @@ mod tests {
     fn test_ip_lookup() {
         use super::testing::ip_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         ip_lookup_test::<Runtime, TokioRuntimeProvider>(io_loop, handle)
     }
 
@@ -1136,7 +1132,7 @@ mod tests {
     fn test_ip_lookup_across_threads() {
         use super::testing::ip_lookup_across_threads_test;
         let _io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         ip_lookup_across_threads_test::<Runtime, TokioRuntimeProvider>(handle)
     }
 
@@ -1145,7 +1141,7 @@ mod tests {
     fn test_sec_lookup() {
         use super::testing::sec_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         sec_lookup_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1154,7 +1150,7 @@ mod tests {
     fn test_sec_lookup_fails() {
         use super::testing::sec_lookup_fails_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         sec_lookup_fails_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1165,7 +1161,7 @@ mod tests {
     fn test_system_lookup() {
         use super::testing::system_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         system_lookup_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1176,7 +1172,7 @@ mod tests {
     fn test_hosts_lookup() {
         use super::testing::hosts_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         hosts_lookup_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1184,7 +1180,7 @@ mod tests {
     fn test_fqdn() {
         use super::testing::fqdn_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         fqdn_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1192,7 +1188,7 @@ mod tests {
     fn test_ndots() {
         use super::testing::ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         ndots_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1200,7 +1196,7 @@ mod tests {
     fn test_large_ndots() {
         use super::testing::large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         large_ndots_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1208,7 +1204,7 @@ mod tests {
     fn test_domain_search() {
         use super::testing::domain_search_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         domain_search_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1216,7 +1212,7 @@ mod tests {
     fn test_search_list() {
         use super::testing::search_list_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         search_list_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1224,7 +1220,7 @@ mod tests {
     fn test_idna() {
         use super::testing::idna_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         idna_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1232,7 +1228,7 @@ mod tests {
     fn test_localhost_ipv4() {
         use super::testing::localhost_ipv4_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         localhost_ipv4_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1240,7 +1236,7 @@ mod tests {
     fn test_localhost_ipv6() {
         use super::testing::localhost_ipv6_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         localhost_ipv6_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1248,7 +1244,7 @@ mod tests {
     fn test_search_ipv4_large_ndots() {
         use super::testing::search_ipv4_large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         search_ipv4_large_ndots_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1256,7 +1252,7 @@ mod tests {
     fn test_search_ipv6_large_ndots() {
         use super::testing::search_ipv6_large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         search_ipv6_large_ndots_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
@@ -1264,20 +1260,18 @@ mod tests {
     fn test_search_ipv6_name_parse_fails() {
         use super::testing::search_ipv6_name_parse_fails_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         search_ipv6_name_parse_fails_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_build_names_onion() {
-        let handle = TokioHandle::default();
+        let handle = TokioRuntimeProvider::new();
         let mut config = ResolverConfig::default();
         config.add_search(Name::from_ascii("example.com.").unwrap());
-        let resolver = AsyncResolver::<
-            GenericConnection,
-            GenericConnectionProvider<TokioRuntimeProvider>,
-        >::new(config, ResolverOpts::default(), handle)
-        .expect("failed to create resolver");
+        let resolver =
+            AsyncResolver::<TokioRuntimeProvider>::new(config, ResolverOpts::default(), handle)
+                .expect("failed to create resolver");
         let tor_address = [
             Name::from_ascii("2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion")
                 .unwrap(),

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -584,7 +584,7 @@ pub mod testing {
     ) {
         //env_logger::try_init().ok();
 
-        let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
+        let resolver = AsyncResolver::new(
             ResolverConfig::default(),
             ResolverOpts {
                 validate: true,
@@ -625,7 +625,7 @@ pub mod testing {
     ) {
         use crate::error::*;
         use proto::rr::RecordType;
-        let resolver = AsyncResolver::<GenericConnection, GenericConnectionProvider<R>>::new(
+        let resolver = AsyncResolver::new(
             ResolverConfig::default(),
             ResolverOpts {
                 validate: true,

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -25,10 +25,7 @@ use crate::dns_lru::{self, DnsLru};
 use crate::error::*;
 use crate::lookup::{self, Lookup, LookupEither, LookupFuture};
 use crate::lookup_ip::{LookupIp, LookupIpFuture};
-use crate::name_server::{
-    ConnectionProvider, GenericConnection, GenericConnectionProvider, NameServerPool,
-    RuntimeProvider,
-};
+use crate::name_server::{GenericConnection, NameServerPool, RuntimeProvider};
 #[cfg(feature = "tokio-runtime")]
 use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
 

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -1100,7 +1100,7 @@ mod tests {
     fn test_lookup_google() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioRuntimeProvider;
+        let handle = TokioRuntimeProvider::new();
         lookup_test::<Runtime, TokioRuntimeProvider>(ResolverConfig::google(), io_loop, handle)
     }
 
@@ -1108,7 +1108,7 @@ mod tests {
     fn test_lookup_cloudflare() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioRuntimeProvider;
+        let handle = TokioRuntimeProvider::new();
         lookup_test::<Runtime, TokioRuntimeProvider>(ResolverConfig::cloudflare(), io_loop, handle)
     }
 

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -25,7 +25,8 @@ use crate::error::*;
 use crate::lookup::{self, Lookup, LookupEither, LookupFuture};
 use crate::lookup_ip::{LookupIp, LookupIpFuture};
 #[cfg(feature = "tokio-runtime")]
-use crate::name_server::{NameServerPool, RuntimeProvider, TokioRuntimeProvider};
+use crate::name_server::TokioRuntimeProvider;
+use crate::name_server::{AbstractNameServerPool, RuntimeProvider};
 
 use crate::Hosts;
 
@@ -200,7 +201,8 @@ impl<P: RuntimeProvider> AsyncResolver<P> {
         options: ResolverOpts,
         conn_provider: P,
     ) -> Result<Self, ResolveError> {
-        let pool = NameServerPool::from_config_with_provider(&config, &options, conn_provider);
+        let pool =
+            AbstractNameServerPool::from_config_with_provider(&config, &options, conn_provider);
         let either;
         let client = RetryDnsHandle::new(pool, options.attempts);
         if options.validate {

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -473,7 +473,7 @@ pub mod testing {
     use std::{net::*, str::FromStr};
 
     use crate::config::{LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts};
-    use crate::name_server::{GenericConnection, GenericConnectionProvider, RuntimeProvider};
+    use crate::name_server::{GenericConnection, RuntimeProvider};
     use crate::AsyncResolver;
     use proto::{rr::Name, Executor};
 

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -43,6 +43,7 @@ where
 #[allow(clippy::type_complexity)]
 pub(crate) fn new_https_stream_with_future<S, F>(
     future: F,
+    socket_addr: SocketAddr,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
 ) -> DnsExchangeConnect<HttpsClientConnect<S>, HttpsClientStream, TokioTime>

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -287,10 +287,9 @@ pub use async_resolver::AsyncResolver;
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
 pub use async_resolver::TokioAsyncResolver;
 pub use hosts::Hosts;
-pub use name_server::ConnectionProvider;
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
-pub use name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
+pub use name_server::TokioHandle;
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
 pub use resolver::Resolver;

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -32,7 +32,7 @@ use crate::caching_client::CachingClient;
 use crate::dns_lru::MAX_TTL;
 use crate::error::*;
 use crate::lookup_ip::LookupIpIter;
-use crate::name_server::{ConnectionProvider, NameServerPool};
+use crate::name_server::NameServerPool;
 
 /// Result of a DNS query when querying for any record type supported by the Trust-DNS Proto library.
 ///

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -401,8 +401,13 @@ pub mod tokio_runtime {
 
     impl TokioRuntimeProvider {
         /// Create a Tokio runtime
-        pub fn new() -> TokioRuntimeProvider {
-            Self {}
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+    impl Default for TokioRuntimeProvider {
+        fn default() -> Self {
+            Self
         }
     }
 
@@ -423,7 +428,7 @@ pub mod tokio_runtime {
             Box::pin(async move {
                 TokioTcpStream::connect(server_addr)
                     .await
-                    .map(|c| AsyncIoTokioAsStd(c))
+                    .map(AsyncIoTokioAsStd)
             })
         }
 

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -30,9 +30,8 @@ use tokio_rustls::client::TlsStream as TokioTlsStream;
 use proto::https::{HttpsClientConnect, HttpsClientStream};
 #[cfg(feature = "mdns")]
 use proto::multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType};
-use proto::quic::QuicLocalAddr;
 #[cfg(feature = "dns-over-quic")]
-use proto::quic::{QuicClientConnect, QuicClientStream};
+use proto::quic::{QuicClientConnect, QuicClientStream, QuicLocalAddr};
 use proto::tcp::DnsTcpStream;
 use proto::udp::DnsUdpSocket;
 use proto::{
@@ -111,13 +110,6 @@ pub trait RuntimeProvider: Clone + 'static {
         options: &ResolverOpts,
     ) -> Self::Connecting<Self::Udp>;
 
-    #[cfg(feature = "mdns")]
-    /// Create a UDP socket with configuration for mdns only.
-    fn bind_mdns_udp(
-        &self,
-        config: &NameServerConfig,
-        options: &ResolverOpts,
-    ) -> std::io::Result<std::net::UdpSocket>;
 }
 
 /// A type defines the Handle which can spawn future.
@@ -336,8 +328,8 @@ pub(crate) enum ConnectionConnect<R: RuntimeProvider> {
 /// Resolves to a new Connection
 #[must_use = "futures do nothing unless polled"]
 pub struct ConnectionFuture<R: RuntimeProvider> {
-    connect: ConnectionConnect<R>,
-    spawner: R::Handle,
+    pub(crate) connect: ConnectionConnect<R>,
+    pub(crate) spawner: R::Handle,
 }
 
 impl<R: RuntimeProvider> Future for ConnectionFuture<R> {

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -282,8 +282,9 @@ impl CreateConnection for GenericConnection {
                     )
                 };
                 #[cfg(not(feature = "dns-over-rustls"))]
-                let (stream, handle) =
-                    { crate::tls::new_tls_stream::<R>(socket_addr, bind_addr, tls_dns_name) };
+                let (stream, handle) = {
+                    crate::tls::new_tls_stream_with_future(tcp_future, socket_addr, tls_dns_name)
+                };
 
                 let dns_conn = DnsMultiplexer::with_timeout(
                     stream,

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -33,15 +33,12 @@ use tokio_rustls::client::TlsStream as TokioTlsStream;
 use crate::config::{NameServerConfig, Protocol, ResolverOpts};
 #[cfg(feature = "dns-over-https")]
 use proto::https::{HttpsClientConnect, HttpsClientStream};
-use proto::iocompat::AsyncIoTokioAsStd;
 #[cfg(feature = "mdns")]
 use proto::multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType};
 #[cfg(feature = "dns-over-quic")]
-use proto::quic::{QuicClientConnect, QuicClientStream, QuicLocalAddr};
+use proto::quic::{QuicClientConnect, QuicClientStream};
 use proto::tcp::DnsTcpStream;
 use proto::udp::DnsUdpSocket;
-#[cfg(feature = "tokio-runtime")]
-use proto::TokioTime;
 use proto::{
     self,
     error::ProtoError,
@@ -56,6 +53,10 @@ use proto::{
     },
     Time,
 };
+#[cfg(feature = "tokio-runtime")]
+use proto::{iocompat::AsyncIoTokioAsStd, TokioTime};
+#[cfg(feature = "dns-over-quic")]
+use trust_dns_proto::udp::QuicLocalAddr;
 
 use crate::error::ResolveError;
 use crate::name_server::name_server::CreateConnection;

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -5,12 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::io;
 use std::marker::Unpin;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures_util::future::{Future, FutureExt};
+use futures_util::future::{Future, FutureExt, FutureObj};
 use futures_util::stream::{Stream, StreamExt};
 use futures_util::{ready, AsyncRead, AsyncWrite};
 #[cfg(feature = "tokio-runtime")]
@@ -75,19 +76,11 @@ pub trait RuntimeProvider: Clone + 'static {
     type Tcp: DnsTcpStream;
 
     /// Create a TCP connection with custom configuration.
-    fn connect_tcp(
-        &self,
-        config: &NameServerConfig,
-        options: &ResolverOpts,
-    ) -> ConnectionFuture<Self::Tcp>;
+    fn connect_tcp(&self, server_addr: SocketAddr) -> FutureObj<io::Result<Self::Tcp>>;
 
     /// Create a UDP socket with custom configuration.
     /// *Notice: the future should be ready once returned at best effort. Otherwise UDP DNS may need much more retries.*
-    fn bind_udp(
-        &self,
-        config: &NameServerConfig,
-        options: &ResolverOpts,
-    ) -> ConnectionFuture<Self::Udp>;
+    fn bind_udp(&self, local_addr: Option<SocketAddr>) -> FutureObj<io::Result<Self::Udp>>;
 }
 
 /// A type defines the Handle which can spawn future.

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -34,6 +34,7 @@ use proto::quic::QuicLocalAddr;
 #[cfg(feature = "dns-over-quic")]
 use proto::quic::{QuicClientConnect, QuicClientStream};
 use proto::tcp::DnsTcpStream;
+use proto::udp::DnsUdpSocket;
 use proto::{
     self,
     error::ProtoError,
@@ -84,10 +85,10 @@ pub trait RuntimeProvider: Clone + 'static {
 
     #[cfg(not(feature = "dns-over-quic"))]
     /// UdpSocket
-    type Udp: UdpSocket + Send;
+    type Udp: DnsUdpSocket + Send;
     #[cfg(feature = "dns-over-quic")]
     /// UdpSocket
-    type Udp: UdpSocket + QuicLocalAddr + Send;
+    type Udp: DnsUdpSocket + QuicLocalAddr + Send;
 
     /// TcpStream
     type Tcp: DnsTcpStream;
@@ -103,6 +104,7 @@ pub trait RuntimeProvider: Clone + 'static {
     ) -> Self::Connecting<Self::Tcp>;
 
     /// Create a UDP socket with custom configuration.
+    /// *Notice: the future should be ready once returned at best effort. Otherwise UDP DNS may need much more retries.*
     fn bind_udp(
         &self,
         config: &NameServerConfig,

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -396,18 +396,13 @@ pub mod tokio_runtime {
     }
 
     /// The Tokio Runtime for async execution
-    #[derive(Clone, Copy)]
-    pub struct TokioRuntimeProvider;
+    #[derive(Clone, Default)]
+    pub struct TokioRuntimeProvider(TokioHandle);
 
     impl TokioRuntimeProvider {
         /// Create a Tokio runtime
         pub fn new() -> Self {
             Self::default()
-        }
-    }
-    impl Default for TokioRuntimeProvider {
-        fn default() -> Self {
-            Self
         }
     }
 
@@ -418,7 +413,7 @@ pub mod tokio_runtime {
         type Tcp = AsyncIoTokioAsStd<TokioTcpStream>;
 
         fn create_handle(&self) -> Self::Handle {
-            TokioHandle::default()
+            self.0.clone()
         }
 
         fn connect_tcp(

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -26,6 +26,4 @@ use self::name_server_stats::NameServerStats;
 
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
-pub use self::connection_provider::tokio_runtime::{
-    TokioConnection, TokioConnectionProvider, TokioHandle, TokioRuntime,
-};
+pub use self::connection_provider::tokio_runtime::{TokioHandle, TokioRuntimeProvider};

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -19,8 +19,8 @@ pub use self::connection_provider::{RuntimeProvider, Spawn};
 #[cfg(feature = "mdns")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
 pub(crate) use self::name_server::mdns_nameserver;
-pub use self::name_server::NameServer;
-pub use self::name_server_pool::NameServerPool;
+pub use self::name_server::{AbstractNameServer, CreateConnection, NameServer};
+pub use self::name_server_pool::{AbstractNameServerPool, NameServerPool};
 use self::name_server_state::NameServerState;
 use self::name_server_stats::NameServerStats;
 

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -14,8 +14,8 @@ mod name_server_pool;
 mod name_server_state;
 mod name_server_stats;
 
-pub use self::connection_provider::{ConnectionProvider, RuntimeProvider, Spawn};
-pub use self::connection_provider::{GenericConnection, GenericConnectionProvider};
+pub use self::connection_provider::GenericConnection;
+pub use self::connection_provider::{RuntimeProvider, Spawn};
 #[cfg(feature = "mdns")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
 pub(crate) use self::name_server::mdns_nameserver;

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -7,7 +7,7 @@
 
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
-use std::net::SocketAddr;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
@@ -17,39 +17,47 @@ use futures_util::stream::{once, Stream};
 
 #[cfg(feature = "mdns")]
 use proto::multicast::MDNS_IPV4;
-use proto::op::NoopMessageFinalizer;
-use proto::tcp::TcpClientStream;
-use proto::udp::UdpClientStream;
-use proto::xfer::{DnsExchange, DnsHandle, DnsRequest, DnsResponse, FirstAnswer};
-use proto::DnsMultiplexer;
+use proto::xfer::{DnsHandle, DnsRequest, DnsResponse, FirstAnswer};
 use tracing::debug;
 
-use crate::config::Protocol;
 use crate::config::{NameServerConfig, ResolverOpts};
 use crate::error::ResolveError;
-use crate::name_server::connection_provider::{ConnectionConnect, ConnectionFuture};
 use crate::name_server::{GenericConnection, NameServerState, NameServerStats, RuntimeProvider};
 #[cfg(feature = "mdns")]
 use proto::multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType};
 
-/// Specifies the details of a remote NameServer used for lookups
+/// This struct is needed only for testing. Specifically, `C` is needed for mocking.
 #[derive(Clone)]
-pub struct NameServer<P: RuntimeProvider + Send> {
+pub struct AbstractNameServer<
+    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
+    P: RuntimeProvider + Send,
+> {
     config: NameServerConfig,
     options: ResolverOpts,
-    client: Arc<Mutex<Option<GenericConnection>>>,
+    client: Arc<Mutex<Option<C>>>,
     state: Arc<NameServerState>,
     stats: Arc<NameServerStats>,
     runtime_provider: P,
 }
 
-impl<P: RuntimeProvider> Debug for NameServer<P> {
+/// Specifies the details of a remote NameServer used for lookups
+pub type NameServer<P> = AbstractNameServer<GenericConnection, P>;
+
+impl<C, P> Debug for AbstractNameServer<C, P>
+where
+    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
+    P: RuntimeProvider + Send,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "config: {:?}, options: {:?}", self.config, self.options)
     }
 }
 
-impl<P: RuntimeProvider> NameServer<P> {
+impl<C, P> AbstractNameServer<C, P>
+where
+    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
+    P: RuntimeProvider + Send,
+{
     /// Construct a new Nameserver with the configuration and options. The connection provider will create UDP and TCP sockets
     pub fn new(config: NameServerConfig, options: ResolverOpts, runtime_provider: P) -> Self {
         Self {
@@ -66,7 +74,7 @@ impl<P: RuntimeProvider> NameServer<P> {
     pub fn from_conn(
         config: NameServerConfig,
         options: ResolverOpts,
-        client: GenericConnection,
+        client: C,
         runtime_provider: P,
     ) -> Self {
         Self {
@@ -94,7 +102,7 @@ impl<P: RuntimeProvider> NameServer<P> {
     /// This will return a mutable client to allows for sending messages.
     ///
     /// If the connection is in a failed state, then this will establish a new connection
-    async fn connected_mut_client(&mut self) -> Result<GenericConnection, ResolveError> {
+    async fn connected_mut_client(&mut self) -> Result<C, ResolveError> {
         let mut client = self.client.lock().await;
 
         // if this is in a failure state
@@ -104,7 +112,8 @@ impl<P: RuntimeProvider> NameServer<P> {
             // TODO: we need the local EDNS options
             self.state.reinit(None);
 
-            let new_client = self.new_connection(&self.config, &self.options).await?;
+            let new_client =
+                C::new_connection(&self.runtime_provider, &self.config, &self.options).await?;
 
             // establish a new connection
             *client = Some(new_client);
@@ -115,139 +124,6 @@ impl<P: RuntimeProvider> NameServer<P> {
         Ok((*client)
             .clone()
             .expect("bad state, client should be connected"))
-    }
-
-    fn new_connection(
-        &self,
-        config: &NameServerConfig,
-        options: &ResolverOpts,
-    ) -> ConnectionFuture<P> {
-        let dns_connect = match config.protocol {
-            Protocol::Udp => {
-                let provider_handle = self.runtime_provider.clone();
-                let closure = move |addr: SocketAddr| provider_handle.bind_udp(addr);
-                let stream = UdpClientStream::with_creator(
-                    config.socket_addr,
-                    None,
-                    options.timeout,
-                    Arc::new(closure),
-                );
-                let exchange = DnsExchange::connect(stream);
-                ConnectionConnect::Udp(exchange)
-            }
-            Protocol::Tcp => {
-                let socket_addr = config.socket_addr;
-                let timeout = options.timeout;
-                let tcp_future = self.runtime_provider.connect_tcp(socket_addr);
-
-                let (stream, handle) =
-                    TcpClientStream::with_future(tcp_future, socket_addr, timeout);
-                // TODO: need config for Signer...
-                let dns_conn = DnsMultiplexer::with_timeout(
-                    stream,
-                    handle,
-                    timeout,
-                    NoopMessageFinalizer::new(),
-                );
-
-                let exchange = DnsExchange::connect(dns_conn);
-                ConnectionConnect::Tcp(exchange)
-            }
-            #[cfg(feature = "dns-over-tls")]
-            Protocol::Tls => {
-                let socket_addr = config.socket_addr;
-                let timeout = options.timeout;
-                let tls_dns_name = config.tls_dns_name.clone().unwrap_or_default();
-                let tcp_future = self.runtime_provider.connect_tcp(socket_addr);
-
-                #[cfg(feature = "dns-over-rustls")]
-                let client_config = config.tls_config.clone();
-
-                #[cfg(feature = "dns-over-rustls")]
-                let (stream, handle) = {
-                    crate::tls::new_tls_stream_with_future(
-                        tcp_future,
-                        socket_addr,
-                        tls_dns_name,
-                        client_config,
-                    )
-                };
-                #[cfg(not(feature = "dns-over-rustls"))]
-                let (stream, handle) =
-                    { crate::tls::new_tls_stream::<R>(socket_addr, bind_addr, tls_dns_name) };
-
-                let dns_conn = DnsMultiplexer::with_timeout(
-                    stream,
-                    handle,
-                    timeout,
-                    NoopMessageFinalizer::new(),
-                );
-
-                let exchange = DnsExchange::connect(dns_conn);
-                ConnectionConnect::Tls(exchange)
-            }
-            #[cfg(feature = "dns-over-https")]
-            Protocol::Https => {
-                let socket_addr = config.socket_addr;
-                let tls_dns_name = config.tls_dns_name.clone().unwrap_or_default();
-                #[cfg(feature = "dns-over-rustls")]
-                let client_config = config.tls_config.clone();
-                let tcp_future = self.runtime_provider.connect_tcp(socket_addr);
-
-                let exchange = crate::https::new_https_stream_with_future(
-                    tcp_future,
-                    socket_addr,
-                    tls_dns_name,
-                    client_config,
-                );
-                ConnectionConnect::Https(exchange)
-            }
-            #[cfg(feature = "dns-over-quic")]
-            Protocol::Quic => {
-                let socket_addr = config.socket_addr;
-                let bind_addr = config.bind_addr.unwrap_or(match socket_addr {
-                    SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
-                    SocketAddr::V6(_) => {
-                        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), 0)
-                    }
-                });
-                let tls_dns_name = config.tls_dns_name.clone().unwrap_or_default();
-                #[cfg(feature = "dns-over-rustls")]
-                let client_config = config.tls_config.clone();
-                let udp_future = self.runtime_provider.bind_udp(bind_addr);
-
-                let exchange = crate::quic::new_quic_stream_with_future(
-                    udp_future,
-                    socket_addr,
-                    tls_dns_name,
-                    client_config,
-                );
-                ConnectionConnect::Quic(exchange)
-            }
-            #[cfg(feature = "mdns")]
-            Protocol::Mdns => {
-                let socket_addr = config.socket_addr;
-                let timeout = options.timeout;
-
-                let (stream, handle) =
-                    MdnsClientStream::new(socket_addr, MdnsQueryType::OneShot, None, None, None);
-                // TODO: need config for Signer...
-                let dns_conn = DnsMultiplexer::with_timeout(
-                    stream,
-                    handle,
-                    timeout,
-                    NoopMessageFinalizer::new(),
-                );
-
-                let exchange = DnsExchange::connect(dns_conn);
-                ConnectionConnect::Mdns(exchange)
-            }
-        };
-
-        ConnectionFuture {
-            connect: dns_connect,
-            spawner: self.runtime_provider.create_handle(),
-        }
     }
 
     async fn inner_send<R: Into<DnsRequest> + Unpin + Send + 'static>(
@@ -297,8 +173,9 @@ impl<P: RuntimeProvider> NameServer<P> {
     }
 }
 
-impl<P> DnsHandle for NameServer<P>
+impl<C, P> DnsHandle for AbstractNameServer<C, P>
 where
+    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
     P: RuntimeProvider,
 {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ResolveError>> + Send>>;
@@ -316,7 +193,11 @@ where
     }
 }
 
-impl<P: RuntimeProvider> Ord for NameServer<P> {
+impl<C, P> Ord for AbstractNameServer<C, P>
+where
+    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
+    P: RuntimeProvider + Send,
+{
     /// Custom implementation of Ord for NameServer which incorporates the performance of the connection into it's ranking
     fn cmp(&self, other: &Self) -> Ordering {
         // if they are literally equal, just return
@@ -328,20 +209,33 @@ impl<P: RuntimeProvider> Ord for NameServer<P> {
     }
 }
 
-impl<P: RuntimeProvider> PartialOrd for NameServer<P> {
+impl<C, P> PartialOrd for AbstractNameServer<C, P>
+where
+    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
+    P: RuntimeProvider + Send,
+{
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<P: RuntimeProvider> PartialEq for NameServer<P> {
+impl<C, P> PartialEq for AbstractNameServer<C, P>
+where
+    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
+    P: RuntimeProvider + Send,
+{
     /// NameServers are equal if the config (connection information) are equal
     fn eq(&self, other: &Self) -> bool {
         self.config == other.config
     }
 }
 
-impl<P: RuntimeProvider> Eq for NameServer<P> {}
+impl<C, P> Eq for AbstractNameServer<C, P>
+where
+    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
+    P: RuntimeProvider + Send,
+{
+}
 
 // TODO: once IPv6 is better understood, also make this a binary keep.
 #[cfg(feature = "mdns")]
@@ -363,6 +257,19 @@ where
         bind_addr: None,
     };
     NameServer::new_with_provider(config, options, conn_provider)
+}
+
+/// Used for connection mocking
+pub trait CreateConnection: Sized {
+    type FutureConn<P: RuntimeProvider>: Future<Output = Result<Self, ResolveError>>
+        + Send
+        + 'static;
+
+    fn new_connection<P: RuntimeProvider>(
+        runtime_provider: &P,
+        config: &NameServerConfig,
+        options: &ResolverOpts,
+    ) -> Self::FutureConn<P>;
 }
 
 #[cfg(test)]

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -261,10 +261,12 @@ where
 
 /// Used for connection mocking
 pub trait CreateConnection: Sized {
+    /// Future of Self
     type FutureConn<P: RuntimeProvider>: Future<Output = Result<Self, ResolveError>>
         + Send
         + 'static;
 
+    /// Create a future of Self with the help of runtime provider.
     fn new_connection<P: RuntimeProvider>(
         runtime_provider: &P,
         config: &NameServerConfig,

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -259,7 +259,9 @@ where
     NameServer::new_with_provider(config, options, conn_provider)
 }
 
-/// Used for connection mocking
+/// Used for creating new connections.
+/// We introduce this trait as an intermediate layer for real logic and mock testing.
+/// If you are an end user and use `GenericConnection`, just ignore this trait.
 pub trait CreateConnection: Sized {
     /// Future of Self
     type FutureConn<P: RuntimeProvider>: Future<Output = Result<Self, ResolveError>>

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -30,7 +30,7 @@ use proto::multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType};
 #[derive(Clone)]
 pub struct AbstractNameServer<
     C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
-    P: RuntimeProvider + Send,
+    P: RuntimeProvider,
 > {
     config: NameServerConfig,
     options: ResolverOpts,

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -430,7 +430,6 @@ mod tests {
             bind_addr: None,
         };
         let io_loop = Runtime::new().unwrap();
-        let runtime_handle = TokioHandle::default();
         let name_server =
             future::lazy(|_| NameServer::new(config, options, TokioRuntimeProvider::new()));
 

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -23,7 +23,7 @@ use crate::config::{NameServerConfigGroup, ResolverConfig, ResolverOpts, ServerO
 use crate::error::{ResolveError, ResolveErrorKind};
 #[cfg(feature = "mdns")]
 use crate::name_server;
-use crate::name_server::{ConnectionProvider, NameServer, RuntimeProvider};
+use crate::name_server::{NameServer, RuntimeProvider};
 #[cfg(test)]
 #[cfg(feature = "tokio-runtime")]
 use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -76,7 +76,7 @@ where
                 #[cfg(not(feature = "dns-over-rustls"))]
                 let ns_config = { ns_config.clone() };
 
-                NameServer::<P>::new_with_provider(ns_config, *options, conn_provider.clone())
+                NameServer::new(ns_config, *options, conn_provider.clone())
             })
             .collect();
 
@@ -94,7 +94,7 @@ where
                 #[cfg(not(feature = "dns-over-rustls"))]
                 let ns_config = { ns_config.clone() };
 
-                NameServer::<P>::new_with_provider(ns_config, *options, conn_provider.clone())
+                NameServer::new(ns_config, *options, conn_provider.clone())
             })
             .collect();
 
@@ -113,9 +113,8 @@ where
         options: &ResolverOpts,
         conn_provider: P,
     ) -> Self {
-        let map_config_to_ns = |ns_config| {
-            NameServer::<P>::new_with_provider(ns_config, *options, conn_provider.clone())
-        };
+        let map_config_to_ns =
+            |ns_config| NameServer::new(ns_config, *options, conn_provider.clone());
 
         let (datagram, stream): (Vec<_>, Vec<_>) = name_servers
             .into_inner()
@@ -328,7 +327,7 @@ where
 
         if par_conns.is_empty() {
             if !busy.is_empty() && backoff < Duration::from_millis(300) {
-                P::Time::delay_for(backoff).await;
+                P::Timer::delay_for(backoff).await;
                 conns.extend(busy.drain(..));
                 backoff *= 2;
                 continue;

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -176,8 +176,8 @@ where
     #[allow(dead_code)]
     fn from_nameservers_test(
         options: &ResolverOpts,
-        datagram_conns: Arc<[NameServer<P>]>,
-        stream_conns: Arc<[NameServer<P>]>,
+        datagram_conns: Arc<[AbstractNameServer<C, P>]>,
+        stream_conns: Arc<[AbstractNameServer<C, P>]>,
     ) -> Self {
         Self {
             datagram_conns,
@@ -470,6 +470,7 @@ mod tests {
     use super::*;
     use crate::config::NameServerConfig;
     use crate::config::Protocol;
+    use crate::name_server::NameServer;
     use crate::name_server::TokioRuntimeProvider;
 
     #[ignore]
@@ -543,11 +544,6 @@ mod tests {
             );
         }
     }
-
-    #[test]
-    use crate::name_server;
-    #[test]
-    use crate::name_server::TokioHandle;
 
     #[test]
     fn test_multi_use_conns() {

--- a/crates/resolver/src/quic.rs
+++ b/crates/resolver/src/quic.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use proto::quic::QuicLocalAddr;
 use rustls::ClientConfig as CryptoConfig;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -18,6 +19,7 @@ use crate::config::TlsClientConfig;
 use crate::tls::CLIENT_CONFIG;
 
 #[allow(clippy::type_complexity)]
+#[allow(unused)]
 pub(crate) fn new_quic_stream(
     socket_addr: SocketAddr,
     bind_addr: Option<SocketAddr>,
@@ -42,15 +44,15 @@ pub(crate) fn new_quic_stream(
 }
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_quic_stream_with_future(
+pub(crate) fn new_quic_stream_with_future<S, F>(
     future: F,
     socket_addr: SocketAddr,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
 ) -> DnsExchangeConnect<QuicClientConnect, QuicClientStream, TokioTime>
 where
-    S: DnsUdpSocket,
-    F: Future<Output = std::io::Result<S>> + Send,
+    S: DnsUdpSocket + QuicLocalAddr + 'static,
+    F: Future<Output = std::io::Result<S>> + Send + 'static,
 {
     let client_config = client_config.map_or_else(
         || CLIENT_CONFIG.clone(),

--- a/crates/resolver/src/quic.rs
+++ b/crates/resolver/src/quic.rs
@@ -6,8 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 use rustls::ClientConfig as CryptoConfig;
+use std::future::Future;
 use std::net::SocketAddr;
 
+use proto::udp::DnsUdpSocket;
 use proto::xfer::{DnsExchange, DnsExchangeConnect};
 use proto::TokioTime;
 use trust_dns_proto::quic::{QuicClientConnect, QuicClientStream};
@@ -37,4 +39,29 @@ pub(crate) fn new_quic_stream(
         quic_builder.bind_addr(bind_addr);
     }
     DnsExchange::connect(quic_builder.build(socket_addr, dns_name))
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn new_quic_stream_with_future(
+    future: F,
+    socket_addr: SocketAddr,
+    dns_name: String,
+    client_config: Option<TlsClientConfig>,
+) -> DnsExchangeConnect<QuicClientConnect, QuicClientStream, TokioTime>
+where
+    S: DnsUdpSocket,
+    F: Future<Output = std::io::Result<S>> + Send,
+{
+    let client_config = client_config.map_or_else(
+        || CLIENT_CONFIG.clone(),
+        |TlsClientConfig(client_config)| client_config,
+    );
+
+    let mut quic_builder = QuicClientStream::builder();
+
+    // TODO: normalize the crypto config settings, can we just use common ALPN settings?
+    let crypto_config: CryptoConfig = (*client_config).clone();
+
+    quic_builder.crypto_config(crypto_config);
+    DnsExchange::connect(quic_builder.build_with_future(future, socket_addr, dns_name))
 }

--- a/crates/resolver/src/quic.rs
+++ b/crates/resolver/src/quic.rs
@@ -5,10 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use proto::quic::QuicLocalAddr;
 use rustls::ClientConfig as CryptoConfig;
 use std::future::Future;
 use std::net::SocketAddr;
+use trust_dns_proto::udp::QuicLocalAddr;
 
 use proto::udp::DnsUdpSocket;
 use proto::xfer::{DnsExchange, DnsExchangeConnect};

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -20,7 +20,7 @@ use crate::error::*;
 use crate::lookup;
 use crate::lookup::Lookup;
 use crate::lookup_ip::LookupIp;
-use crate::name_server::{TokioConnection, TokioConnectionProvider, TokioHandle};
+use crate::name_server::TokioRuntimeProvider;
 use crate::AsyncResolver;
 
 /// The Resolver is used for performing DNS queries.
@@ -35,7 +35,7 @@ pub struct Resolver {
     //   drawbacks. One major issues, is if this Resolver is shared across threads, it will cause all to block on any
     //   query. A TLS on the other hand would not, at the cost of only allowing a Resolver to be configured once per Thread
     runtime: Mutex<Runtime>,
-    async_resolver: AsyncResolver<TokioConnection, TokioConnectionProvider>,
+    async_resolver: AsyncResolver<TokioRuntimeProvider>,
 }
 
 macro_rules! lookup_fn {
@@ -80,7 +80,7 @@ impl Resolver {
         builder.enable_all();
 
         let runtime = builder.build()?;
-        let async_resolver = AsyncResolver::new(config, options, TokioHandle::default())
+        let async_resolver = AsyncResolver::new(config, options, TokioRuntimeProvider::new())
             .expect("failed to create resolver");
 
         Ok(Self {

--- a/crates/resolver/src/tls/dns_over_native_tls.rs
+++ b/crates/resolver/src/tls/dns_over_native_tls.rs
@@ -15,7 +15,7 @@ use futures_util::future::Future;
 
 use proto::error::ProtoError;
 use proto::native_tls::{TlsClientStream, TlsClientStreamBuilder};
-use proto::tcp::{Connect, DnsTcpStream};
+use proto::tcp::DnsTcpStream;
 use proto::BufDnsStreamHandle;
 
 #[allow(clippy::type_complexity)]

--- a/crates/resolver/src/tls/dns_over_native_tls.rs
+++ b/crates/resolver/src/tls/dns_over_native_tls.rs
@@ -15,7 +15,7 @@ use futures_util::future::Future;
 
 use proto::error::ProtoError;
 use proto::native_tls::{TlsClientStream, TlsClientStreamBuilder};
-use proto::tcp::Connect;
+use proto::tcp::{Connect, DnsTcpStream};
 use proto::BufDnsStreamHandle;
 
 #[allow(clippy::type_complexity)]
@@ -32,4 +32,20 @@ pub(crate) fn new_tls_stream<S: Connect>(
         tls_builder.bind_addr(bind_addr);
     }
     tls_builder.build(socket_addr, dns_name)
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn new_tls_stream_with_future<S, F>(
+    future: F,
+    socket_addr: SocketAddr,
+    dns_name: String,
+) -> (
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
+    BufDnsStreamHandle,
+)
+where
+    S: DnsTcpStream,
+    F: Future<Output = std::io::Result<S>> + Send + Unpin + 'static,
+{
+    TlsClientStreamBuilder::new().build_with_future(future, socket_addr, dns_name)
 }

--- a/crates/resolver/src/tls/dns_over_native_tls.rs
+++ b/crates/resolver/src/tls/dns_over_native_tls.rs
@@ -15,17 +15,16 @@ use futures_util::future::Future;
 
 use proto::error::ProtoError;
 use proto::native_tls::{TlsClientStream, TlsClientStreamBuilder};
+use proto::tcp::Connect;
 use proto::BufDnsStreamHandle;
 
-use crate::name_server::RuntimeProvider;
-
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_tls_stream<R: RuntimeProvider>(
+pub(crate) fn new_tls_stream<S: Connect>(
     socket_addr: SocketAddr,
     bind_addr: Option<SocketAddr>,
     dns_name: String,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
     let mut tls_builder = TlsClientStreamBuilder::new();

--- a/crates/resolver/src/tls/dns_over_native_tls.rs
+++ b/crates/resolver/src/tls/dns_over_native_tls.rs
@@ -19,22 +19,6 @@ use proto::tcp::{Connect, DnsTcpStream};
 use proto::BufDnsStreamHandle;
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_tls_stream<S: Connect>(
-    socket_addr: SocketAddr,
-    bind_addr: Option<SocketAddr>,
-    dns_name: String,
-) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
-    BufDnsStreamHandle,
-) {
-    let mut tls_builder = TlsClientStreamBuilder::new();
-    if let Some(bind_addr) = bind_addr {
-        tls_builder.bind_addr(bind_addr);
-    }
-    tls_builder.build(socket_addr, dns_name)
-}
-
-#[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream_with_future<S, F>(
     future: F,
     socket_addr: SocketAddr,

--- a/crates/resolver/src/tls/dns_over_openssl.rs
+++ b/crates/resolver/src/tls/dns_over_openssl.rs
@@ -15,17 +15,16 @@ use futures_util::future::Future;
 
 use proto::error::ProtoError;
 use proto::openssl::{TlsClientStream, TlsClientStreamBuilder};
+use proto::tcp::Connect;
 use proto::BufDnsStreamHandle;
 
-use crate::name_server::RuntimeProvider;
-
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_tls_stream<R: RuntimeProvider>(
+pub(crate) fn new_tls_stream<S: Connect>(
     socket_addr: SocketAddr,
     bind_addr: Option<SocketAddr>,
     dns_name: String,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
     let mut tls_builder = TlsClientStreamBuilder::new();

--- a/crates/resolver/src/tls/dns_over_openssl.rs
+++ b/crates/resolver/src/tls/dns_over_openssl.rs
@@ -15,7 +15,7 @@ use futures_util::future::Future;
 
 use proto::error::ProtoError;
 use proto::openssl::{TlsClientStream, TlsClientStreamBuilder};
-use proto::tcp::{Connect, DnsTcpStream};
+use proto::tcp::DnsTcpStream;
 use proto::BufDnsStreamHandle;
 
 #[allow(clippy::type_complexity)]

--- a/crates/resolver/src/tls/dns_over_openssl.rs
+++ b/crates/resolver/src/tls/dns_over_openssl.rs
@@ -15,7 +15,7 @@ use futures_util::future::Future;
 
 use proto::error::ProtoError;
 use proto::openssl::{TlsClientStream, TlsClientStreamBuilder};
-use proto::tcp::Connect;
+use proto::tcp::{Connect, DnsTcpStream};
 use proto::BufDnsStreamHandle;
 
 #[allow(clippy::type_complexity)]
@@ -32,4 +32,20 @@ pub(crate) fn new_tls_stream<S: Connect>(
         tls_builder.bind_addr(bind_addr);
     }
     tls_builder.build(socket_addr, dns_name)
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn new_tls_stream_with_future<S, F>(
+    future: F,
+    socket_addr: SocketAddr,
+    dns_name: String,
+) -> (
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
+    BufDnsStreamHandle,
+)
+where
+    S: DnsTcpStream,
+    F: Future<Output = std::io::Result<S>> + Send + Unpin + 'static,
+{
+    TlsClientStreamBuilder::new().build_with_future(future, socket_addr, dns_name)
 }

--- a/crates/resolver/src/tls/dns_over_openssl.rs
+++ b/crates/resolver/src/tls/dns_over_openssl.rs
@@ -19,22 +19,6 @@ use proto::tcp::{Connect, DnsTcpStream};
 use proto::BufDnsStreamHandle;
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_tls_stream<S: Connect>(
-    socket_addr: SocketAddr,
-    bind_addr: Option<SocketAddr>,
-    dns_name: String,
-) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
-    BufDnsStreamHandle,
-) {
-    let mut tls_builder = TlsClientStreamBuilder::new();
-    if let Some(bind_addr) = bind_addr {
-        tls_builder.bind_addr(bind_addr);
-    }
-    tls_builder.build(socket_addr, dns_name)
-}
-
-#[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream_with_future<S, F>(
     future: F,
     socket_addr: SocketAddr,

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -56,25 +56,6 @@ lazy_static! {
 }
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn new_tls_stream<S: Connect>(
-    socket_addr: SocketAddr,
-    bind_addr: Option<SocketAddr>,
-    dns_name: String,
-    client_config: Option<TlsClientConfig>,
-) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
-    BufDnsStreamHandle,
-) {
-    let client_config = client_config.map_or_else(
-        || CLIENT_CONFIG.clone(),
-        |TlsClientConfig(client_config)| client_config,
-    );
-    let (stream, handle) =
-        tls_client_connect_with_bind_addr(socket_addr, bind_addr, dns_name, client_config);
-    (Box::pin(stream), handle)
-}
-
-#[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream_with_future<S, F>(
     future: F,
     socket_addr: SocketAddr,

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -78,10 +78,11 @@ pub(crate) fn new_tls_stream<R: RuntimeProvider>(
 #[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream_with_future<S, F>(
     future: F,
+    socket_addr: SocketAddr,
     dns_name: String,
     client_config: Option<TlsClientConfig>,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<R::Tcp>, ProtoError>> + Send>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 )
 where
@@ -92,6 +93,7 @@ where
         || CLIENT_CONFIG.clone(),
         |TlsClientConfig(client_config)| client_config,
     );
-    let (stream, handle) = tls_client_connect_with_future(future, dns_name, client_config);
+    let (stream, handle) =
+        tls_client_connect_with_future(future, socket_addr, dns_name, client_config);
     (Box::pin(stream), handle)
 }

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -18,8 +18,8 @@ use rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
 
 use proto::error::ProtoError;
 use proto::rustls::tls_client_stream::tls_client_connect_with_future;
-use proto::rustls::{tls_client_connect_with_bind_addr, TlsClientStream};
-use proto::tcp::{Connect, DnsTcpStream};
+use proto::rustls::TlsClientStream;
+use proto::tcp::DnsTcpStream;
 use proto::BufDnsStreamHandle;
 
 use crate::config::TlsClientConfig;

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -13,7 +13,6 @@ mod dns_over_rustls;
 
 cfg_if! {
     if #[cfg(feature = "dns-over-rustls")] {
-        pub(crate) use self::dns_over_rustls::new_tls_stream;
         pub(crate) use self::dns_over_rustls::new_tls_stream_with_future;
         #[cfg(any(feature = "dns-over-https-rustls", feature = "dns-over-quic"))]
         pub(crate) use self::dns_over_rustls::CLIENT_CONFIG;
@@ -34,7 +33,8 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::{TokioAsyncResolver, TokioHandle};
+    use crate::name_server::TokioRuntimeProvider;
+    use crate::TokioAsyncResolver;
 
     fn tls_test(config: ResolverConfig) {
         let io_loop = Runtime::new().unwrap();
@@ -45,7 +45,7 @@ mod tests {
                 try_tcp_on_error: true,
                 ..ResolverOpts::default()
             },
-            TokioHandle::default(),
+            TokioRuntimeProvider::default(),
         )
         .expect("failed to create resolver");
 

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -14,6 +14,7 @@ mod dns_over_rustls;
 cfg_if! {
     if #[cfg(feature = "dns-over-rustls")] {
         pub(crate) use self::dns_over_rustls::new_tls_stream;
+        pub(crate) use self::dns_over_rustls::new_tls_stream_with_future;
         #[cfg(any(feature = "dns-over-https-rustls", feature = "dns-over-quic"))]
         pub(crate) use self::dns_over_rustls::CLIENT_CONFIG;
     } else if #[cfg(feature = "dns-over-native-tls")] {

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -17,7 +17,7 @@ cfg_if! {
         #[cfg(any(feature = "dns-over-https-rustls", feature = "dns-over-quic"))]
         pub(crate) use self::dns_over_rustls::CLIENT_CONFIG;
     } else if #[cfg(feature = "dns-over-native-tls")] {
-        pub(crate) use self::dns_over_native_tls::new_tls_stream;
+        pub(crate) use self::dns_over_native_tls::new_tls_stream_with_future;
     } else if #[cfg(feature = "dns-over-openssl")] {
         pub(crate) use self::dns_over_openssl::new_tls_stream;
     } else {

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -19,7 +19,7 @@ cfg_if! {
     } else if #[cfg(feature = "dns-over-native-tls")] {
         pub(crate) use self::dns_over_native_tls::new_tls_stream_with_future;
     } else if #[cfg(feature = "dns-over-openssl")] {
-        pub(crate) use self::dns_over_openssl::new_tls_stream;
+        pub(crate) use self::dns_over_openssl::new_tls_stream_with_future;
     } else {
         compile_error!("One of the dns-over-rustls, dns-over-native-tls, or dns-over-openssl must be enabled for dns-over-tls features");
     }

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 use trust_dns_proto::rr::{Name, RData, RecordType};
-use trust_dns_resolver::TokioHandle;
+use trust_dns_resolver::name_server::TokioRuntimeProvider;
 use trust_dns_server::{
     authority::{Authority, LookupObject},
     store::forwarder::ForwardAuthority,
@@ -18,7 +18,7 @@ use trust_dns_server::{
 fn test_lookup() {
     let runtime = Runtime::new().expect("failed to create Tokio Runtime");
     let forwarder =
-        ForwardAuthority::new(TokioHandle::default()).expect("failed to create forwarder");
+        ForwardAuthority::new(TokioRuntimeProvider::new()).expect("failed to create forwarder");
 
     let lookup = runtime
         .block_on(forwarder.lookup(

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -133,6 +133,7 @@ impl<O: OnSend + Unpin> RuntimeProvider for MockConnProvider<O> {
     fn bind_udp(
         &self,
         _local_addr: SocketAddr,
+        _server_addr: SocketAddr,
     ) -> Pin<Box<dyn Send + Future<Output = std::io::Result<Self::Udp>>>> {
         Box::pin(async { Ok(UdpPlaceholder) })
     }

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -18,9 +18,10 @@ use futures::{future, AsyncRead, AsyncWrite, Future};
 use trust_dns_client::op::{Message, Query};
 use trust_dns_client::rr::{rdata::SOA, Name, RData, Record};
 use trust_dns_proto::error::ProtoError;
-use trust_dns_proto::quic::QuicLocalAddr;
 use trust_dns_proto::tcp::DnsTcpStream;
 use trust_dns_proto::udp::DnsUdpSocket;
+#[cfg(feature = "dns-over-quic")]
+use trust_dns_proto::udp::QuicLocalAddr;
 use trust_dns_proto::xfer::{DnsHandle, DnsRequest, DnsResponse};
 use trust_dns_proto::TokioTime;
 use trust_dns_resolver::config::{NameServerConfig, ResolverOpts};

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -15,12 +15,9 @@ use trust_dns_client::rr::{Name, RecordType};
 use trust_dns_integration::mock_client::*;
 use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::{DnsHandle, DnsResponse, FirstAnswer};
-use trust_dns_proto::TokioTime;
 use trust_dns_resolver::config::*;
 use trust_dns_resolver::error::{ResolveError, ResolveErrorKind};
-use trust_dns_resolver::name_server::{
-    AbstractNameServer, AbstractNameServerPool, NameServer, NameServerPool, RuntimeProvider,
-};
+use trust_dns_resolver::name_server::{AbstractNameServer, AbstractNameServerPool};
 
 const DEFAULT_SERVER_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -18,7 +18,7 @@ use trust_dns_proto::xfer::{DnsHandle, DnsResponse, FirstAnswer};
 use trust_dns_proto::TokioTime;
 use trust_dns_resolver::config::*;
 use trust_dns_resolver::error::{ResolveError, ResolveErrorKind};
-use trust_dns_resolver::name_server::{ConnectionProvider, NameServer, NameServerPool};
+use trust_dns_resolver::name_server::{NameServer, NameServerPool};
 
 const DEFAULT_SERVER_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 


### PR DESCRIPTION
# Why we need new interface?
Current `ConnectionProvider` interface didn't provide enough ability for end-users to create customized connections, although it looked like. For example, users find it hard to customize underlying TCP or UDP sockets, see #1863, #1870, #1335. Users may also seek for abstract TCP stream instead of real one. Related discussion can be found on #1863.

# What is our plan?
We design new `RuntimeProvider` interface, whose responsibility is to provide TCP-like and UDP-like connections. Currently, the new interface looks like: 
```rust
pub trait RuntimeProvider: Clone + Send + Sync + Unpin + 'static {
    type Handle: Clone + Send + Spawn + Sync + Unpin;
    type Timer: Time + Send + Unpin;
    type Udp: DnsUdpSocket + Send;
    type Tcp: DnsTcpStream;

    /// Create a runtime handle
    fn create_handle(&self) -> Self::Handle;

    /// Create a TCP connection with custom configuration.
    fn connect_tcp(
        &self, server_addr: SocketAddr,
    ) -> Pin<Box<dyn Send + Future<Output = io::Result<Self::Tcp>>>>;

    /// Create a UDP socket bound to `local_addr`. The returned value should **not** be connected to `server_addr`.
    /// *Notice: the future should be ready once returned at best effort. Otherwise UDP DNS may need much more retries.*
    fn bind_udp(
        &self, local_addr: SocketAddr, server_addr: SocketAddr,
    ) -> Pin<Box<dyn Send + Future<Output = io::Result<Self::Udp>>>>;
}
```
where we introduce new `DnsUdpSocket` as the counterpart of `DnsTcpSocket` ,removing requirements for bind and connect.

# Design problems
- <del>Should we take `GenericConnection` as our only implementation, or leaving some interface for users to implement their own ones? </del>
# Progress
- Underlying support
  - [x] support for providing customized TCP stream
  - [x] support for providing customized UDP socket for quic
  - [x] support for providing customized UDP socket for udp
- [x] change interface
- [x] fix dependent code
- [x] fix tests
- [x] pass tests