### PR TITLE
Authority can depend on client source ipnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
+ "ipnet",
  "openssl",
  "rusqlite",
  "rustls",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -79,6 +79,7 @@ futures-executor = { workspace = true, default-features = false, features = ["st
 futures-util = { workspace = true, default-features = false, features = ["std"] }
 h2 = { workspace = true, features = ["stream"], optional = true }
 http = { workspace = true, optional = true }
+ipnet.workspace = true
 openssl = { workspace = true, features = ["v102", "v110"], optional = true }
 rusqlite = { workspace = true, features = ["bundled", "time"], optional = true }
 rustls = { workspace = true, optional = true }


### PR DESCRIPTION
I thought it could be useful to answer differently to clients depending on their source ip network.

There is no breaking change (existing functions still work the same way) but I added the two following functions in the catalog.rs file:

```rust
pub fn upsert_for_ipnet(
    &mut self,
    ipnet: IpNet,
    name: LowerName,
    authority: Box<dyn AuthorityObject>,
)

pub fn remove_for_ipnet(
    &mut self,
    ipnet: &IpNet,
    name: &LowerName,
) -> Option<Box<dyn AuthorityObject>>
```

Now, authorities are stored like this:
```rust
authorities: vec![(None, HashMap::new())],
```

There is a small performance overhead when adding an AuthorityObject because the vector has to be sorted to have at the first position the smallest IpNet and last position the biggest one (which is None, corresponding to all networks and to the current behaviour, all networks).



If this is not a wanted behavior or functionnalty feel free to delete this, I won't be offended it was just something I needed :)