### PR TITLE
Use `default-features = false` for `quinn`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,6 @@ dependencies = [
  "ring",
  "rustc-hash",
  "rustls",
- "rustls-native-certs",
  "slab",
  "thiserror",
  "tinyvec",
@@ -1366,18 +1365,6 @@ dependencies = [
  "ring",
  "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ ring = "0.16"
 
 
 # net proto
-quinn = "0.10"
+quinn = { version = "0.10", default-features = false }
 h2 = "0.3.0"
 http = "0.2"
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -84,7 +84,7 @@ js-sys = { workspace = true, optional = true }
 lazy_static.workspace = true
 native-tls = { workspace = true, optional = true }
 openssl = { workspace = true, features = ["v102", "v110"], optional = true }
-quinn = { workspace = true, optional = true }
+quinn = { workspace = true, optional = true, features = ["log", "runtime-tokio", "tls-rustls"] }
 rand.workspace = true
 ring = { workspace = true, optional = true, features = ["std"] }
 rustls = { workspace = true, optional = true }


### PR DESCRIPTION
Removes the unused dependency on `rustls-native-certs`.

Fixes #1940.