### PR TITLE
Bump `rustls-webpki` to v0.101.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",


### PR DESCRIPTION
Mainly made to unbreak the CI, which currently fails on `cargo-audit` with https://rustsec.org/advisories/RUSTSEC-2023-0053.