### PR TITLE
client: rm zone parse optional class arg.

### DIFF
--- a/crates/client/src/serialize/txt/rdata_parsers/svcb.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/svcb.rs
@@ -321,7 +321,6 @@ where
 mod tests {
     use trust_dns_proto::rr::RData;
 
-    use crate::rr::DNSClass;
     use crate::serialize::txt::{Lexer, Parser};
 
     use super::*;
@@ -333,7 +332,7 @@ mod tests {
         let mut parser = Parser::new();
 
         let records = parser
-            .parse(lex, Some(Name::root()), Some(DNSClass::IN))
+            .parse(lex, Some(Name::root()))
             .expect("failed to parse record")
             .1;
         let record_set = records.into_iter().next().expect("no record found").1;

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -16,7 +16,6 @@ use std::{
 };
 
 use tracing::{debug, info};
-use trust_dns_proto::rr::DNSClass;
 
 #[cfg(feature = "dnssec")]
 use crate::{
@@ -198,7 +197,7 @@ impl FileAuthority {
 
         let lexer = Lexer::new(&buf);
         let (origin, records) = Parser::new()
-            .parse(lexer, Some(origin), Some(DNSClass::IN))
+            .parse(lexer, Some(origin))
             .map_err(|e| format!("failed to parse {}: {:?}", config.zone_file_path, e))?;
 
         info!(

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -15,7 +15,7 @@ use std::{
 
 use serde::Deserialize;
 use trust_dns_client::{
-    rr::{DNSClass, RData, Record, RecordSet},
+    rr::{RData, Record, RecordSet},
     serialize::txt::{Lexer, Parser},
 };
 use trust_dns_resolver::Name;
@@ -47,7 +47,7 @@ impl RecursiveConfig {
         let lexer = Lexer::new(&roots_str);
         let mut parser = Parser::new();
 
-        let (_zone, roots_zone) = parser.parse(lexer, Some(Name::root()), Some(DNSClass::IN))?;
+        let (_zone, roots_zone) = parser.parse(lexer, Some(Name::root()))?;
 
         // TODO: we may want to deny some of the root nameservers, for reasons...
         Ok(roots_zone

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -58,7 +58,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()), None);
+    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()));
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
     }
@@ -424,7 +424,7 @@ a       A       127.0.0.1
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()), None);
+    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()));
 
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
@@ -452,7 +452,7 @@ b       A       127.0.0.2
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()), None);
+    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()));
 
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
@@ -479,7 +479,7 @@ a       A       127.0.0.1
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()), None);
+    let records = Parser::new().parse(lexer, Some(Name::from_str("isi.edu").unwrap()));
 
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())
@@ -498,7 +498,7 @@ fn test_named_root() {
 "###,
     );
 
-    let records = Parser::new().parse(lexer, Some(Name::root()), Some(DNSClass::IN));
+    let records = Parser::new().parse(lexer, Some(Name::root()));
 
     if records.is_err() {
         panic!("failed to parse: {:?}", records.err())


### PR DESCRIPTION
This branch is a follow-up for https://github.com/bluejekyll/trust-dns/pull/1874. It removes the optional DNSClass argument from the client crate's txt serialization `Parser.parse` func.

For trust-dns's use-cases the argument is redundant and we can assume the IN ("internet") class. Records parsed from the zone data must either omit a class (in which case IN is implicit) or specify IN explicitly (no mismatched classes).