### PR TITLE
Use SPDX 2.1 license expression.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ homepage = "https://trust-dns.org/"
 repository = "https://github.com/bluejekyll/trust-dns"
 keywords = ["DNS", "BIND", "dig", "named", "dnssec"]
 categories = ["network-programming"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 
 [workspace.dependencies]


### PR DESCRIPTION
This improves the usage of automated tooling which consumes the license information.