### PR TITLE
deps: upgrade Tokio 1.21.0 -> 1.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,9 +1630,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1640,11 +1640,10 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Description

This branch updates the `Cargo.lock` file with the output produced by `cargo update -p tokio`, updating Tokio from [1.21.0](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.21.0) to [1.24.1](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.24.1). 

Notably this resolves [RUSTSEC-2023-0001](https://rustsec.org/advisories/RUSTSEC-2023-0001), which was previously flagged in CI by `cargo audit`.

#### Note to reviewers

As a word of warning, there's a [decent number of commits](https://github.com/tokio-rs/tokio/compare/tokio-1.21.0...tokio-1.24.1) between these two tags and the vuln itself seems uninteresting for trust-dns. I'm probably too new to this codebase and the Tokio ecosystem to safely vet the update beyond saying that `cargo make test` passes locally, so this may require more analysis by a maintainer. It's also possible we could specify a more precise version to `cargo update -p tokio` to resolve the vuln with less of a semver jump.

#### Cargo audit
<details>
<summary>tip of main cargo audit output</summary>

```
[nix-shell:~/Code/Rust/trust-dns]$ git rev-parse HEAD
7232d887d1d0c0ade287e40e09250bf74a9b137a

[nix-shell:~/Code/Rust/trust-dns]$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 478 security advisories (from /home/daniel/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (231 crate dependencies)
Crate:     tokio
Version:   1.21.0
Title:     reject_remote_clients Configuration corruption
Date:      2023-01-04
ID:        RUSTSEC-2023-0001
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0001
Solution:  Upgrade to >=1.18.4, <1.19.0 OR >=1.20.3, <1.21.0 OR >=1.23.1
Dependency tree:
tokio 1.21.0
├── trust-dns-util 0.22.0
├── trust-dns-server 0.22.0
│   ├── trust-dns-integration 0.22.0
│   └── trust-dns 0.22.0
├── trust-dns-resolver 0.22.0
│   ├── trust-dns-util 0.22.0
│   ├── trust-dns-server 0.22.0
│   ├── trust-dns-recursor 0.22.0
│   │   ├── trust-dns-util 0.22.0
│   │   ├── trust-dns-server 0.22.0
│   │   └── trust-dns-integration 0.22.0
│   ├── trust-dns-integration 0.22.0
│   ├── trust-dns 0.22.0
│   └── async-std-resolver 0.22.0
├── trust-dns-recursor 0.22.0
├── trust-dns-proto 0.22.0
│   ├── trust-dns-util 0.22.0
│   ├── trust-dns-server 0.22.0
│   ├── trust-dns-resolver 0.22.0
│   ├── trust-dns-recursor 0.22.0
│   ├── trust-dns-integration 0.22.0
│   ├── trust-dns-client 0.22.0
│   │   ├── trust-dns-util 0.22.0
│   │   ├── trust-dns-server 0.22.0
│   │   ├── trust-dns-integration 0.22.0
│   │   ├── trust-dns-compatibility 0.22.0
│   │   └── trust-dns 0.22.0
│   └── trust-dns 0.22.0
├── trust-dns-integration 0.22.0
├── trust-dns-client 0.22.0
├── trust-dns 0.22.0
├── tokio-util 0.7.3
│   └── h2 0.3.14
│       ├── trust-dns-server 0.22.0
│       └── trust-dns-proto 0.22.0
├── tokio-rustls 0.23.4
│   ├── trust-dns-server 0.22.0
│   ├── trust-dns-resolver 0.22.0
│   └── trust-dns-proto 0.22.0
├── tokio-openssl 0.6.3
│   ├── trust-dns-server 0.22.0
│   ├── trust-dns-resolver 0.22.0
│   └── trust-dns-proto 0.22.0
├── tokio-native-tls 0.3.0
│   ├── trust-dns-resolver 0.22.0
│   └── trust-dns-proto 0.22.0
├── quinn 0.9.0
│   └── trust-dns-proto 0.22.0
└── h2 0.3.14

error: 1 vulnerability found!
```
</details>

<details>
<summary>branch cargo audit output:</summary>

```
[nix-shell:~/Code/Rust/trust-dns]$ git rev-parse HEAD
1056bb41d4b1a0a58c4d1926ab52dc60fd459a79

[nix-shell:~/Code/Rust/trust-dns]$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 478 security advisories (from /home/daniel/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (231 crate dependencies)

```
</details>