### PR TITLE
Make dns_hostname optional to disable verify

### DIFF
--- a/bin/src/trust-dns.rs
+++ b/bin/src/trust-dns.rs
@@ -577,11 +577,18 @@ fn config_https(
     }
 
     for https_listener in &https_sockaddrs {
-        info!(
-            "loading cert for DNS over TLS named {} from {:?}",
-            tls_cert_config.get_endpoint_name(),
-            tls_cert_config.get_path()
-        );
+        if let Some(endpoint_name) = tls_cert_config.get_endpoint_name() {
+            info!(
+                "loading cert for DNS over TLS named {} from {:?}",
+                endpoint_name,
+                tls_cert_config.get_path()
+            );
+        } else {
+            info!(
+                "loading cert for DNS over TLS from {:?}",
+                tls_cert_config.get_path()
+            );
+        }
         // TODO: see about modifying native_tls to impl Clone for Pkcs12
         let tls_cert = dnssec::load_cert(zone_dir, tls_cert_config)
             .expect("error loading tls certificate file");
@@ -605,7 +612,7 @@ fn config_https(
                 https_listener,
                 config.get_tcp_request_timeout(),
                 tls_cert,
-                tls_cert_config.get_endpoint_name().to_string(),
+                tls_cert_config.get_endpoint_name().map(|s| s.to_string()),
             )
             .expect("could not register HTTPS listener");
     }
@@ -636,11 +643,18 @@ fn config_quic(
     }
 
     for quic_listener in &quic_sockaddrs {
-        info!(
-            "loading cert for DNS over TLS named {} from {:?}",
-            tls_cert_config.get_endpoint_name(),
-            tls_cert_config.get_path()
-        );
+        if let Some(endpoint_name) = tls_cert_config.get_endpoint_name() {
+            info!(
+                "loading cert for DNS over QUIC named {} from {:?}",
+                endpoint_name,
+                tls_cert_config.get_path()
+            );
+        } else {
+            info!(
+                "loading cert for DNS over QUIC from {:?}",
+                tls_cert_config.get_path()
+            );
+        }
         // TODO: see about modifying native_tls to impl Clone for Pkcs12
         let tls_cert = dnssec::load_cert(zone_dir, tls_cert_config)
             .expect("error loading tls certificate file");
@@ -664,7 +678,7 @@ fn config_quic(
                 quic_listener,
                 config.get_tcp_request_timeout(),
                 tls_cert,
-                tls_cert_config.get_endpoint_name().to_string(),
+                tls_cert_config.get_endpoint_name().map(|s| s.to_string()),
             )
             .expect("could not register QUIC listener");
     }

--- a/crates/proto/src/https/https_server.rs
+++ b/crates/proto/src/https/https_server.rs
@@ -7,7 +7,6 @@
 
 //! HTTPS related server items
 
-use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;

--- a/crates/proto/src/https/https_server.rs
+++ b/crates/proto/src/https/https_server.rs
@@ -26,7 +26,7 @@ use crate::https::HttpsError;
 /// To allow downstream clients to do something interesting with the lifetime of the bytes, this doesn't
 ///   perform a conversion to a Message, only collects all the bytes.
 pub async fn message_from<R>(
-    this_server_name: Arc<str>,
+    this_server_name: Option<Arc<str>>,
     request: Request<R>,
 ) -> Result<BytesMut, HttpsError>
 where
@@ -34,7 +34,7 @@ where
 {
     debug!("Received request: {:#?}", request);
 
-    let this_server_name = this_server_name.borrow();
+    let this_server_name = this_server_name.as_deref();
     match crate::https::request::verify(this_server_name, &request) {
         Ok(_) => (),
         Err(err) => return Err(err),
@@ -127,7 +127,7 @@ mod tests {
         let request = request::new("ns.example.com", len).unwrap();
         let request = request.map(|()| stream);
 
-        let from_post = message_from(Arc::from("ns.example.com"), request);
+        let from_post = message_from(Some(Arc::from("ns.example.com")), request);
         let bytes = match block_on(from_post) {
             Ok(bytes) => bytes,
             e => panic!("{:#?}", e),

--- a/crates/server/src/config/dnssec.rs
+++ b/crates/server/src/config/dnssec.rs
@@ -204,7 +204,7 @@ impl Default for PrivateKeyType {
 #[derive(Deserialize, PartialEq, Eq, Debug)]
 pub struct TlsCertConfig {
     path: String,
-    endpoint_name: String,
+    endpoint_name: Option<String>,
     cert_type: Option<CertType>,
     password: Option<String>,
     private_key: Option<String>,
@@ -218,8 +218,8 @@ impl TlsCertConfig {
     }
 
     /// return the DNS name of the certificate hosted at the TLS endpoint
-    pub fn get_endpoint_name(&self) -> &str {
-        &self.endpoint_name
+    pub fn get_endpoint_name(&self) -> Option<&str> {
+        self.endpoint_name.as_deref()
     }
 
     /// Returns the format type of the certificate file

--- a/crates/server/src/server/https_handler.rs
+++ b/crates/server/src/server/https_handler.rs
@@ -27,7 +27,7 @@ pub(crate) async fn h2_handler<T, I>(
     handler: Arc<T>,
     io: I,
     src_addr: SocketAddr,
-    dns_hostname: Arc<str>,
+    dns_hostname: Option<Arc<str>>,
 ) where
     T: RequestHandler,
     I: AsyncRead + AsyncWrite + Unpin,

--- a/crates/server/src/server/quic_handler.rs
+++ b/crates/server/src/server/quic_handler.rs
@@ -29,7 +29,7 @@ pub(crate) async fn quic_handler<T>(
     handler: Arc<T>,
     mut quic_streams: QuicStreams,
     src_addr: SocketAddr,
-    _dns_hostname: Arc<str>,
+    _dns_hostname: Option<Arc<str>>,
 ) -> Result<(), ProtoError>
 where
     T: RequestHandler,

--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -532,14 +532,15 @@ impl<T: RequestHandler> ServerFuture<T> {
         // TODO: need to set a timeout between requests.
         _timeout: Duration,
         certificate_and_key: (Vec<Certificate>, PrivateKey),
-        dns_hostname: String,
+        dns_hostname: Option<String>,
     ) -> io::Result<()> {
         use tokio_rustls::TlsAcceptor;
 
         use crate::proto::rustls::tls_server;
         use crate::server::https_handler::h2_handler;
 
-        let dns_hostname: Arc<str> = Arc::from(dns_hostname);
+        let dns_hostname: Option<Arc<str>> = dns_hostname.map(|n| n.into());
+
         let handler = self.handler.clone();
         debug!("registered https: {listener:?}");
 
@@ -626,12 +627,13 @@ impl<T: RequestHandler> ServerFuture<T> {
         // TODO: need to set a timeout between requests.
         _timeout: Duration,
         certificate_and_key: (Vec<Certificate>, PrivateKey),
-        dns_hostname: String,
+        dns_hostname: Option<String>,
     ) -> io::Result<()> {
         use crate::proto::quic::QuicServer;
         use crate::server::quic_handler::quic_handler;
 
-        let dns_hostname: Arc<str> = Arc::from(dns_hostname);
+        let dns_hostname: Option<Arc<str>> = dns_hostname.map(|n| n.into());
+
         let handler = self.handler.clone();
 
         debug!("registered quic: {:?}", socket);


### PR DESCRIPTION
An Https service can optionally verify the server_name(dns_hostname), only the `certificate` and `certificate-key` are required.