### PR TITLE
docs: fix truncated rustdoc TODO on LowerName.

### DIFF
--- a/crates/proto/src/rr/lower_name.rs
+++ b/crates/proto/src/rr/lower_name.rs
@@ -20,6 +20,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use crate::rr::Name;
 use crate::serialize::binary::*;
 
+/// TODO: all LowerNames should be stored in a global "intern" space, and then everything that uses
 ///  them should be through references. As a workaround the Strings are all Rc as well as the array
 #[derive(Default, Debug, Eq, Clone)]
 pub struct LowerName(Name);


### PR DESCRIPTION
:wave: I noticed [the Rustdoc for the client `LowerName` type](https://docs.rs/trust-dns-client/latest/trust_dns_client/rr/struct.LowerName.html) was confusing. In total it says "them should be through references. As a workaround the Strings are all Rc as well as the array" :thinking: I traced down what happened with some Git spelunking.

In ec059f3 the `LowerName` type was introduced along with [two TODO rustdoc comments](https://github.com/bluejekyll/trust-dns/commit/ec059f38d0a3c46b4d8d448ddd36f9b1a42c287f#diff-5530b6a4d1c8c113a81cba0a5b94a78fe849b53bda8ec027ea6c55bdeb30640fR24-R28), one for refactoring to use references into a global intern space and one for supporting non-utf8 encodings.

In 55477de, the UTF-8 TODO was resolved and Punycode/IDNA support was added. As an unintended side-effect, it looks like this commit also truncated the first TODO, leaving a dangling piece of text.

This commit restores the missing piece of text about using references into a global intern space in the future.