### PR TITLE
Make RData::read() API public

### DIFF
--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -754,7 +754,7 @@ impl RData {
     }
 
     /// Read data from the decoder
-    pub(crate) fn read_data(
+    pub fn read(
         decoder: &mut BinDecoder<'_>,
         record_type: RecordType,
         length: Restrict<u16>,
@@ -1242,7 +1242,7 @@ mod tests {
             let mut decoder = BinDecoder::new(&binary);
 
             assert_eq!(
-                RData::read_data(
+                RData::read(
                     &mut decoder,
                     record_type_from_rdata(&expect),
                     Restrict::new(length)

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -531,11 +531,7 @@ impl<'r> BinDecodable<'r> for Record<RData> {
             //                according to the TYPE and CLASS of the resource record.
             // Adding restrict to the rdata length because it's used for many calculations later
             //  and must be validated before hand
-            Some(RData::read_data(
-                decoder,
-                record_type,
-                Restrict::new(rd_length),
-            )?)
+            Some(RData::read(decoder, record_type, Restrict::new(rd_length))?)
         };
 
         debug_assert!(


### PR DESCRIPTION
[`RData::read()`](https://github.com/bluejekyll/trust-dns/pull/1770/files#diff-ffc7b721f2150b0b8af3b8dec18dadc84ea33a31b87ac23a601510a2fccf52d0L706) used to be public before #1770. We were using it at work to retrieve binary-encoded record data from Redis for our DNS servers. As far as I can tell, there's no good alternative in the 0.23.0-alpha.1 API -- `Record<RData>` implements `BinEncodable` but it also wants to decode things like type and TTL.