### PR TITLE
deps: upgrade bumpalo 3.11.0 -> 3.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"


### PR DESCRIPTION
This commit updates the `Cargo.lock` file with the output produced by `cargo update -p bumpalo --precise 3.11.1`, updating a transitive dependency on the `bumpalo` crate from 3.11.0 to 3.11.1.

Notably this resolves [RUSTSEC-2022-0078](https://rustsec.org/advisories/RUSTSEC-2022-0078). which was previously flagged in CI by `cargo audit`.

<details>
<summary>cargo audit of main tip:</summary>

```

[nix-shell:~/Code/Rust/trust-dns]$ git rev-parse HEAD
e5075c6059d317629fc2844c9f1d6a853bb3490e

[nix-shell:~/Code/Rust/trust-dns]$ cargo audit --deny warnings
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 486 security advisories (from /home/daniel/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (231 crate dependencies)
Crate:     bumpalo
Version:   3.11.0
Warning:   unsound
Title:     Use-after-free due to a lifetime error in `Vec::into_iter()`
Date:      2022-01-14
ID:        RUSTSEC-2022-0078
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0078
Dependency tree:
bumpalo 3.11.0
└── wasm-bindgen-backend 0.2.82
    └── wasm-bindgen-macro-support 0.2.82
        └── wasm-bindgen-macro 0.2.82
            └── wasm-bindgen 0.2.82
                ├── web-sys 0.3.59
                │   ├── wasm-bindgen-futures 0.4.32
                │   │   └── async-std 1.12.0
                │   │       └── async-std-resolver 0.22.0
                │   └── ring 0.16.20
                │       ├── webpki 0.22.0
                │       │   ├── webpki-roots 0.22.4
                │       │   │   ├── trust-dns-util 0.22.0
                │       │   │   ├── trust-dns-resolver 0.22.0
                │       │   │   │   ├── trust-dns-util 0.22.0
                │       │   │   │   ├── trust-dns-server 0.22.0
                │       │   │   │   │   ├── trust-dns-integration 0.22.0
                │       │   │   │   │   └── trust-dns 0.22.0
                │       │   │   │   ├── trust-dns-recursor 0.22.0
                │       │   │   │   │   ├── trust-dns-util 0.22.0
                │       │   │   │   │   ├── trust-dns-server 0.22.0
                │       │   │   │   │   └── trust-dns-integration 0.22.0
                │       │   │   │   ├── trust-dns-integration 0.22.0
                │       │   │   │   ├── trust-dns 0.22.0
                │       │   │   │   └── async-std-resolver 0.22.0
                │       │   │   ├── trust-dns-proto 0.22.0
                │       │   │   │   ├── trust-dns-util 0.22.0
                │       │   │   │   ├── trust-dns-server 0.22.0
                │       │   │   │   ├── trust-dns-resolver 0.22.0
                │       │   │   │   ├── trust-dns-recursor 0.22.0
                │       │   │   │   ├── trust-dns-integration 0.22.0
                │       │   │   │   ├── trust-dns-client 0.22.0
                │       │   │   │   │   ├── trust-dns-util 0.22.0
                │       │   │   │   │   ├── trust-dns-server 0.22.0
                │       │   │   │   │   ├── trust-dns-integration 0.22.0
                │       │   │   │   │   ├── trust-dns-compatibility 0.22.0
                │       │   │   │   │   └── trust-dns 0.22.0
                │       │   │   │   └── trust-dns 0.22.0
                │       │   │   ├── trust-dns-integration 0.22.0
                │       │   │   └── trust-dns 0.22.0
                │       │   ├── trust-dns-util 0.22.0
                │       │   ├── trust-dns-proto 0.22.0
                │       │   ├── trust-dns-client 0.22.0
                │       │   ├── tokio-rustls 0.23.4
                │       │   │   ├── trust-dns-server 0.22.0
                │       │   │   ├── trust-dns-resolver 0.22.0
                │       │   │   └── trust-dns-proto 0.22.0
                │       │   ├── rustls 0.20.6
                │       │   │   ├── trust-dns-util 0.22.0
                │       │   │   ├── trust-dns-server 0.22.0
                │       │   │   ├── trust-dns-resolver 0.22.0
                │       │   │   ├── trust-dns-proto 0.22.0
                │       │   │   ├── trust-dns-integration 0.22.0
                │       │   │   ├── trust-dns-client 0.22.0
                │       │   │   ├── trust-dns 0.22.0
                │       │   │   ├── tokio-rustls 0.23.4
                │       │   │   ├── quinn-proto 0.9.0
                │       │   │   │   ├── quinn-udp 0.3.0
                │       │   │   │   │   └── quinn 0.9.0
                │       │   │   │   │       └── trust-dns-proto 0.22.0
                │       │   │   │   └── quinn 0.9.0
                │       │   │   └── quinn 0.9.0
                │       │   ├── quinn-proto 0.9.0
                │       │   └── quinn 0.9.0
                │       ├── trust-dns-proto 0.22.0
                │       ├── trust-dns-client 0.22.0
                │       ├── sct 0.7.0
                │       │   └── rustls 0.20.6
                │       ├── rustls 0.20.6
                │       └── quinn-proto 0.9.0
                ├── wasm-bindgen-futures 0.4.32
                ├── trust-dns-proto 0.22.0
                ├── js-sys 0.3.59
                │   ├── web-sys 0.3.59
                │   ├── wasm-bindgen-futures 0.4.32
                │   ├── trust-dns-proto 0.22.0
                │   └── gloo-timers 0.2.4
                │       └── async-std 1.12.0
                └── gloo-timers 0.2.4

error: 1 denied warning found!
```
</details>