### PR TITLE
Add AsyncResolverBuilder and option to overide a pre-created cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +279,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -783,6 +792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +829,17 @@ name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb09950ae85a0a94b27676cccf37da5ff13f27076aa1adbc6545dd0d0e1bd4e"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1920,6 +1949,14 @@ dependencies = [
  "wasm-bindgen",
  "webpki",
  "webpki-roots",
+]
+
+[[package]]
+name = "trust-dns-proto-fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "trust-dns-proto",
 ]
 
 [[package]]

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -282,10 +282,10 @@ pub use self::proto::rr::{IntoName, Name, TryParseIp};
 #[cfg(feature = "testing")]
 #[cfg_attr(docsrs, doc(cfg(feature = "testing")))]
 pub use async_resolver::testing;
-pub use async_resolver::{AsyncResolverBuilder,AsyncResolver};
+pub use async_resolver::{AsyncResolver, AsyncResolverBuilder};
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
-pub use async_resolver::TokioAsyncResolver;
+pub use async_resolver::{TokioAsyncResolver, TokioAsyncResolverBuilder};
 pub use hosts::Hosts;
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -282,7 +282,7 @@ pub use self::proto::rr::{IntoName, Name, TryParseIp};
 #[cfg(feature = "testing")]
 #[cfg_attr(docsrs, doc(cfg(feature = "testing")))]
 pub use async_resolver::testing;
-pub use async_resolver::AsyncResolver;
+pub use async_resolver::{AsyncResolverBuilder,AsyncResolver};
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
 pub use async_resolver::TokioAsyncResolver;


### PR DESCRIPTION
This PR adds the ability to share a DNS Cache between different `AsyncResolver`s. It also add an `AsyncResolverBuilder` to avoid adding yet more `new_with_...` methods to the `AsyncResolver`.

The rough reasoning behind it was that we've got a few different threads running all of which need to make DNS requests, but we didn't want to be making unnecessary requests if we've already done a previous lookup; hence a desire for multiple `AsyncResolver`s to shared their cache.

Since we did this work initially, I've thought that perhaps we could just have each thread use a `clone` of an initial `AsyncResolver`, which would mean that they shared the cache, since it's an `Arc`, so perhaps this change is unnecessary?

So I guess I have a question for reviewers:

Would there be any performance (or other) impact to using cloned `AsyncResolver` across multiple threads at the same time. Looking through the struct, I see that there are a few other items behind `Arc`s, such as https://github.com/bluejekyll/trust-dns/blob/main/crates/resolver/src/name_server/name_server_pool.rs#L39-L40 which I fear might cause some kind of issues, but don't really feel like I know enough to know.

If you don't think there would be any impact from that, then this PR is probably unnecessary (unless you disagree). 