### PR TITLE
proto: clean up error logging

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -328,6 +328,10 @@ impl ProtoError {
     pub fn is_busy(&self) -> bool {
         matches!(*self.kind, ProtoErrorKind::Busy)
     }
+
+    pub(crate) fn as_dyn(&self) -> &(dyn std::error::Error + 'static) {
+        self
+    }
 }
 
 impl fmt::Display for ProtoError {

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -196,7 +196,7 @@ where
                     let (dns_request, serial_response): (DnsRequest, _) = dns_request.into_parts();
 
                     // Try to forward the `DnsResponseStream` to the requesting task. If we fail,
-                    // it must be because the requesting task has gone away / is no longerwarn!
+                    // it must be because the requesting task has gone away / is no longer
                     // interested. In that case, we can just log a warning, but there's no need
                     // to take any more serious measures (such as shutting down this task).
                     match serial_response.send_response(io_stream.send_message(dns_request)) {

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -179,7 +179,10 @@ where
                     return Poll::Ready(Ok(()));
                 }
                 Poll::Ready(Some(Err(err))) => {
-                    debug!("io_stream hit an error, shutting down");
+                    debug!(
+                        error = err.as_dyn(),
+                        "io_stream hit an error, shutting down"
+                    );
 
                     return Poll::Ready(Err(err));
                 }
@@ -324,7 +327,7 @@ where
                         }
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(error)) => {
-                            debug!("stream errored while connecting: {:?}", error);
+                            debug!(erorr = error.as_dyn(), "stream errored while connecting");
                             next = Self::FailAll {
                                 error,
                                 outbound_messages: outbound_messages

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -327,7 +327,7 @@ where
                         }
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(error)) => {
-                            debug!(erorr = error.as_dyn(), "stream errored while connecting");
+                            debug!(error = error.as_dyn(), "stream errored while connecting");
                             next = Self::FailAll {
                                 error,
                                 outbound_messages: outbound_messages

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -179,7 +179,7 @@ where
                     return Poll::Ready(Ok(()));
                 }
                 Poll::Ready(Some(Err(err))) => {
-                    warn!("io_stream hit an error, shutting down: {}", err);
+                    debug!("io_stream hit an error, shutting down");
 
                     return Poll::Ready(Err(err));
                 }
@@ -193,7 +193,7 @@ where
                     let (dns_request, serial_response): (DnsRequest, _) = dns_request.into_parts();
 
                     // Try to forward the `DnsResponseStream` to the requesting task. If we fail,
-                    // it must be because the requesting task has gone away / is no longer
+                    // it must be because the requesting task has gone away / is no longerwarn!
                     // interested. In that case, we can just log a warning, but there's no need
                     // to take any more serious measures (such as shutting down this task).
                     match serial_response.send_response(io_stream.send_message(dns_request)) {

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -198,11 +198,7 @@ where
 
     /// Closes all outstanding completes with a closed stream error
     fn stream_closed_close_all(&mut self, error: ProtoError) {
-        if !self.active_requests.is_empty() {
-            warn!("stream {} error: {}", self.stream, error);
-        } else {
-            debug!("stream {} error: {}", self.stream, error);
-        }
+        debug!("stream {} error: {}", self.stream, error);
 
         for (_, active_request) in self.active_requests.drain() {
             // complete the request, it's failed...


### PR DESCRIPTION
This branch changes some log messages in `trust-dns-proto` from the `WARN` level to the `DEBUG` level. In addition, while I was here, I also made a small change to improve how errors are recorded in these `tracing` events.

This branch consists of the following commits:

+ **proto: log errors as structured `tracing` fields**
  
  This commit changes `trust-dns-proto` to record errors `dyn Error` trait
  objects in structured `tracing` fields. This allows a `tracing`
  subscriber to choose to display richer representations of these errors,
  such as recording their source chains, as they are recorded as a value
  implementing the `Error` trait rather than an unstructured
  `fmt::Debug`/`fmt::Display` value.
  
+ **proto: log DnsExchange io stream error at `DEBUG`**
  
  Currently, this error is logged at the `WARN` level. However, the error
  is returned in the future's output, so user code can determine whether
  it should be logged at a higher verbosity level or hidden entirely.
  Therefore, this commit changes the error to be logged at the `DEBUG`
  level.
  
+ **proto: always log stream closed errors at `DEBUG`**
  
  Currently, the `DnsMultiplexer` will log stream closed errors at `DEBUG`
  if there are no active requests, or at `WARN` if there are active
  requests. This results in innocuous errors like a TCP stream closing
  being logged as warnings in some cases.
  
  Since the error is already propagated to all active requests when
  closing them, user code can determine whether this should be logged at a
  higher verbosity level or simply ignored. This commit changes the
  `stream_closed_close_all` function to always log at the `DEBUG` level.
  
  Fixes #1880