### PR TITLE
Return `Self` from `AsyncResolver::new()`

### DIFF
--- a/crates/async-std-resolver/README.md
+++ b/crates/async-std-resolver/README.md
@@ -31,7 +31,7 @@ async fn main() {
   let resolver = resolver(
     config::ResolverConfig::default(),
     config::ResolverOpts::default(),
-  ).await.expect("failed to connect resolver");
+  ).await;
 
   // Lookup the IP addresses associated with a name.
   // This returns a future that will lookup the IP addresses, it must be run in the Core to

--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -55,7 +55,7 @@
 //!   let resolver = resolver(
 //!     config::ResolverConfig::default(),
 //!     config::ResolverOpts::default(),
-//!   ).await.expect("failed to connect resolver");
+//!   ).await;
 //!
 //!   // Lookup the IP addresses associated with a name.
 //!   // This returns a future that will lookup the IP addresses, it must be run in the Core to
@@ -130,7 +130,7 @@ pub type AsyncStdResolver = AsyncResolver<AsyncStdRuntimeProvider>;
 pub async fn resolver(
     config: config::ResolverConfig,
     options: config::ResolverOpts,
-) -> Result<AsyncStdResolver, ResolveError> {
+) -> AsyncStdResolver {
     AsyncStdResolver::new(config, options, AsyncStdRuntimeProvider::new())
 }
 

--- a/crates/resolver/examples/custom_provider.rs
+++ b/crates/resolver/examples/custom_provider.rs
@@ -82,8 +82,7 @@ async fn main() {
         ResolverConfig::google(),
         ResolverOpts::default(),
         PrintProvider::default(),
-    )
-    .unwrap();
+    );
     lookup_test(resolver).await;
 
     #[cfg(feature = "dns-over-https-rustls")]
@@ -92,8 +91,7 @@ async fn main() {
             ResolverConfig::cloudflare_https(),
             ResolverOpts::default(),
             PrintProvider::default(),
-        )
-        .unwrap();
+        );
         lookup_test(resolver2).await;
     }
 

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -84,8 +84,7 @@ mod tests {
                 ..ResolverOpts::default()
             },
             TokioRuntimeProvider::default(),
-        )
-        .expect("failed to create resolver");
+        );
 
         let response = io_loop
             .block_on(resolver.lookup_ip("www.example.com."))

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -112,7 +112,7 @@
 //!     TokioAsyncResolver::tokio(
 //!         ResolverConfig::default(),
 //!         ResolverOpts::default())
-//! }).expect("failed to connect resolver");
+//! });
 //!
 //! // Lookup the IP addresses associated with a name.
 //! // This returns a future that will lookup the IP addresses, it must be run in the Core to
@@ -153,7 +153,7 @@
 //! #    TokioAsyncResolver::tokio(
 //! #        ResolverConfig::default(),
 //! #        ResolverOpts::default())
-//! # }).expect("failed to connect resolver");
+//! # });
 //! #
 //! let ips = io_loop.block_on(resolver.lookup_ip("www.example.com.")).unwrap();
 //!

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -80,8 +80,7 @@ impl Resolver {
         builder.enable_all();
 
         let runtime = builder.build()?;
-        let async_resolver = AsyncResolver::new(config, options, TokioRuntimeProvider::new())
-            .expect("failed to create resolver");
+        let async_resolver = AsyncResolver::new(config, options, TokioRuntimeProvider::new());
 
         Ok(Self {
             runtime: Mutex::new(runtime),

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -46,8 +46,7 @@ mod tests {
                 ..ResolverOpts::default()
             },
             TokioRuntimeProvider::default(),
-        )
-        .expect("failed to create resolver");
+        );
 
         let response = io_loop
             .block_on(resolver.lookup_ip("www.example.com."))

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -77,8 +77,7 @@ impl ForwardAuthority {
 
         let config = ResolverConfig::from_parts(None, vec![], name_servers);
 
-        let resolver = TokioAsyncResolver::new(config, options, TokioRuntimeProvider::new())
-            .map_err(|e| format!("error constructing new Resolver: {}", e))?;
+        let resolver = TokioAsyncResolver::new(config, options, TokioRuntimeProvider::new());
 
         info!("forward resolver configured: {}: ", origin);
 

--- a/util/src/resolve.rs
+++ b/util/src/resolve.rs
@@ -339,7 +339,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         options.ip_strategy = trust_dns_resolver::config::LookupIpStrategy::Ipv4AndIpv6;
     }
 
-    let resolver_arc = Arc::new(TokioAsyncResolver::tokio(config, options)?);
+    let resolver_arc = Arc::new(TokioAsyncResolver::tokio(config, options));
 
     if let Some(domainname) = &opts.domainname {
         log_query(domainname, opts.ty, &name_servers, &opts);


### PR DESCRIPTION
I was wondering how this can return an error and found out that it just can't. Maybe it was left this way to avoid breaking changes?

Is this desirable?