### PR TITLE
resolver: Fix minimal tokio version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ futures-executor = { version = "0.3.5", default-features = false }
 futures-io = { version = "0.3.5", default-features = false }
 futures-util = { version = "0.3.5", default-features = false }
 async-std = "1.6"
-tokio = "1.0"
+tokio = "1.21"
 tokio-native-tls = "0.3.0"
 tokio-openssl = "0.6.0"
 tokio-rustls = "0.23.0"


### PR DESCRIPTION
The resolver uses `JoinSet`, which was only stabilized in tokio 1.21. This fixes the `cargo minimal-versions` check issues in dependent crates (see a failed run [here](https://github.com/Gelbpunkt/hyper-trust-dns/actions/runs/4961062221/jobs/8878778776?pr=5)). You might be interested in checking this in your CI as well.