### PR TITLE
Add Google DoT and DoH to `ResolverConfig`

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -65,6 +65,38 @@ impl ResolverConfig {
         }
     }
 
+    /// Creates a default configuration, using `8.8.8.8`, `8.8.4.4` and `2001:4860:4860::8888`, `2001:4860:4860::8844` (thank you, Google). This limits the registered connections to just TLS lookups
+    ///
+    /// Please see Google's [privacy statement](https://developers.google.com/speed/public-dns/privacy) for important information about what they track, many ISP's track similar information in DNS. To use the system configuration see: `Resolver::from_system_conf` and `AsyncResolver::from_system_conf`
+    ///
+    /// NameServerConfigGroups can be combined to use a set of different providers, see `NameServerConfigGroup` and `ResolverConfig::from_parts`
+    #[cfg(feature = "dns-over-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-tls")))]
+    pub fn google_tls() -> Self {
+        Self {
+            // TODO: this should get the hostname and use the basename as the default
+            domain: None,
+            search: vec![],
+            name_servers: NameServerConfigGroup::google_tls(),
+        }
+    }
+
+    /// Creates a default configuration, using `8.8.8.8`, `8.8.4.4` and `2001:4860:4860::8888`, `2001:4860:4860::8844` (thank you, Google). This limits the registered connections to just HTTPS lookups
+    ///
+    /// Please see Google's [privacy statement](https://developers.google.com/speed/public-dns/privacy) for important information about what they track, many ISP's track similar information in DNS. To use the system configuration see: `Resolver::from_system_conf` and `AsyncResolver::from_system_conf`
+    ///
+    /// NameServerConfigGroups can be combined to use a set of different providers, see `NameServerConfigGroup` and `ResolverConfig::from_parts`
+    #[cfg(feature = "dns-over-https")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    pub fn google_https() -> Self {
+        Self {
+            // TODO: this should get the hostname and use the basename as the default
+            domain: None,
+            search: vec![],
+            name_servers: NameServerConfigGroup::google_https(),
+        }
+    }
+
     /// Creates a default configuration, using `1.1.1.1`, `1.0.0.1` and `2606:4700:4700::1111`, `2606:4700:4700::1001` (thank you, Cloudflare).
     ///
     /// Please see: <https://www.cloudflare.com/dns/>
@@ -628,6 +660,15 @@ impl NameServerConfigGroup {
     /// Please see Google's [privacy statement](https://developers.google.com/speed/public-dns/privacy) for important information about what they track, many ISP's track similar information in DNS. To use the system configuration see: `Resolver::from_system_conf` and `AsyncResolver::from_system_conf`
     pub fn google() -> Self {
         Self::from_ips_clear(GOOGLE_IPS, 53, true)
+    }
+
+    /// Creates a default configuration, using `8.8.8.8`, `8.8.4.4` and `2001:4860:4860::8888`, `2001:4860:4860::8844` (thank you, Google). This limits the registered connections to just TLS lookups
+    ///
+    /// Please see Google's [privacy statement](https://developers.google.com/speed/public-dns/privacy) for important information about what they track, many ISP's track similar information in DNS. To use the system configuration see: `Resolver::from_system_conf` and `AsyncResolver::from_system_conf`
+    #[cfg(feature = "dns-over-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-tls")))]
+    pub fn google_tls() -> Self {
+        Self::from_ips_tls(GOOGLE_IPS, 853, "dns.google".to_string(), true)
     }
 
     /// Creates a default configuration, using `8.8.8.8`, `8.8.4.4` and `2001:4860:4860::8888`, `2001:4860:4860::8844` (thank you, Google). This limits the registered connections to just HTTPS lookups

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -125,6 +125,11 @@ mod tests {
     }
 
     #[test]
+    fn test_google_https() {
+        https_test(ResolverConfig::google_https())
+    }
+
+    #[test]
     fn test_cloudflare_https() {
         https_test(ResolverConfig::cloudflare_https())
     }

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -69,6 +69,12 @@ mod tests {
 
     #[test]
     #[cfg(not(windows))] // flakes on AppVeyor...
+    fn test_google_tls() {
+        tls_test(ResolverConfig::google_tls())
+    }
+
+    #[test]
+    #[cfg(not(windows))] // flakes on AppVeyor...
     fn test_cloudflare_tls() {
         tls_test(ResolverConfig::cloudflare_tls())
     }


### PR DESCRIPTION
Just noticed that these were missing.