### PR TITLE
Fix panics in ClientSubnet conversions

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trust-dns"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-std-resolver"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trust-dns-client"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trust-dns-proto"
 version = "0.22.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 

--- a/crates/proto/src/https/https_client_stream.rs
+++ b/crates/proto/src/https/https_client_stream.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::convert::TryInto;
 use std::fmt::{self, Display};
 use std::future::Future;
 use std::io;

--- a/crates/proto/src/op/op_code.rs
+++ b/crates/proto/src/op/op_code.rs
@@ -60,7 +60,6 @@ impl fmt::Display for OpCode {
 /// Convert from `OpCode` to `u8`
 ///
 /// ```
-/// use std::convert::From;
 /// use trust_dns_proto::op::op_code::OpCode;
 ///
 /// let var: u8 = From::from(OpCode::Query);
@@ -86,7 +85,6 @@ impl From<OpCode> for u8 {
 /// Convert from `u8` to `OpCode`
 ///
 /// ```
-/// use std::convert::From;
 /// use trust_dns_proto::op::op_code::OpCode;
 ///
 /// let var: OpCode = OpCode::from_u8(0).unwrap();

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -197,7 +197,6 @@ impl Display for ResponseCode {
 /// Convert from `ResponseCode` to `u16`
 ///
 /// ```
-/// use std::convert::From;
 /// use trust_dns_proto::op::response_code::ResponseCode;
 ///
 /// let var: ResponseCode = From::from(0);
@@ -242,7 +241,6 @@ impl From<ResponseCode> for u16 {
 /// Convert from `u16` to `ResponseCode`
 ///
 /// ```
-/// use std::convert::From;
 /// use trust_dns_proto::op::response_code::ResponseCode;
 ///
 /// let var: u16 = From::from(ResponseCode::NoError);

--- a/crates/proto/src/quic/quic_stream.rs
+++ b/crates/proto/src/quic/quic_stream.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::convert::{TryFrom, TryInto};
-
 use bytes::{Bytes, BytesMut};
 use quinn::{RecvStream, SendStream, VarInt};
 use tracing::debug;

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -9,9 +9,7 @@
 #![allow(clippy::use_self)]
 
 use std::cmp::Ordering;
-use std::convert::From;
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 #[cfg(feature = "serde-config")]

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -8,7 +8,6 @@
 //! TSIG for secret key authentication of transaction
 #![allow(clippy::use_self)]
 
-use std::convert::TryInto;
 use std::fmt;
 
 #[cfg(feature = "serde-config")]

--- a/crates/proto/src/rr/dnssec/supported_algorithm.rs
+++ b/crates/proto/src/rr/dnssec/supported_algorithm.rs
@@ -16,9 +16,7 @@
 
 //! bitmap for expressing the set of supported algorithms in edns.
 
-use std::convert::From;
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "serde-config")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -26,11 +26,10 @@ use serde::{Deserialize, Serialize};
 
 use tracing::warn;
 
-use crate::error::*;
-use crate::serialize::binary::*;
-
+use crate::error::{ProtoError, ProtoErrorKind, ProtoResult};
 #[cfg(feature = "dnssec")]
 use crate::rr::dnssec::SupportedAlgorithms;
+use crate::serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, Restrict};
 
 /// The OPT record type is used for ExtendedDNS records.
 ///

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -18,7 +18,6 @@
 #![allow(clippy::use_self)]
 
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -9,8 +9,6 @@
 #![allow(deprecated, clippy::use_self)] // allows us to deprecate RData types
 
 use std::cmp::Ordering;
-#[cfg(test)]
-use std::convert::From;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -9,9 +9,7 @@
 #![allow(clippy::use_self)]
 
 use std::cmp::Ordering;
-use std::convert::From;
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 #[cfg(feature = "serde-config")]
@@ -315,7 +313,6 @@ impl<'r> BinDecodable<'r> for RecordType {
 /// Convert from `RecordType` to `&str`
 ///
 /// ```
-/// use std::convert::From;
 /// use trust_dns_proto::rr::record_type::RecordType;
 ///
 /// let var: &'static str = From::from(RecordType::A);
@@ -371,7 +368,6 @@ impl From<RecordType> for &'static str {
 /// Convert from `RecordType` to `u16`
 ///
 /// ```
-/// use std::convert::From;
 /// use trust_dns_proto::rr::record_type::RecordType;
 ///
 /// let var: u16 = RecordType::A.into();

--- a/crates/proto/src/rustls/tls_stream.rs
+++ b/crates/proto/src/rustls/tls_stream.rs
@@ -7,7 +7,6 @@
 
 //! DNS over TLS I/O stream implementation for Rustls
 
-use std::convert::TryInto;
 use std::future::Future;
 use std::io;
 use std::net::SocketAddr;

--- a/crates/proto/src/serialize/txt/rdata_parsers/soa.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/soa.rs
@@ -15,7 +15,6 @@
  */
 
 //! Parser for SOA text form
-use std::convert::TryInto;
 
 use crate::{
     rr::{domain::Name, rdata::SOA},

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trust-dns-recursor"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trust-dns-resolver"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -8,7 +8,6 @@
 //! An LRU cache designed for work with DNS lookups
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trust-dns-server"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when

--- a/crates/server/src/config/dnssec.rs
+++ b/crates/server/src/config/dnssec.rs
@@ -261,7 +261,6 @@ impl TlsCertConfig {
 fn load_key(zone_name: Name, key_config: &KeyConfig) -> Result<SigSigner, String> {
     use tracing::info;
 
-    use std::convert::TryInto;
     use std::fs::File;
     use std::io::Read;
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "trust-dns-proto-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 [package.metadata]

--- a/tests/compatibility-tests/Cargo.toml
+++ b/tests/compatibility-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trust-dns-compatibility"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trust-dns-integration"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when

--- a/tests/integration-tests/src/example_authority.rs
+++ b/tests/integration-tests/src/example_authority.rs
@@ -196,8 +196,6 @@ pub fn create_example() -> InMemoryAuthority {
 #[cfg(feature = "dnssec")]
 #[allow(unused)]
 pub fn create_secure_example() -> InMemoryAuthority {
-    use std::convert::TryInto;
-
     use openssl::rsa::Rsa;
     use time::Duration;
     use trust_dns_proto::rr::dnssec::*;

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trust-dns-util"
 version = "0.22.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60.0"
 
 # A short blurb about the package. This is not rendered in any format when


### PR DESCRIPTION
#1906 (cc @mokeyish) introduced `From` conversions that called `expect()`, which caused errors in OSS-Fuzz. Replace these `From` impls with `TryFrom` instead, and upgrade to 2021 edition where `TryFrom`/`TryInto` became part of the prelude.