### PR TITLE
Update rustls, tokio-rustls, quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,20 +1146,19 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
+checksum = "21252f1c0fc131f1b69182db8f34837e8a69737b8251dff75636a9be0518c324"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
+ "quinn-proto 0.10.1",
+ "quinn-udp 0.4.0",
  "rustc-hash",
  "rustls",
  "thiserror",
  "tokio",
  "tracing",
- "webpki",
 ]
 
 [[package]]
@@ -1167,6 +1166,21 @@ name = "quinn-proto"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
+dependencies = [
+ "bytes",
+ "rand",
+ "rustc-hash",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85af4ed6ee5a89f26a26086e9089a6643650544c025158449a3626ebf72884b3"
 dependencies = [
  "bytes",
  "rand",
@@ -1178,7 +1192,6 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki",
 ]
 
 [[package]]
@@ -1188,10 +1201,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
  "libc",
- "quinn-proto",
+ "quinn-proto 0.9.2",
  "socket2 0.4.9",
  "tracing",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
+dependencies = [
+ "bytes",
+ "libc",
+ "socket2 0.5.3",
+ "tracing",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1360,14 +1386,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -1389,6 +1415,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1661,31 +1697,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
  "socket2 0.4.9",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -1712,13 +1747,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1776,6 +1810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1866,13 +1901,13 @@ dependencies = [
  "rand",
  "ring",
  "rustls",
+ "rustls-webpki",
  "serde",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "trust-dns-proto",
- "webpki",
 ]
 
 [[package]]
@@ -1933,11 +1968,12 @@ dependencies = [
  "native-tls",
  "openssl",
  "quinn",
- "quinn-udp",
+ "quinn-udp 0.3.2",
  "rand",
  "ring",
  "rustls",
  "rustls-pemfile",
+ "rustls-webpki",
  "serde",
  "smallvec",
  "socket2 0.5.3",
@@ -1951,7 +1987,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wasm-bindgen",
- "webpki",
  "webpki-roots",
 ]
 
@@ -2051,6 +2086,7 @@ dependencies = [
  "data-encoding",
  "openssl",
  "rustls",
+ "rustls-webpki",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2058,7 +2094,6 @@ dependencies = [
  "trust-dns-proto",
  "trust-dns-recursor",
  "trust-dns-resolver",
- "webpki",
  "webpki-roots",
 ]
 
@@ -2224,22 +2259,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
 dependencies = [
- "webpki",
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,22 +54,22 @@ async-std = "1.6"
 tokio = "1.21"
 tokio-native-tls = "0.3.0"
 tokio-openssl = "0.6.0"
-tokio-rustls = "0.23.0"
+tokio-rustls = "0.24.0"
 parking_lot = "0.12"
 
 
 # ssl
 native-tls = "0.2"
 openssl = "0.10.48"
-rustls = "0.20.0"
+rustls = "0.21.0"
 rustls-pemfile = "1.0.0"
-webpki = "0.22.0"
-webpki-roots = "0.22.1"
+webpki = { version = "0.100.1", package = "rustls-webpki" }
+webpki-roots = "0.23.0"
 ring = "0.16"
 
 
 # net proto
-quinn = "0.9"
+quinn = "0.10"
 quinn-udp = "0.3.2"
 h2 = "0.3.0"
 http = "0.2"

--- a/crates/proto/src/quic/quic_config.rs
+++ b/crates/proto/src/quic/quic_config.rs
@@ -15,7 +15,7 @@ pub(crate) fn endpoint() -> EndpointConfig {
     // all DNS packets have a maximum size of u16 due to DoQ and 1035 rfc
     // TODO: the RFC claims max == u16::max, but this matches the max in some test servers.
     endpoint_config
-        .max_udp_payload_size(0x45acu16 as u64)
+        .max_udp_payload_size(0x45ac)
         .expect("max udp payload size exceeded");
 
     endpoint_config

--- a/crates/proto/src/quic/quic_server.rs
+++ b/crates/proto/src/quic/quic_server.rs
@@ -60,7 +60,7 @@ impl QuicServer {
             endpoint_config,
             Some(server_config),
             socket,
-            quinn::TokioRuntime,
+            Arc::new(quinn::TokioRuntime),
         )?;
 
         Ok(Self { endpoint })

--- a/util/src/dns.rs
+++ b/util/src/dns.rs
@@ -28,8 +28,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 #[cfg(feature = "dns-over-rustls")]
 use rustls::{
     client::{HandshakeSignatureValid, ServerCertVerified},
-    internal::msgs::handshake::DigitallySignedStruct,
-    Certificate, ClientConfig, OwnedTrustAnchor, RootCertStore,
+    Certificate, ClientConfig, DigitallySignedStruct, OwnedTrustAnchor, RootCertStore,
 };
 use tokio::net::{TcpStream as TokioTcpStream, UdpSocket};
 use tracing::Level;


### PR DESCRIPTION
## Description

This branch updates the Rustls dependency to the recently released 0.21.0 tag. I expect this release will be of particular interest to Trust DNS users because it brings support for IP address subjects in certificates and I understand that to be a common requirement for DoT/DoH.

It also introduces updates to tokio-rustls and quinn to releases using the same 0.21.0 rustls dependency.

Within the Trust DNS codebase a couple small upstream API changes are addressed to ensure the build and tests pass.

## Remaining work

- [X] wait for https://github.com/tokio-rs/tls/pull/137 to be merged
- [x] wait for tokio-rustls v0.24.0 to be published to crates.io
- [x] remove Cargo.toml patch for tokio-rustls
- [x] wait for https://github.com/quinn-rs/quinn/pull/1515 to be merged
- [x] update to rustls-webpki
- [x] wait for quinn 0.10 to be published to crates.io https://github.com/quinn-rs/quinn/issues/1528
- [x] remove Cargo.toml patch for quinn
- [x] wait for https://github.com/rustls/webpki-roots/pull/28 to be merged
- [x] update Cargo.toml for webpki-roots v0.23.0
- [x] fix quinn API breakages
- [x] get PR approved