### PR TITLE
Provider API Redesign

### DIFF
--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -96,7 +96,7 @@
 
 use trust_dns_resolver::AsyncResolver;
 
-use crate::runtime::AsyncStdRuntimeProvider;
+use crate::runtime::AsyncStdConnectionProvider;
 
 mod net;
 mod runtime;
@@ -104,7 +104,6 @@ mod runtime;
 mod tests;
 mod time;
 
-use crate::proto::Executor;
 pub use trust_dns_resolver::config;
 pub use trust_dns_resolver::error::ResolveError;
 pub use trust_dns_resolver::lookup;
@@ -112,7 +111,7 @@ pub use trust_dns_resolver::lookup_ip;
 pub use trust_dns_resolver::proto;
 
 /// An AsyncResolver used with async_std
-pub type AsyncStdResolver = AsyncResolver<AsyncStdRuntimeProvider>;
+pub type AsyncStdResolver = AsyncResolver<AsyncStdConnectionProvider>;
 
 /// Construct a new async-std based `AsyncResolver` with the provided configuration.
 ///
@@ -131,7 +130,7 @@ pub async fn resolver(
     config: config::ResolverConfig,
     options: config::ResolverOpts,
 ) -> Result<AsyncStdResolver, ResolveError> {
-    AsyncStdResolver::new(config, options, AsyncStdRuntimeProvider::new())
+    AsyncStdResolver::new(config, options, AsyncStdConnectionProvider::default())
 }
 
 /// Constructs a new async-std based Resolver with the system configuration.
@@ -140,5 +139,5 @@ pub async fn resolver(
 #[cfg(any(unix, target_os = "windows"))]
 #[cfg(feature = "system-config")]
 pub async fn resolver_from_system_conf() -> Result<AsyncStdResolver, ResolveError> {
-    AsyncStdResolver::from_system_conf(AsyncStdRuntimeProvider::new())
+    AsyncStdResolver::from_system_conf(AsyncStdConnectionProvider::default())
 }

--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -8,7 +8,7 @@ use crate::lookup::LookupFuture;
 use crate::lookup_ip::LookupIpFuture;
 use crate::proto::xfer::DnsRequest;
 use crate::proto::Executor;
-use crate::runtime::AsyncStdRuntimeProvider;
+use crate::runtime::AsyncStdConnectionProvider;
 use crate::AsyncStdResolver;
 use crate::ResolveError;
 
@@ -38,11 +38,11 @@ fn test_send_sync() {
 #[test]
 fn test_lookup_google() {
     use testing::lookup_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
+    let io_loop = AsyncStdConnectionProvider::new();
 
-    lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+    lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
         ResolverConfig::google(),
-        io_loop,
+        io_loop.clone(),
         io_loop,
     )
 }
@@ -50,10 +50,10 @@ fn test_lookup_google() {
 #[test]
 fn test_lookup_cloudflare() {
     use testing::lookup_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+    let io_loop = AsyncStdConnectionProvider::new();
+    lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
         ResolverConfig::cloudflare(),
-        io_loop,
+        io_loop.clone(),
         io_loop,
     )
 }
@@ -61,10 +61,10 @@ fn test_lookup_cloudflare() {
 #[test]
 fn test_lookup_quad9() {
     use testing::lookup_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
+    let io_loop = AsyncStdConnectionProvider::new();
+    lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
         ResolverConfig::quad9(),
-        io_loop,
+        io_loop.clone(),
         io_loop,
     )
 }
@@ -72,31 +72,40 @@ fn test_lookup_quad9() {
 #[test]
 fn test_ip_lookup() {
     use testing::ip_lookup_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    ip_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop)
+    let io_loop = AsyncStdConnectionProvider::new();
+    ip_lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    )
 }
 
 #[test]
 fn test_ip_lookup_across_threads() {
     use testing::ip_lookup_across_threads_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    ip_lookup_across_threads_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop)
+    let io_loop = AsyncStdConnectionProvider::new();
+    ip_lookup_across_threads_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(io_loop)
 }
 
 #[test]
 #[cfg(feature = "dnssec")]
 fn test_sec_lookup() {
     use testing::sec_lookup_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    sec_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    sec_lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
 #[cfg(feature = "dnssec")]
 fn test_sec_lookup_fails() {
     use testing::sec_lookup_fails_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    sec_lookup_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    sec_lookup_fails_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
@@ -105,8 +114,11 @@ fn test_sec_lookup_fails() {
 #[cfg(feature = "system-config")]
 fn test_system_lookup() {
     use testing::system_lookup_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    system_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    system_lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
@@ -116,94 +128,115 @@ fn test_system_lookup() {
 #[cfg(unix)]
 fn test_hosts_lookup() {
     use testing::hosts_lookup_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    hosts_lookup_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    hosts_lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
 fn test_fqdn() {
     use testing::fqdn_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    fqdn_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    fqdn_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(io_loop.clone(), io_loop);
 }
 
 #[test]
 fn test_ndots() {
     use testing::ndots_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    ndots_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(io_loop.clone(), io_loop);
 }
 
 #[test]
 fn test_large_ndots() {
     use testing::large_ndots_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    large_ndots_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
 fn test_domain_search() {
     use testing::domain_search_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    domain_search_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    domain_search_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
 fn test_search_list() {
     use testing::search_list_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    search_list_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    search_list_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
 fn test_idna() {
     use testing::idna_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
-    idna_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    let io_loop = AsyncStdConnectionProvider::new();
+    idna_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(io_loop.clone(), io_loop);
 }
 
 #[test]
 fn test_localhost_ipv4() {
     use testing::localhost_ipv4_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
+    let io_loop = AsyncStdConnectionProvider::new();
 
-    localhost_ipv4_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    localhost_ipv4_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
 fn test_localhost_ipv6() {
     use testing::localhost_ipv6_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
+    let io_loop = AsyncStdConnectionProvider::new();
 
-    localhost_ipv6_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(io_loop, io_loop);
+    localhost_ipv6_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
+    );
 }
 
 #[test]
 fn test_search_ipv4_large_ndots() {
     use testing::search_ipv4_large_ndots_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
+    let io_loop = AsyncStdConnectionProvider::new();
 
-    search_ipv4_large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
-        io_loop, io_loop,
+    search_ipv4_large_ndots_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
     );
 }
 
 #[test]
 fn test_search_ipv6_large_ndots() {
     use testing::search_ipv6_large_ndots_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
+    let io_loop = AsyncStdConnectionProvider::new();
 
-    search_ipv6_large_ndots_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
-        io_loop, io_loop,
+    search_ipv6_large_ndots_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
     );
 }
 
 #[test]
 fn test_search_ipv6_name_parse_fails() {
     use testing::search_ipv6_name_parse_fails_test;
-    let io_loop = AsyncStdRuntimeProvider::new();
+    let io_loop = AsyncStdConnectionProvider::new();
 
-    search_ipv6_name_parse_fails_test::<AsyncStdRuntimeProvider, AsyncStdRuntimeProvider>(
-        io_loop, io_loop,
+    search_ipv6_name_parse_fails_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+        io_loop.clone(),
+        io_loop,
     );
 }

--- a/crates/proto/src/serialize/binary/bin_tests.rs
+++ b/crates/proto/src/serialize/binary/bin_tests.rs
@@ -21,9 +21,9 @@ use std::fmt::Debug;
 
 fn get_character_data() -> Vec<(&'static str, Vec<u8>)> {
     vec![
-        ("", vec![0]),                      // base case, only the root
-        ("a", vec![1, b'a']),               // a single 'a' label
-        ("bc", vec![2, b'b', b'c']),        // two labels, 'a.bc'
+        ("", vec![0]),                    // base case, only the root
+        ("a", vec![1, b'a']),             // a single 'a' label
+        ("bc", vec![2, b'b', b'c']),      // two labels, 'a.bc'
         ("♥", vec![3, 0xE2, 0x99, 0xA5]), // two labels utf8, 'a.♥'
     ]
 }

--- a/crates/proto/src/serialize/binary/bin_tests.rs
+++ b/crates/proto/src/serialize/binary/bin_tests.rs
@@ -21,9 +21,9 @@ use std::fmt::Debug;
 
 fn get_character_data() -> Vec<(&'static str, Vec<u8>)> {
     vec![
-        ("", vec![0]),                    // base case, only the root
-        ("a", vec![1, b'a']),             // a single 'a' label
-        ("bc", vec![2, b'b', b'c']),      // two labels, 'a.bc'
+        ("", vec![0]),                      // base case, only the root
+        ("a", vec![1, b'a']),               // a single 'a' label
+        ("bc", vec![2, b'b', b'c']),        // two labels, 'a.bc'
         ("♥", vec![3, 0xE2, 0x99, 0xA5]), // two labels utf8, 'a.♥'
     ]
 }

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -12,6 +12,7 @@ use futures_util::{future::select_all, FutureExt};
 use lru_cache::LruCache;
 use parking_lot::Mutex;
 use tracing::{debug, info, warn};
+use trust_dns_resolver::name_server::TokioConnectionProvider;
 
 use crate::{
     proto::{
@@ -55,7 +56,8 @@ impl Recursor {
         assert!(!roots.is_empty(), "roots must not be empty");
 
         let opts = recursor_opts();
-        let roots = GenericNameServerPool::from_config(roots, &opts, TokioRuntimeProvider::new());
+        let roots =
+            GenericNameServerPool::from_config(roots, &opts, TokioConnectionProvider::default());
         let roots = RecursorPool::from(Name::root(), roots);
         let name_server_cache = Mutex::new(NameServerCache::new(100)); // TODO: make this configurable
         let record_cache = DnsLru::new(100, TtlConfig::default());
@@ -438,7 +440,7 @@ impl Recursor {
         let ns = GenericNameServerPool::from_config(
             config_group,
             &recursor_opts(),
-            TokioRuntimeProvider::new(),
+            TokioConnectionProvider::default(),
         );
         let ns = RecursorPool::from(zone.clone(), ns);
 

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -24,7 +24,7 @@ use crate::{
         dns_lru::{DnsLru, TtlConfig},
         error::ResolveError,
         lookup::Lookup,
-        name_server::{NameServerPool, TokioRuntimeProvider},
+        name_server::{GenericNameServerPool, TokioRuntimeProvider},
         Name,
     },
     Error, ErrorKind,
@@ -55,7 +55,7 @@ impl Recursor {
         assert!(!roots.is_empty(), "roots must not be empty");
 
         let opts = recursor_opts();
-        let roots = NameServerPool::from_config(roots, &opts, TokioRuntimeProvider::new());
+        let roots = GenericNameServerPool::from_config(roots, &opts, TokioRuntimeProvider::new());
         let roots = RecursorPool::from(Name::root(), roots);
         let name_server_cache = Mutex::new(NameServerCache::new(100)); // TODO: make this configurable
         let record_cache = DnsLru::new(100, TtlConfig::default());
@@ -435,7 +435,7 @@ impl Recursor {
         }
 
         // now construct a namesever pool based off the NS and glue records
-        let ns = NameServerPool::from_config(
+        let ns = GenericNameServerPool::from_config(
             config_group,
             &recursor_opts(),
             TokioRuntimeProvider::new(),

--- a/crates/recursor/src/recursor_pool.rs
+++ b/crates/recursor/src/recursor_pool.rs
@@ -23,7 +23,7 @@ use trust_dns_proto::{
 use trust_dns_resolver::name_server::{RuntimeProvider, TokioRuntimeProvider};
 use trust_dns_resolver::{
     error::{ResolveError, ResolveErrorKind},
-    name_server::NameServerPool,
+    name_server::GenericNameServerPool,
     Name,
 };
 
@@ -52,12 +52,12 @@ impl Future for SharedLookup {
 #[derive(Clone)]
 pub(crate) struct RecursorPool<P: RuntimeProvider + Send + 'static> {
     zone: Name,
-    ns: NameServerPool<P>,
+    ns: GenericNameServerPool<P>,
     active_requests: Arc<Mutex<ActiveRequests>>,
 }
 
 impl RecursorPool<TokioRuntimeProvider> {
-    pub(crate) fn from(zone: Name, ns: NameServerPool<TokioRuntimeProvider>) -> Self {
+    pub(crate) fn from(zone: Name, ns: GenericNameServerPool<TokioRuntimeProvider>) -> Self {
         let active_requests = Arc::new(Mutex::new(ActiveRequests::default()));
 
         Self {

--- a/crates/resolver/examples/custom_provider.rs
+++ b/crates/resolver/examples/custom_provider.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "128"]
 
+use trust_dns_resolver::name_server::{ConnectionProvider, GenericConnector};
 #[cfg(feature = "tokio-runtime")]
 use {
     std::future::Future,
@@ -57,7 +58,7 @@ impl RuntimeProvider for PrintProvider {
 }
 
 #[cfg(feature = "tokio-runtime")]
-async fn lookup_test<R: RuntimeProvider>(resolver: AsyncResolver<R>) {
+async fn lookup_test<R: ConnectionProvider>(resolver: AsyncResolver<R>) {
     let response = resolver.lookup_ip("www.example.com.").await.unwrap();
 
     // There can be many addresses associated with the name,
@@ -81,7 +82,7 @@ async fn main() {
     let resolver = AsyncResolver::new(
         ResolverConfig::google(),
         ResolverOpts::default(),
-        PrintProvider::default(),
+        GenericConnector::new(PrintProvider::default()),
     )
     .unwrap();
     lookup_test(resolver).await;
@@ -91,7 +92,7 @@ async fn main() {
         let resolver2 = AsyncResolver::new(
             ResolverConfig::cloudflare_https(),
             ResolverOpts::default(),
-            PrintProvider::default(),
+            GenericConnector::new(PrintProvider::default()),
         )
         .unwrap();
         lookup_test(resolver2).await;

--- a/crates/resolver/examples/custom_provider.rs
+++ b/crates/resolver/examples/custom_provider.rs
@@ -1,6 +1,5 @@
 #![recursion_limit = "128"]
 
-use trust_dns_resolver::name_server::{ConnectionProvider, GenericConnector};
 #[cfg(feature = "tokio-runtime")]
 use {
     std::future::Future,
@@ -8,7 +7,7 @@ use {
     std::pin::Pin,
     tokio::net::{TcpStream, UdpSocket},
     trust_dns_resolver::config::{ResolverConfig, ResolverOpts},
-    trust_dns_resolver::name_server::RuntimeProvider,
+    trust_dns_resolver::name_server::{ConnectionProvider, GenericConnector, RuntimeProvider},
     trust_dns_resolver::proto::iocompat::AsyncIoTokioAsStd,
     trust_dns_resolver::proto::TokioTime,
     trust_dns_resolver::{AsyncResolver, TokioHandle},

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -1,5 +1,7 @@
 #![recursion_limit = "128"]
 
+use trust_dns_resolver::name_server::TokioConnectionProvider;
+
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
 fn main() {
     tokio::runtime::Builder::new_multi_thread()
@@ -13,7 +15,6 @@ fn main() {
 
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
 async fn tokio_main() {
-    use trust_dns_resolver::name_server::TokioRuntimeProvider;
     use trust_dns_resolver::TokioAsyncResolver;
 
     let resolver = {
@@ -21,7 +22,7 @@ async fn tokio_main() {
         #[cfg(any(unix, windows))]
         {
             // use the system resolver configuration
-            TokioAsyncResolver::from_system_conf(TokioRuntimeProvider::new())
+            TokioAsyncResolver::from_system_conf(TokioConnectionProvider::default())
         }
 
         // For other operating systems, we can use one of the preconfigured definitions
@@ -59,7 +60,7 @@ async fn tokio_main() {
 }
 
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
-async fn resolve_list<P: trust_dns_resolver::name_server::RuntimeProvider>(
+async fn resolve_list<P: trust_dns_resolver::name_server::ConnectionProvider>(
     names: &[&str],
     resolver: &trust_dns_resolver::AsyncResolver<P>,
 ) -> tokio::time::Duration {

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -1,7 +1,5 @@
 #![recursion_limit = "128"]
 
-use trust_dns_resolver::name_server::TokioConnectionProvider;
-
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
 fn main() {
     tokio::runtime::Builder::new_multi_thread()
@@ -15,7 +13,7 @@ fn main() {
 
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
 async fn tokio_main() {
-    use trust_dns_resolver::TokioAsyncResolver;
+    use trust_dns_resolver::{name_server::TokioConnectionProvider, TokioAsyncResolver};
 
     let resolver = {
         // To make this independent, if targeting macOS, BSD, Linux, or Windows, we can use the system's configuration:

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -1,6 +1,5 @@
 #![recursion_limit = "128"]
 
-use trust_dns_resolver::name_server::TokioConnectionProvider;
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
 use {
     futures_util::future,
@@ -9,6 +8,7 @@ use {
     std::io,
     std::net::SocketAddr,
     std::task::Poll,
+    trust_dns_resolver::name_server::TokioConnectionProvider,
     trust_dns_resolver::TokioAsyncResolver,
     trust_dns_resolver::{IntoName, TryParseIp},
 };

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "128"]
 
+use trust_dns_resolver::name_server::TokioConnectionProvider;
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
 use {
     futures_util::future,
@@ -8,7 +9,7 @@ use {
     std::io,
     std::net::SocketAddr,
     std::task::Poll,
-    trust_dns_resolver::{name_server::TokioRuntimeProvider, TokioAsyncResolver},
+    trust_dns_resolver::TokioAsyncResolver,
     trust_dns_resolver::{IntoName, TryParseIp},
 };
 
@@ -46,7 +47,7 @@ lazy_static! {
                 #[cfg(any(unix, windows))]
                 {
                     // use the system resolver configuration
-                    TokioAsyncResolver::from_system_conf(TokioRuntimeProvider::new())
+                    TokioAsyncResolver::from_system_conf(TokioConnectionProvider::default())
                 }
 
                 // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -3,10 +3,11 @@
 //! This example shows how to create a resolver that uses the tokio multithreaded runtime. This is how
 //! you might integrate the resolver into a more complex application.
 
+use trust_dns_resolver::name_server::TokioConnectionProvider;
+
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
 fn main() {
     use tokio::runtime::Runtime;
-    use trust_dns_resolver::name_server::TokioRuntimeProvider;
     use trust_dns_resolver::TokioAsyncResolver;
 
     tracing_subscriber::fmt::init();
@@ -19,7 +20,7 @@ fn main() {
         #[cfg(any(unix, windows))]
         {
             // use the system resolver configuration
-            TokioAsyncResolver::from_system_conf(TokioRuntimeProvider::new())
+            TokioAsyncResolver::from_system_conf(TokioConnectionProvider::default())
         }
 
         // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -3,12 +3,10 @@
 //! This example shows how to create a resolver that uses the tokio multithreaded runtime. This is how
 //! you might integrate the resolver into a more complex application.
 
-use trust_dns_resolver::name_server::TokioConnectionProvider;
-
 #[cfg(all(feature = "tokio-runtime", feature = "system-config"))]
 fn main() {
     use tokio::runtime::Runtime;
-    use trust_dns_resolver::TokioAsyncResolver;
+    use trust_dns_resolver::{name_server::TokioConnectionProvider, TokioAsyncResolver};
 
     tracing_subscriber::fmt::init();
 

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -25,8 +25,7 @@ use crate::error::*;
 use crate::lookup::{self, Lookup, LookupEither, LookupFuture};
 use crate::lookup_ip::{LookupIp, LookupIpFuture};
 #[cfg(feature = "tokio-runtime")]
-use crate::name_server::TokioRuntimeProvider;
-use crate::name_server::{NameServerPool, RuntimeProvider};
+use crate::name_server::{ConnectionProvider, NameServerPool, TokioConnectionProvider};
 
 use crate::Hosts;
 
@@ -57,7 +56,7 @@ use crate::Hosts;
 /// linked to it. When all of its [`AsyncResolver`]s have been dropped, the
 /// background future will finish.
 #[derive(Clone)]
-pub struct AsyncResolver<P: RuntimeProvider> {
+pub struct AsyncResolver<P: ConnectionProvider> {
     config: ResolverConfig,
     options: ResolverOpts,
     client_cache: CachingClient<LookupEither<P>, ResolveError>,
@@ -67,7 +66,7 @@ pub struct AsyncResolver<P: RuntimeProvider> {
 /// An AsyncResolver used with Tokio
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
-pub type TokioAsyncResolver = AsyncResolver<TokioRuntimeProvider>;
+pub type TokioAsyncResolver = AsyncResolver<TokioConnectionProvider>;
 
 macro_rules! lookup_fn {
     ($p:ident, $l:ty, $r:path) => {
@@ -119,7 +118,7 @@ impl TokioAsyncResolver {
     /// documentation for `AsyncResolver` for more information on how to use
     /// the background future.
     pub fn tokio(config: ResolverConfig, options: ResolverOpts) -> Result<Self, ResolveError> {
-        Self::new(config, options, TokioRuntimeProvider::new())
+        Self::new(config, options, TokioConnectionProvider::default())
     }
 
     /// Constructs a new Tokio based Resolver with the system configuration.
@@ -132,11 +131,11 @@ impl TokioAsyncResolver {
         doc(cfg(all(feature = "system-config", any(unix, target_os = "windows"))))
     )]
     pub fn tokio_from_system_conf() -> Result<Self, ResolveError> {
-        Self::from_system_conf(TokioRuntimeProvider::new())
+        Self::from_system_conf(TokioConnectionProvider::default())
     }
 }
 
-impl<R: RuntimeProvider> AsyncResolver<R> {
+impl<R: ConnectionProvider> AsyncResolver<R> {
     /// Construct a new generic `AsyncResolver` with the provided configuration.
     ///
     /// see [TokioAsyncResolver::tokio(..)] instead.
@@ -181,7 +180,7 @@ impl<R: RuntimeProvider> AsyncResolver<R> {
     }
 }
 
-impl<P: RuntimeProvider> AsyncResolver<P> {
+impl<P: ConnectionProvider> AsyncResolver<P> {
     /// Construct a new `AsyncResolver` with the provided configuration.
     ///
     /// # Arguments
@@ -450,7 +449,7 @@ impl<P: RuntimeProvider> AsyncResolver<P> {
     lookup_fn!(txt_lookup, lookup::TxtLookup, RecordType::TXT);
 }
 
-impl<P: RuntimeProvider> fmt::Debug for AsyncResolver<P> {
+impl<P: ConnectionProvider> fmt::Debug for AsyncResolver<P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AsyncResolver")
             .field("request_tx", &"...")
@@ -466,12 +465,12 @@ pub mod testing {
     use std::{net::*, str::FromStr};
 
     use crate::config::{LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts};
-    use crate::name_server::RuntimeProvider;
+    use crate::name_server::ConnectionProvider;
     use crate::AsyncResolver;
     use proto::{rr::Name, Executor};
 
     /// Test IP lookup from URLs.
-    pub fn lookup_test<E: Executor, R: RuntimeProvider>(
+    pub fn lookup_test<E: Executor, R: ConnectionProvider>(
         config: ResolverConfig,
         mut exec: E,
         handle: R,
@@ -499,7 +498,7 @@ pub mod testing {
     }
 
     /// Test IP lookup from IP literals.
-    pub fn ip_lookup_test<E: Executor, R: RuntimeProvider>(mut exec: E, handle: R) {
+    pub fn ip_lookup_test<E: Executor, R: ConnectionProvider>(mut exec: E, handle: R) {
         let resolver =
             AsyncResolver::<R>::new(ResolverConfig::default(), ResolverOpts::default(), handle)
                 .expect("failed to create resolver");
@@ -526,7 +525,7 @@ pub mod testing {
     }
 
     /// Test IP lookup from IP literals across threads.
-    pub fn ip_lookup_across_threads_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn ip_lookup_across_threads_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         handle: R,
     ) {
         // Test ensuring that running the background task on a separate
@@ -579,7 +578,7 @@ pub mod testing {
     /// Test IP lookup from URLs with DNSSEC validation.
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
-    pub fn sec_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn sec_lookup_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -620,7 +619,7 @@ pub mod testing {
     #[allow(deprecated)]
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
-    pub fn sec_lookup_fails_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn sec_lookup_fails_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -664,7 +663,7 @@ pub mod testing {
     /// Test AsyncResolver created from system configuration with IP lookup.
     #[cfg(feature = "system-config")]
     #[cfg_attr(docsrs, doc(cfg(feature = "system-config")))]
-    pub fn system_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn system_lookup_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -693,7 +692,7 @@ pub mod testing {
     /// Test AsyncResolver created from system configuration with host lookups.
     #[cfg(feature = "system-config")]
     #[cfg_attr(docsrs, doc(cfg(feature = "system-config")))]
-    pub fn hosts_lookup_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn hosts_lookup_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -715,7 +714,7 @@ pub mod testing {
     }
 
     /// Test fqdn.
-    pub fn fqdn_test<E: Executor + Send + 'static, R: RuntimeProvider>(mut exec: E, handle: R) {
+    pub fn fqdn_test<E: Executor + Send + 'static, R: ConnectionProvider>(mut exec: E, handle: R) {
         let domain = Name::from_str("incorrect.example.com.").unwrap();
         let search = vec![
             Name::from_str("bad.example.com.").unwrap(),
@@ -749,7 +748,7 @@ pub mod testing {
     }
 
     /// Test ndots with non-fqdn.
-    pub fn ndots_test<E: Executor + Send + 'static, R: RuntimeProvider>(mut exec: E, handle: R) {
+    pub fn ndots_test<E: Executor + Send + 'static, R: ConnectionProvider>(mut exec: E, handle: R) {
         let domain = Name::from_str("incorrect.example.com.").unwrap();
         let search = vec![
             Name::from_str("bad.example.com.").unwrap(),
@@ -786,7 +785,7 @@ pub mod testing {
     }
 
     /// Test large ndots with non-fqdn.
-    pub fn large_ndots_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn large_ndots_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -826,7 +825,7 @@ pub mod testing {
     }
 
     /// Test domain search.
-    pub fn domain_search_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn domain_search_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -867,7 +866,7 @@ pub mod testing {
     }
 
     /// Test search lists.
-    pub fn search_list_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn search_list_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -907,7 +906,7 @@ pub mod testing {
     }
 
     /// Test idna.
-    pub fn idna_test<E: Executor + Send + 'static, R: RuntimeProvider>(mut exec: E, handle: R) {
+    pub fn idna_test<E: Executor + Send + 'static, R: ConnectionProvider>(mut exec: E, handle: R) {
         let resolver =
             AsyncResolver::<R>::new(ResolverConfig::default(), ResolverOpts::default(), handle)
                 .expect("failed to create resolver");
@@ -922,7 +921,7 @@ pub mod testing {
     }
 
     /// Test ipv4 localhost.
-    pub fn localhost_ipv4_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn localhost_ipv4_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -948,7 +947,7 @@ pub mod testing {
     }
 
     /// Test ipv6 localhost.
-    pub fn localhost_ipv6_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn localhost_ipv6_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -974,7 +973,7 @@ pub mod testing {
     }
 
     /// Test ipv4 search with large ndots.
-    pub fn search_ipv4_large_ndots_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn search_ipv4_large_ndots_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -1004,7 +1003,7 @@ pub mod testing {
     }
 
     /// Test ipv6 search with large ndots.
-    pub fn search_ipv6_large_ndots_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn search_ipv6_large_ndots_test<E: Executor + Send + 'static, R: ConnectionProvider>(
         mut exec: E,
         handle: R,
     ) {
@@ -1034,7 +1033,10 @@ pub mod testing {
     }
 
     /// Test ipv6 name parse fails.
-    pub fn search_ipv6_name_parse_fails_test<E: Executor + Send + 'static, R: RuntimeProvider>(
+    pub fn search_ipv6_name_parse_fails_test<
+        E: Executor + Send + 'static,
+        R: ConnectionProvider,
+    >(
         mut exec: E,
         handle: R,
     ) {
@@ -1071,7 +1073,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::name_server::{GenericConnection, TokioRuntimeProvider};
+    use crate::name_server::GenericConnection;
 
     use super::*;
 
@@ -1090,8 +1092,8 @@ mod tests {
         assert!(is_send_t::<ResolverOpts>());
         assert!(is_sync_t::<ResolverOpts>());
 
-        assert!(is_send_t::<AsyncResolver<TokioRuntimeProvider>>());
-        assert!(is_sync_t::<AsyncResolver<TokioRuntimeProvider>>());
+        assert!(is_send_t::<AsyncResolver<TokioConnectionProvider>>());
+        assert!(is_sync_t::<AsyncResolver<TokioConnectionProvider>>());
 
         assert!(is_send_t::<DnsRequest>());
         assert!(is_send_t::<LookupIpFuture<GenericConnection, ResolveError>>());
@@ -1102,40 +1104,44 @@ mod tests {
     fn test_lookup_google() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioRuntimeProvider::new();
-        lookup_test::<Runtime, TokioRuntimeProvider>(ResolverConfig::google(), io_loop, handle)
+        let handle = TokioConnectionProvider::default();
+        lookup_test::<Runtime, TokioConnectionProvider>(ResolverConfig::google(), io_loop, handle)
     }
 
     #[test]
     fn test_lookup_cloudflare() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioRuntimeProvider::new();
-        lookup_test::<Runtime, TokioRuntimeProvider>(ResolverConfig::cloudflare(), io_loop, handle)
+        let handle = TokioConnectionProvider::default();
+        lookup_test::<Runtime, TokioConnectionProvider>(
+            ResolverConfig::cloudflare(),
+            io_loop,
+            handle,
+        )
     }
 
     #[test]
     fn test_lookup_quad9() {
         use super::testing::lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioRuntimeProvider::new();
-        lookup_test::<Runtime, TokioRuntimeProvider>(ResolverConfig::quad9(), io_loop, handle)
+        let handle = TokioConnectionProvider::default();
+        lookup_test::<Runtime, TokioConnectionProvider>(ResolverConfig::quad9(), io_loop, handle)
     }
 
     #[test]
     fn test_ip_lookup() {
         use super::testing::ip_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioRuntimeProvider::new();
-        ip_lookup_test::<Runtime, TokioRuntimeProvider>(io_loop, handle)
+        let handle = TokioConnectionProvider::default();
+        ip_lookup_test::<Runtime, TokioConnectionProvider>(io_loop, handle)
     }
 
     #[test]
     fn test_ip_lookup_across_threads() {
         use super::testing::ip_lookup_across_threads_test;
         let _io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        ip_lookup_across_threads_test::<Runtime, TokioRuntimeProvider>(handle)
+        let handle = TokioConnectionProvider::default();
+        ip_lookup_across_threads_test::<Runtime, TokioConnectionProvider>(handle)
     }
 
     #[test]
@@ -1143,8 +1149,8 @@ mod tests {
     fn test_sec_lookup() {
         use super::testing::sec_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        sec_lookup_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        sec_lookup_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
@@ -1152,8 +1158,8 @@ mod tests {
     fn test_sec_lookup_fails() {
         use super::testing::sec_lookup_fails_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        sec_lookup_fails_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        sec_lookup_fails_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
@@ -1163,8 +1169,8 @@ mod tests {
     fn test_system_lookup() {
         use super::testing::system_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        system_lookup_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        system_lookup_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
@@ -1175,105 +1181,105 @@ mod tests {
     fn test_hosts_lookup() {
         use super::testing::hosts_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        hosts_lookup_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        hosts_lookup_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_fqdn() {
         use super::testing::fqdn_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        fqdn_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        fqdn_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_ndots() {
         use super::testing::ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        ndots_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        ndots_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_large_ndots() {
         use super::testing::large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        large_ndots_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        large_ndots_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_domain_search() {
         use super::testing::domain_search_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        domain_search_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        domain_search_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_search_list() {
         use super::testing::search_list_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        search_list_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        search_list_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_idna() {
         use super::testing::idna_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        idna_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        idna_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_localhost_ipv4() {
         use super::testing::localhost_ipv4_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        localhost_ipv4_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        localhost_ipv4_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_localhost_ipv6() {
         use super::testing::localhost_ipv6_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        localhost_ipv6_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        localhost_ipv6_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_search_ipv4_large_ndots() {
         use super::testing::search_ipv4_large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        search_ipv4_large_ndots_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        search_ipv4_large_ndots_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_search_ipv6_large_ndots() {
         use super::testing::search_ipv6_large_ndots_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        search_ipv6_large_ndots_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        search_ipv6_large_ndots_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_search_ipv6_name_parse_fails() {
         use super::testing::search_ipv6_name_parse_fails_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
-        let handle = TokioRuntimeProvider::new();
-        search_ipv6_name_parse_fails_test::<Runtime, TokioRuntimeProvider>(io_loop, handle);
+        let handle = TokioConnectionProvider::default();
+        search_ipv6_name_parse_fails_test::<Runtime, TokioConnectionProvider>(io_loop, handle);
     }
 
     #[test]
     fn test_build_names_onion() {
-        let handle = TokioRuntimeProvider::new();
+        let handle = TokioConnectionProvider::default();
         let mut config = ResolverConfig::default();
         config.add_search(Name::from_ascii("example.com.").unwrap());
         let resolver =
-            AsyncResolver::<TokioRuntimeProvider>::new(config, ResolverOpts::default(), handle)
+            AsyncResolver::<TokioConnectionProvider>::new(config, ResolverOpts::default(), handle)
                 .expect("failed to create resolver");
         let tor_address = [
             Name::from_ascii("2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion")

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -25,7 +25,8 @@ use crate::error::*;
 use crate::lookup::{self, Lookup, LookupEither, LookupFuture};
 use crate::lookup_ip::{LookupIp, LookupIpFuture};
 #[cfg(feature = "tokio-runtime")]
-use crate::name_server::{ConnectionProvider, NameServerPool, TokioConnectionProvider};
+use crate::name_server::TokioConnectionProvider;
+use crate::name_server::{ConnectionProvider, NameServerPool};
 
 use crate::Hosts;
 

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -26,7 +26,7 @@ use crate::lookup::{self, Lookup, LookupEither, LookupFuture};
 use crate::lookup_ip::{LookupIp, LookupIpFuture};
 #[cfg(feature = "tokio-runtime")]
 use crate::name_server::TokioRuntimeProvider;
-use crate::name_server::{AbstractNameServerPool, RuntimeProvider};
+use crate::name_server::{NameServerPool, RuntimeProvider};
 
 use crate::Hosts;
 
@@ -201,8 +201,7 @@ impl<P: RuntimeProvider> AsyncResolver<P> {
         options: ResolverOpts,
         conn_provider: P,
     ) -> Result<Self, ResolveError> {
-        let pool =
-            AbstractNameServerPool::from_config_with_provider(&config, &options, conn_provider);
+        let pool = NameServerPool::from_config_with_provider(&config, &options, conn_provider);
         let either;
         let client = RetryDnsHandle::new(pool, options.attempts);
         if options.validate {

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -71,7 +71,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::name_server::TokioRuntimeProvider;
+    use crate::name_server::TokioConnectionProvider;
     use crate::TokioAsyncResolver;
 
     fn https_test(config: ResolverConfig) {
@@ -83,7 +83,7 @@ mod tests {
                 try_tcp_on_error: true,
                 ..ResolverOpts::default()
             },
-            TokioRuntimeProvider::default(),
+            TokioConnectionProvider::default(),
         )
         .expect("failed to create resolver");
 

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -28,7 +28,6 @@ use crate::{
     dns_lru::MAX_TTL,
     error::*,
     lookup_ip::LookupIpIter,
-    name_server::{GenericNameServerPool, RuntimeProvider},
     proto::{
         error::ProtoError,
         op::Query,
@@ -41,6 +40,7 @@ use crate::{
     },
 };
 
+use crate::name_server::{ConnectionProvider, NameServerPool};
 #[cfg(feature = "dnssec")]
 use proto::DnssecDnsHandle;
 
@@ -185,14 +185,14 @@ impl Iterator for LookupIntoIter {
 /// Different lookup options for the lookup attempts and validation
 #[derive(Clone)]
 #[doc(hidden)]
-pub enum LookupEither<P: RuntimeProvider + Send> {
-    Retry(RetryDnsHandle<GenericNameServerPool<P>>),
+pub enum LookupEither<P: ConnectionProvider + Send> {
+    Retry(RetryDnsHandle<NameServerPool<P>>),
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
-    Secure(DnssecDnsHandle<RetryDnsHandle<GenericNameServerPool<P>>>),
+    Secure(DnssecDnsHandle<RetryDnsHandle<NameServerPool<P>>>),
 }
 
-impl<P: RuntimeProvider> DnsHandle for LookupEither<P> {
+impl<P: ConnectionProvider> DnsHandle for LookupEither<P> {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ResolveError>> + Send>>;
     type Error = ResolveError;
 

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -28,7 +28,7 @@ use crate::{
     dns_lru::MAX_TTL,
     error::*,
     lookup_ip::LookupIpIter,
-    name_server::{NameServerPool, RuntimeProvider},
+    name_server::{GenericNameServerPool, RuntimeProvider},
     proto::{
         error::ProtoError,
         op::Query,
@@ -186,10 +186,10 @@ impl Iterator for LookupIntoIter {
 #[derive(Clone)]
 #[doc(hidden)]
 pub enum LookupEither<P: RuntimeProvider + Send> {
-    Retry(RetryDnsHandle<NameServerPool<P>>),
+    Retry(RetryDnsHandle<GenericNameServerPool<P>>),
     #[cfg(feature = "dnssec")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dnssec")))]
-    Secure(DnssecDnsHandle<RetryDnsHandle<NameServerPool<P>>>),
+    Secure(DnssecDnsHandle<RetryDnsHandle<GenericNameServerPool<P>>>),
 }
 
 impl<P: RuntimeProvider> DnsHandle for LookupEither<P> {

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -28,6 +28,7 @@ use crate::{
     dns_lru::MAX_TTL,
     error::*,
     lookup_ip::LookupIpIter,
+    name_server::{ConnectionProvider, NameServerPool},
     proto::{
         error::ProtoError,
         op::Query,
@@ -40,7 +41,6 @@ use crate::{
     },
 };
 
-use crate::name_server::{ConnectionProvider, NameServerPool};
 #[cfg(feature = "dnssec")]
 use proto::DnssecDnsHandle;
 

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -14,8 +14,8 @@ mod name_server_pool;
 mod name_server_state;
 mod name_server_stats;
 
-pub use self::connection_provider::GenericConnection;
-pub use self::connection_provider::{RuntimeProvider, Spawn};
+pub use self::connection_provider::{ConnectionProvider, RuntimeProvider, Spawn};
+pub use self::connection_provider::{GenericConnection, GenericConnector};
 #[cfg(feature = "mdns")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
 pub(crate) use self::name_server::mdns_nameserver;
@@ -26,4 +26,6 @@ use self::name_server_stats::NameServerStats;
 
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]
-pub use self::connection_provider::tokio_runtime::{TokioHandle, TokioRuntimeProvider};
+pub use self::connection_provider::tokio_runtime::{
+    TokioConnectionProvider, TokioHandle, TokioRuntimeProvider,
+};

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -19,8 +19,8 @@ pub use self::connection_provider::{RuntimeProvider, Spawn};
 #[cfg(feature = "mdns")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
 pub(crate) use self::name_server::mdns_nameserver;
-pub use self::name_server::{AbstractNameServer, CreateConnection, NameServer};
-pub use self::name_server_pool::{AbstractNameServerPool, NameServerPool};
+pub use self::name_server::{CreateConnection, GenericNameServer, NameServer};
+pub use self::name_server_pool::{GenericNameServerPool, NameServerPool};
 use self::name_server_state::NameServerState;
 use self::name_server_stats::NameServerStats;
 

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -19,7 +19,7 @@ pub use self::connection_provider::{GenericConnection, GenericConnector};
 #[cfg(feature = "mdns")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
 pub(crate) use self::name_server::mdns_nameserver;
-pub use self::name_server::{CreateConnection, GenericNameServer, NameServer};
+pub use self::name_server::{GenericNameServer, NameServer};
 pub use self::name_server_pool::{GenericNameServerPool, NameServerPool};
 use self::name_server_state::NameServerState;
 use self::name_server_stats::NameServerStats;

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -249,18 +249,6 @@ where
     GenericNameServer::new_with_provider(config, options, conn_provider)
 }
 
-/// Used for creating new connections.
-/// We introduce this trait as an intermediate layer for real logic and mock testing.
-/// If you are an end user and use `GenericConnection`, just ignore this trait.
-pub trait CreateConnection: Sized {
-    /// Create a future of Self with the help of runtime provider.
-    fn new_connection<P: RuntimeProvider>(
-        runtime_provider: &P,
-        config: &NameServerConfig,
-        options: &ResolverOpts,
-    ) -> Box<dyn Future<Output = Result<Self, ResolveError>> + Send + Unpin + 'static>;
-}
-
 #[cfg(test)]
 #[cfg(feature = "tokio-runtime")]
 mod tests {

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -7,7 +7,6 @@
 
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
-use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
@@ -23,7 +22,7 @@ use tracing::debug;
 use crate::config::{NameServerConfig, ResolverOpts};
 use crate::error::ResolveError;
 use crate::name_server::connection_provider::{ConnectionProvider, GenericConnector};
-use crate::name_server::{NameServerState, NameServerStats, RuntimeProvider};
+use crate::name_server::{NameServerState, NameServerStats};
 #[cfg(feature = "mdns")]
 use proto::multicast::{MdnsClientConnect, MdnsClientStream, MdnsQueryType};
 

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -23,21 +23,19 @@ use crate::config::{NameServerConfigGroup, ResolverConfig, ResolverOpts, ServerO
 use crate::error::{ResolveError, ResolveErrorKind};
 #[cfg(feature = "mdns")]
 use crate::name_server;
-use crate::name_server::name_server::{CreateConnection, NameServer};
+use crate::name_server::connection_provider::{ConnectionProvider, GenericConnector};
+use crate::name_server::name_server::NameServer;
+use crate::name_server::RuntimeProvider;
 #[cfg(test)]
 #[cfg(feature = "tokio-runtime")]
 use crate::name_server::TokioRuntimeProvider;
-use crate::name_server::{GenericConnection, RuntimeProvider};
 
 /// Abstract interface for mocking purpose
 #[derive(Clone)]
-pub struct NameServerPool<
-    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
-    P: RuntimeProvider + Send + 'static,
-> {
+pub struct NameServerPool<P: ConnectionProvider + Send + 'static> {
     // TODO: switch to FuturesMutex (Mutex will have some undesirable locking)
-    datagram_conns: Arc<[NameServer<C, P>]>, /* All NameServers must be the same type */
-    stream_conns: Arc<[NameServer<C, P>]>,   /* All NameServers must be the same type */
+    datagram_conns: Arc<[NameServer<P>]>, /* All NameServers must be the same type */
+    stream_conns: Arc<[NameServer<P>]>,   /* All NameServers must be the same type */
     #[cfg(feature = "mdns")]
     mdns_conns: NameServer<P>, /* All NameServers must be the same type */
     options: ResolverOpts,
@@ -46,7 +44,7 @@ pub struct NameServerPool<
 /// A pool of NameServers
 ///
 /// This is not expected to be used directly, see [crate::AsyncResolver].
-pub type GenericNameServerPool<P> = NameServerPool<GenericConnection, P>;
+pub type GenericNameServerPool<P> = NameServerPool<GenericConnector<P>>;
 
 #[cfg(test)]
 #[cfg(feature = "tokio-runtime")]
@@ -56,21 +54,20 @@ impl GenericNameServerPool<TokioRuntimeProvider> {
         options: &ResolverOpts,
         runtime: TokioRuntimeProvider,
     ) -> Self {
-        Self::from_config_with_provider(config, options, runtime)
+        Self::from_config_with_provider(config, options, GenericConnector::new(runtime))
     }
 }
 
-impl<C, P> NameServerPool<C, P>
+impl<P> NameServerPool<P>
 where
-    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
-    P: RuntimeProvider + 'static,
+    P: ConnectionProvider + 'static,
 {
     pub(crate) fn from_config_with_provider(
         config: &ResolverConfig,
         options: &ResolverOpts,
         conn_provider: P,
     ) -> Self {
-        let datagram_conns: Vec<NameServer<C, P>> = config
+        let datagram_conns: Vec<NameServer<P>> = config
             .name_servers()
             .iter()
             .filter(|ns_config| ns_config.protocol.is_datagram())
@@ -88,7 +85,7 @@ where
             })
             .collect();
 
-        let stream_conns: Vec<NameServer<C, P>> = config
+        let stream_conns: Vec<NameServer<P>> = config
             .name_servers()
             .iter()
             .filter(|ns_config| ns_config.protocol.is_stream())
@@ -145,8 +142,8 @@ where
     #[cfg(not(feature = "mdns"))]
     pub fn from_nameservers(
         options: &ResolverOpts,
-        datagram_conns: Vec<NameServer<C, P>>,
-        stream_conns: Vec<NameServer<C, P>>,
+        datagram_conns: Vec<NameServer<P>>,
+        stream_conns: Vec<NameServer<P>>,
     ) -> Self {
         Self {
             datagram_conns: Arc::from(datagram_conns),
@@ -159,9 +156,9 @@ where
     #[cfg(feature = "mdns")]
     pub fn from_nameservers(
         options: &ResolverOpts,
-        datagram_conns: Vec<NameServer<C, P>>,
-        stream_conns: Vec<NameServer<C, P>>,
-        mdns_conns: NameServer<C, P>,
+        datagram_conns: Vec<NameServer<P>>,
+        stream_conns: Vec<NameServer<P>>,
+        mdns_conns: NameServer<P>,
     ) -> Self {
         GenericNameServerPool {
             datagram_conns: Arc::from(datagram_conns),
@@ -176,8 +173,8 @@ where
     #[allow(dead_code)]
     fn from_nameservers_test(
         options: &ResolverOpts,
-        datagram_conns: Arc<[NameServer<C, P>]>,
-        stream_conns: Arc<[NameServer<C, P>]>,
+        datagram_conns: Arc<[NameServer<P>]>,
+        stream_conns: Arc<[NameServer<P>]>,
     ) -> Self {
         Self {
             datagram_conns,
@@ -190,25 +187,24 @@ where
     #[cfg(feature = "mdns")]
     fn from_nameservers_test(
         options: &ResolverOpts,
-        datagram_conns: Arc<[NameServer<C, P>]>,
-        stream_conns: Arc<[NameServer<C, P>]>,
-        mdns_conns: NameServer<C, P>,
+        datagram_conns: Arc<[NameServer<P>]>,
+        stream_conns: Arc<[NameServer<P>]>,
+        mdns_conns: NameServer<P>,
     ) -> Self {
         GenericNameServerPool {
             datagram_conns,
             stream_conns,
             mdns_conns,
             options: *options,
-            conn_provider,
         }
     }
 
     async fn try_send(
         opts: ResolverOpts,
-        conns: Arc<[NameServer<C, P>]>,
+        conns: Arc<[NameServer<P>]>,
         request: DnsRequest,
     ) -> Result<DnsResponse, ResolveError> {
-        let mut conns: Vec<NameServer<C, P>> = conns.to_vec();
+        let mut conns: Vec<NameServer<P>> = conns.to_vec();
 
         match opts.server_ordering_strategy {
             // select the highest priority connection
@@ -223,10 +219,9 @@ where
     }
 }
 
-impl<C, P> DnsHandle for NameServerPool<C, P>
+impl<P> DnsHandle for NameServerPool<P>
 where
-    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
-    P: RuntimeProvider + 'static,
+    P: ConnectionProvider + 'static,
 {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ResolveError>> + Send>>;
     type Error = ResolveError;
@@ -302,14 +297,13 @@ where
 
 // TODO: we should be able to have a self-referential future here with Pin and not require cloned conns
 /// An async function that will loop over all the conns with a max parallel request count of ops.num_concurrent_req
-async fn parallel_conn_loop<C, P>(
-    mut conns: Vec<NameServer<C, P>>,
+async fn parallel_conn_loop<P>(
+    mut conns: Vec<NameServer<P>>,
     request: DnsRequest,
     opts: ResolverOpts,
 ) -> Result<DnsResponse, ResolveError>
 where
-    C: DnsHandle<Error = ResolveError> + Send + Sync + 'static + CreateConnection,
-    P: RuntimeProvider + 'static,
+    P: ConnectionProvider + 'static,
 {
     let mut err = ResolveError::no_connections();
     // If the name server we're trying is giving us backpressure by returning ProtoErrorKind::Busy,
@@ -323,13 +317,13 @@ where
     // close to the connection, which means the top level resolution might take substantially longer
     // to fire than the timeout configured in `ResolverOpts`.
     let mut backoff = Duration::from_millis(20);
-    let mut busy = SmallVec::<[NameServer<C, P>; 2]>::new();
+    let mut busy = SmallVec::<[NameServer<P>; 2]>::new();
 
     loop {
         let request_cont = request.clone();
 
         // construct the parallel requests, 2 is the default
-        let mut par_conns = SmallVec::<[NameServer<C, P>; 2]>::new();
+        let mut par_conns = SmallVec::<[NameServer<P>; 2]>::new();
         let count = conns.len().min(opts.num_concurrent_reqs.max(1));
         for conn in conns.drain(..count) {
             par_conns.push(conn);
@@ -337,7 +331,10 @@ where
 
         if par_conns.is_empty() {
             if !busy.is_empty() && backoff < Duration::from_millis(300) {
-                P::Timer::delay_for(backoff).await;
+                <<P as ConnectionProvider>::RuntimeProvider as RuntimeProvider>::Timer::delay_for(
+                    backoff,
+                )
+                .await;
                 conns.extend(busy.drain(..));
                 backoff *= 2;
                 continue;
@@ -470,8 +467,8 @@ mod tests {
     use super::*;
     use crate::config::NameServerConfig;
     use crate::config::Protocol;
-    use crate::name_server::GenericNameServer;
     use crate::name_server::TokioRuntimeProvider;
+    use crate::name_server::{GenericNameServer, TokioConnectionProvider};
 
     #[ignore]
     // because of there is a real connection that needs a reasonable timeout
@@ -548,7 +545,7 @@ mod tests {
     #[test]
     fn test_multi_use_conns() {
         let io_loop = Runtime::new().unwrap();
-        let conn_provider = TokioRuntimeProvider::new();
+        let conn_provider = TokioConnectionProvider::default();
 
         let tcp = NameServerConfig {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
@@ -568,15 +565,18 @@ mod tests {
         let name_server = GenericNameServer::new(ns_config, opts, conn_provider);
         let name_servers: Arc<[_]> = Arc::from([name_server]);
 
+        #[cfg(not(feature = "mdns"))]
         let mut pool = GenericNameServerPool::from_nameservers_test(
             &opts,
             Arc::from([]),
             Arc::clone(&name_servers),
-            #[cfg(feature = "mdns")]
-            name_server::mdns_nameserver(
-                opts,
-                TokioConnectionProvider::new(TokioHandle::default()),
-            ),
+        );
+        #[cfg(feature = "mdns")]
+        let mut pool = GenericNameServerPool::from_nameservers_test(
+            &opts,
+            Arc::from([]),
+            Arc::clone(&name_servers),
+            name_server::mdns_nameserver(opts, TokioConnectionProvider::default(), false),
         );
 
         let name = Name::from_str("www.example.com.").unwrap();

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -20,7 +20,7 @@ use crate::error::*;
 use crate::lookup;
 use crate::lookup::Lookup;
 use crate::lookup_ip::LookupIp;
-use crate::name_server::TokioRuntimeProvider;
+use crate::name_server::TokioConnectionProvider;
 use crate::AsyncResolver;
 
 /// The Resolver is used for performing DNS queries.
@@ -35,7 +35,7 @@ pub struct Resolver {
     //   drawbacks. One major issues, is if this Resolver is shared across threads, it will cause all to block on any
     //   query. A TLS on the other hand would not, at the cost of only allowing a Resolver to be configured once per Thread
     runtime: Mutex<Runtime>,
-    async_resolver: AsyncResolver<TokioRuntimeProvider>,
+    async_resolver: AsyncResolver<TokioConnectionProvider>,
 }
 
 macro_rules! lookup_fn {
@@ -80,8 +80,9 @@ impl Resolver {
         builder.enable_all();
 
         let runtime = builder.build()?;
-        let async_resolver = AsyncResolver::new(config, options, TokioRuntimeProvider::new())
-            .expect("failed to create resolver");
+        let async_resolver =
+            AsyncResolver::new(config, options, TokioConnectionProvider::default())
+                .expect("failed to create resolver");
 
         Ok(Self {
             runtime: Mutex::new(runtime),

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -33,7 +33,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
-    use crate::name_server::TokioRuntimeProvider;
+    use crate::name_server::TokioConnectionProvider;
     use crate::TokioAsyncResolver;
 
     fn tls_test(config: ResolverConfig) {
@@ -45,7 +45,7 @@ mod tests {
                 try_tcp_on_error: true,
                 ..ResolverOpts::default()
             },
-            TokioRuntimeProvider::default(),
+            TokioConnectionProvider::default(),
         )
         .expect("failed to create resolver");
 

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -8,7 +8,7 @@
 use std::io;
 
 use tracing::{debug, info};
-use trust_dns_resolver::name_server::TokioRuntimeProvider;
+use trust_dns_resolver::name_server::TokioConnectionProvider;
 
 use crate::{
     authority::{
@@ -35,7 +35,7 @@ impl ForwardAuthority {
     /// TODO: change this name to create or something
     #[allow(clippy::new_without_default)]
     #[doc(hidden)]
-    pub fn new(runtime: TokioRuntimeProvider) -> Result<Self, String> {
+    pub fn new(runtime: TokioConnectionProvider) -> Result<Self, String> {
         let resolver = TokioAsyncResolver::from_system_conf(runtime)
             .map_err(|e| format!("error constructing new Resolver: {e}"))?;
 
@@ -77,7 +77,7 @@ impl ForwardAuthority {
 
         let config = ResolverConfig::from_parts(None, vec![], name_servers);
 
-        let resolver = TokioAsyncResolver::new(config, options, TokioRuntimeProvider::new())
+        let resolver = TokioAsyncResolver::new(config, options, TokioConnectionProvider::default())
             .map_err(|e| format!("error constructing new Resolver: {}", e))?;
 
         info!("forward resolver configured: {}: ", origin);

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 use trust_dns_proto::rr::{Name, RData, RecordType};
-use trust_dns_resolver::name_server::TokioRuntimeProvider;
+use trust_dns_resolver::name_server::TokioConnectionProvider;
 use trust_dns_server::{
     authority::{Authority, LookupObject},
     store::forwarder::ForwardAuthority,
@@ -17,8 +17,8 @@ use trust_dns_server::{
 #[test]
 fn test_lookup() {
     let runtime = Runtime::new().expect("failed to create Tokio Runtime");
-    let forwarder =
-        ForwardAuthority::new(TokioRuntimeProvider::new()).expect("failed to create forwarder");
+    let forwarder = ForwardAuthority::new(TokioConnectionProvider::default())
+        .expect("failed to create forwarder");
 
     let lookup = runtime
         .block_on(forwarder.lookup(

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -17,14 +17,13 @@ use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::xfer::{DnsHandle, DnsResponse, FirstAnswer};
 use trust_dns_resolver::config::*;
 use trust_dns_resolver::error::{ResolveError, ResolveErrorKind};
-use trust_dns_resolver::name_server::{AbstractNameServer, AbstractNameServerPool};
+use trust_dns_resolver::name_server::{NameServer, NameServerPool};
 
 const DEFAULT_SERVER_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
-type MockedNameServer<O> =
-    AbstractNameServer<MockClientHandle<O, ResolveError>, MockConnProvider<O>>;
+type MockedNameServer<O> = NameServer<MockClientHandle<O, ResolveError>, MockConnProvider<O>>;
 type MockedNameServerPool<O> =
-    AbstractNameServerPool<MockClientHandle<O, ResolveError>, MockConnProvider<O>>;
+    NameServerPool<MockClientHandle<O, ResolveError>, MockConnProvider<O>>;
 
 #[cfg(test)]
 fn mock_nameserver(
@@ -80,7 +79,7 @@ fn mock_nameserver_on_send_nx<O: OnSend + Unpin>(
     };
     let client = MockClientHandle::mock_on_send(messages, on_send);
 
-    AbstractNameServer::from_conn(
+    NameServer::from_conn(
         NameServerConfig {
             socket_addr: SocketAddr::new(addr, 0),
             protocol: Protocol::Udp,
@@ -115,10 +114,10 @@ fn mock_nameserver_pool_on_send<O: OnSend + Unpin>(
     options: ResolverOpts,
 ) -> MockedNameServerPool<O> {
     #[cfg(not(feature = "mdns"))]
-    return AbstractNameServerPool::from_nameservers(&options, udp, tcp);
+    return NameServerPool::from_nameservers(&options, udp, tcp);
 
     #[cfg(feature = "mdns")]
-    return AbstractNameServerPool::from_nameservers(
+    return NameServerPool::from_nameservers(
         &options, udp,
         tcp,
         //_mdns.unwrap_or_else(move || mock_nameserver_on_send(vec![], options, on_send)),

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -21,9 +21,8 @@ use trust_dns_resolver::name_server::{NameServer, NameServerPool};
 
 const DEFAULT_SERVER_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
-type MockedNameServer<O> = NameServer<MockClientHandle<O, ResolveError>, MockConnProvider<O>>;
-type MockedNameServerPool<O> =
-    NameServerPool<MockClientHandle<O, ResolveError>, MockConnProvider<O>>;
+type MockedNameServer<O> = NameServer<MockConnProvider<O, ResolveError>>;
+type MockedNameServerPool<O> = NameServerPool<MockConnProvider<O, ResolveError>>;
 
 #[cfg(test)]
 fn mock_nameserver(
@@ -76,6 +75,7 @@ fn mock_nameserver_on_send_nx<O: OnSend + Unpin>(
 ) -> MockedNameServer<O> {
     let conn_provider = MockConnProvider {
         on_send: on_send.clone(),
+        _p: Default::default(),
     };
     let client = MockClientHandle::mock_on_send(messages, on_send);
 


### PR DESCRIPTION
In the later discussion of #1876, @jeff-hiner argues that the current Provider API doesn't offer a convenient way to statefully create `DnsHandle`. This PR redesigns the Provider API.

This PR replaces the original `CreateConnection` trait with the new factory trait `ConnectionProvider`, allowing stateful connection creation. Now we have two layers of customization, `ConnectionProvider` and `RuntimeProvider`. The `RuntimeProvider` is a factory to create TCP or UDP connections, as well as runtime-specific timer. The `ConnectionProvider` is a factory to create a `DnsHandle` with the help of `RuntimeProvider`. 

```rust
pub trait ConnectionProvider: 'static + Clone + Send + Sync + Unpin {
    /// The handle to the connect for sending DNS requests.
    type Conn: DnsHandle<Error = ResolveError> + Clone + Send + Sync + 'static;
    /// Ths future is responsible for spawning any background tasks as necessary.
    type FutureConn: Future<Output = Result<Self::Conn, ResolveError>> + Send + 'static;
    /// Provider that handles the underlying I/O and timing.
    type RuntimeProvider: RuntimeProvider;

    /// Create a new connection.
    fn new_connection(&self, config: &NameServerConfig, options: &ResolverOpts)
        -> Self::FutureConn;
}
```

If a user wants to override the default networking behavior, he/she can simply implement a new `RuntimeProvider`, without the need of re-implementing the `GenericConnection` internal logic. If a user wants to override the upper logic of a `DnsHandle`, for example add an auth field to the HTTP header, he/she can just implement a new `ConnectionProvider` and reuse current `RuntimeProvider` (It's also possible not to use a connection provided by `RuntimeProvider`, as long as the user insists).

Currently, the default handle is `GenericConnection` and the default connection provider is `GenericProvider`.

This PR also clarifies the usage of Provider API. The original comment in 0.22 as well as #1876 is kind of misleading.