### PR TITLE
Fix fuzz build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,8 @@ members = [
     "util",
     "tests/compatibility-tests",
     "tests/integration-tests",
+    "fuzz",
 ]
-
-exclude = ["fuzz"]
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
     "fuzz",
 ]
 
+exclude = ["fuzz"]
+
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }
 # mio = { git = "https://github.com/tokio-rs/mio.git" }


### PR DESCRIPTION
Fuzz build fails with following error, I'm not sure if this is right fix but adding `fuzz` to workspace.members fixes the error. 
```
Step #3 - "compile-libfuzzer-address-x86_64": [0m[0m[1m[31merror[0m[1m:[0m failed to parse manifest at `/src/trust-dns/fuzz/Cargo.toml`
Step #3 - "compile-libfuzzer-address-x86_64": 
Step #3 - "compile-libfuzzer-address-x86_64": Caused by:
Step #3 - "compile-libfuzzer-address-x86_64":   error inheriting `libfuzzer-sys` from workspace root manifest's `workspace.dependencies.libfuzzer-sys`
Step #3 - "compile-libfuzzer-address-x86_64": 
Step #3 - "compile-libfuzzer-address-x86_64": Caused by:
Step #3 - "compile-libfuzzer-address-x86_64":   failed to find a workspace root
```
This fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57350