### PR TITLE
Make DnsHandle::send &self instead of &mut self

### DIFF
--- a/bin/tests/server_harness/mut_message_client.rs
+++ b/bin/tests/server_harness/mut_message_client.rs
@@ -29,7 +29,7 @@ impl<C: ClientHandle + Unpin> DnsHandle for MutMessageHandle<C> {
     }
 
     #[allow(unused_mut)]
-    fn send<R: Into<DnsRequest> + Unpin>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest> + Unpin>(&self, request: R) -> Self::Response {
         let mut request = request.into();
 
         #[cfg(feature = "dnssec")]

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -147,7 +147,7 @@ impl DnsHandle for AsyncClient {
     type Response = DnsExchangeSend;
     type Error = ProtoError;
 
-    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         self.exchange.send(request)
     }
 

--- a/crates/client/src/client/async_secure_client.rs
+++ b/crates/client/src/client/async_secure_client.rs
@@ -71,7 +71,7 @@ impl DnsHandle for AsyncDnssecClient {
     type Response = Pin<Box<(dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + 'static)>>;
     type Error = ProtoError;
 
-    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         self.client.send(request)
     }
 }

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -99,7 +99,7 @@ pub trait Client {
         &self,
         msg: R,
     ) -> Vec<ClientResult<DnsResponse>> {
-        let (mut client, runtime) = match self.spawn_client() {
+        let (client, runtime) = match self.spawn_client() {
             Ok(c_r) => c_r,
             Err(e) => return vec![Err(e)],
         };

--- a/crates/client/src/client/memoize_client_handle.rs
+++ b/crates/client/src/client/memoize_client_handle.rs
@@ -48,7 +48,7 @@ where
     async fn inner_send(
         request: DnsRequest,
         active_queries: Arc<Mutex<HashMap<Query, RcStream<<H as DnsHandle>::Response>>>>,
-        mut client: H,
+        client: H,
     ) -> impl Stream<Item = Result<DnsResponse, ProtoError>> {
         // TODO: what if we want to support multiple queries (non-standard)?
         let query = request.queries().first().expect("no query!").clone();
@@ -77,7 +77,7 @@ where
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
     type Error = ProtoError;
 
-    fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
         let request = request.into();
 
         Box::pin(
@@ -119,7 +119,7 @@ mod test {
         type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
         type Error = ProtoError;
 
-        fn send<R: Into<DnsRequest> + Send + 'static>(&mut self, request: R) -> Self::Response {
+        fn send<R: Into<DnsRequest> + Send + 'static>(&self, request: R) -> Self::Response {
             let i = Arc::clone(&self.i);
             let future = async {
                 let i = i;
@@ -148,7 +148,7 @@ mod test {
     fn test_memoized() {
         use futures::executor::block_on;
 
-        let mut client = MemoizeClientHandle::new(TestClient {
+        let client = MemoizeClientHandle::new(TestClient {
             i: Arc::new(Mutex::new(0)),
         });
 

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -107,7 +107,7 @@ impl DnsHandle for DnsExchange {
     type Response = DnsExchangeSend;
     type Error = ProtoError;
 
-    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         DnsExchangeSend {
             result: self.sender.send(request),
             _sender: self.sender.clone(), // TODO: this shouldn't be necessary, currently the presence of Senders is what allows the background to track current users, it generally is dropped right after send, this makes sure that there is at least one active after send

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -53,7 +53,7 @@ pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
     /// * `request` - the fully constructed Message to send, note that most implementations of
     ///               will most likely be required to rewrite the QueryId, do no rely on that as
     ///               being stable.
-    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response;
+    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response;
 
     /// A *classic* DNS query
     ///
@@ -63,7 +63,7 @@ pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
     ///
     /// * `query` - the query to lookup
     /// * `options` - options to use when constructing the message
-    fn lookup(&mut self, query: Query, options: DnsRequestOptions) -> Self::Response {
+    fn lookup(&self, query: Query, options: DnsRequestOptions) -> Self::Response {
         debug!("querying: {} {:?}", query.name(), query.query_type());
         self.send(DnsRequest::new(build_message(query, options), options))
     }

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -115,7 +115,7 @@ where
         true
     }
 
-    fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
         let mut request = request.into();
 
         // backstop
@@ -467,7 +467,7 @@ where
 ///  as a success. Otherwise, a query is sent to get the DS record, and the DNSKEY is validated
 ///  against the DS record.
 async fn verify_dnskey_rrset<H, E>(
-    mut handle: DnssecDnsHandle<H>,
+    handle: DnssecDnsHandle<H>,
     rrset: Rrset,
     options: DnsRequestOptions,
 ) -> Result<Rrset, E>
@@ -715,7 +715,7 @@ where
         .filter_map(|rrsig|rrsig.into_data())
         .map(|sig| {
             let rrset = Arc::clone(&rrset);
-            let mut handle = handle.clone_with_context();
+            let  handle = handle.clone_with_context();
 
             handle
                 .lookup(

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -715,7 +715,7 @@ where
         .filter_map(|rrsig|rrsig.into_data())
         .map(|sig| {
             let rrset = Arc::clone(&rrset);
-            let  handle = handle.clone_with_context();
+            let handle = handle.clone_with_context();
 
             handle
                 .lookup(

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -166,7 +166,7 @@ impl DnsHandle for BufDnsRequestStreamHandle {
     type Response = DnsResponseReceiver;
     type Error = ProtoError;
 
-    fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
         let request: DnsRequest = request.into();
         debug!(
             "enqueueing message:{}:{:?}",
@@ -175,7 +175,8 @@ impl DnsHandle for BufDnsRequestStreamHandle {
         );
 
         let (request, oneshot) = OneshotDnsRequest::oneshot(request);
-        try_oneshot!(self.sender.try_send(request).map_err(|_| {
+        let mut sender = self.sender.clone();
+        try_oneshot!(sender.try_send(request).map_err(|_| {
             debug!("unable to enqueue message");
             ProtoError::from(ProtoErrorKind::Busy)
         }));

--- a/crates/proto/src/xfer/retry_dns_handle.rs
+++ b/crates/proto/src/xfer/retry_dns_handle.rs
@@ -63,7 +63,7 @@ where
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, Self::Error>> + Send + Unpin>>;
     type Error = <H as DnsHandle>::Error;
 
-    fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
         let request = request.into();
 
         // need to clone here so that the retry can resend if necessary...
@@ -165,7 +165,7 @@ mod test {
         type Response = Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin>;
         type Error = ProtoError;
 
-        fn send<R: Into<DnsRequest>>(&mut self, _: R) -> Self::Response {
+        fn send<R: Into<DnsRequest>>(&self, _: R) -> Self::Response {
             let i = self.attempts.load(Ordering::SeqCst);
 
             if (i > self.retries || self.retries - i == 0) && self.last_succeed {
@@ -181,7 +181,7 @@ mod test {
 
     #[test]
     fn test_retry() {
-        let mut handle = RetryDnsHandle::new(
+        let handle = RetryDnsHandle::new(
             TestClient {
                 last_succeed: true,
                 retries: 1,
@@ -196,7 +196,7 @@ mod test {
 
     #[test]
     fn test_error() {
-        let mut client = RetryDnsHandle::new(
+        let client = RetryDnsHandle::new(
             TestClient {
                 last_succeed: false,
                 retries: 1,

--- a/crates/recursor/src/recursor_pool.rs
+++ b/crates/recursor/src/recursor_pool.rs
@@ -77,7 +77,7 @@ where
     }
 
     pub(crate) async fn lookup(&self, query: Query) -> Result<DnsResponse, ResolveError> {
-        let mut ns = self.ns.clone();
+        let ns = self.ns.clone();
 
         let query_cpy = query.clone();
 

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -204,11 +204,11 @@ impl<P: ConnectionProvider> DnsHandle for LookupEither<P> {
         }
     }
 
-    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         match *self {
-            Self::Retry(ref mut c) => c.send(request),
+            Self::Retry(ref c) => c.send(request),
             #[cfg(feature = "dnssec")]
-            Self::Secure(ref mut c) => c.send(request),
+            Self::Secure(ref c) => c.send(request),
         }
     }
 }
@@ -557,7 +557,7 @@ pub mod tests {
         type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ResolveError>> + Send>>;
         type Error = ResolveError;
 
-        fn send<R: Into<DnsRequest>>(&mut self, _: R) -> Self::Response {
+        fn send<R: Into<DnsRequest>>(&self, _: R) -> Self::Response {
             Box::pin(once(
                 future::ready(self.messages.lock().unwrap().pop().unwrap_or_else(empty)).boxed(),
             ))

--- a/crates/resolver/src/lookup_ip.rs
+++ b/crates/resolver/src/lookup_ip.rs
@@ -474,7 +474,7 @@ pub mod tests {
             Pin<Box<dyn Stream<Item = Result<DnsResponse, ResolveError>> + Send + Unpin>>;
         type Error = ResolveError;
 
-        fn send<R: Into<DnsRequest>>(&mut self, _: R) -> Self::Response {
+        fn send<R: Into<DnsRequest>>(&self, _: R) -> Self::Response {
             Box::pin(once(future::ready(
                 self.messages.lock().unwrap().pop().unwrap_or_else(empty),
             )))

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -233,7 +233,7 @@ impl DnsHandle for GenericConnection {
     type Response = ConnectionResponse;
     type Error = ResolveError;
 
-    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         ConnectionResponse(self.0.send(request))
     }
 }

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -128,7 +128,7 @@ where
         mut self,
         request: R,
     ) -> Result<DnsResponse, ResolveError> {
-        let mut client = self.connected_mut_client().await?;
+        let client = self.connected_mut_client().await?;
         let now = Instant::now();
         let response = client.send(request).first_answer().await;
         let rtt = now.elapsed();
@@ -183,7 +183,7 @@ where
     }
 
     // TODO: there needs to be some way of customizing the connection based on EDNS options from the server side...
-    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         let this = self.clone();
         // if state is failed, return future::err(), unless retry delay expired..
         Box::pin(once(this.inner_send(request)))
@@ -289,7 +289,7 @@ mod tests {
 
         let name = Name::parse("www.example.com.", None).unwrap();
         let response = io_loop
-            .block_on(name_server.then(|mut name_server| {
+            .block_on(name_server.then(|name_server| {
                 name_server
                     .lookup(
                         Query::query(name.clone(), RecordType::A),
@@ -323,7 +323,7 @@ mod tests {
 
         let name = Name::parse("www.example.com.", None).unwrap();
         assert!(io_loop
-            .block_on(name_server.then(|mut name_server| {
+            .block_on(name_server.then(|name_server| {
                 name_server
                     .lookup(
                         Query::query(name.clone(), RecordType::A),

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -229,7 +229,7 @@ where
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ResolveError>> + Send>>;
     type Error = ResolveError;
 
-    fn send<R: Into<DnsRequest>>(&mut self, request: R) -> Self::Response {
+    fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
         let opts = self.options;
         let request = request.into();
         let datagram_conns = Arc::clone(&self.datagram_conns);
@@ -360,7 +360,7 @@ where
 
         let mut requests = par_conns
             .into_iter()
-            .map(move |mut conn| {
+            .map(move |conn| {
                 conn.send(request_cont.clone())
                     .first_answer()
                     .map(|result| result.map_err(|e| (conn, e)))
@@ -516,7 +516,7 @@ mod tests {
         resolver_config.add_name_server(config2);
 
         let io_loop = Runtime::new().unwrap();
-        let mut pool = GenericNameServerPool::tokio_from_config(
+        let pool = GenericNameServerPool::tokio_from_config(
             &resolver_config,
             &ResolverOpts::default(),
             TokioRuntimeProvider::new(),
@@ -582,7 +582,7 @@ mod tests {
         let name_servers: Arc<[_]> = Arc::from([name_server]);
 
         #[cfg(not(feature = "mdns"))]
-        let mut pool = GenericNameServerPool::from_nameservers_test(
+        let pool = GenericNameServerPool::from_nameservers_test(
             &opts,
             Arc::from([]),
             Arc::clone(&name_servers),

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -196,7 +196,7 @@ where
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, E>> + Send>>;
     type Error = E;
 
-    fn send<R: Into<DnsRequest>>(&mut self, _: R) -> Self::Response {
+    fn send<R: Into<DnsRequest>>(&self, _: R) -> Self::Response {
         let mut messages = self.messages.lock().expect("failed to lock at messages");
         println!("MockClientHandle::send message count: {}", messages.len());
 
@@ -247,7 +247,7 @@ pub fn error<E>(error: E) -> Result<DnsResponse, E> {
 
 pub trait OnSend: Clone + Send + Sync + 'static {
     fn on_send<E>(
-        &mut self,
+        &self,
         response: Result<DnsResponse, E>,
     ) -> Pin<Box<dyn Future<Output = Result<DnsResponse, E>> + Send>>
     where

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -142,7 +142,7 @@ fn test_datagram() {
         Default::default(),
     );
 
-    let mut pool = mock_nameserver_pool(
+    let pool = mock_nameserver_pool(
         vec![udp_nameserver],
         vec![tcp_nameserver],
         None,
@@ -180,7 +180,7 @@ fn test_datagram_stream_upgrades_on_truncation() {
         Default::default(),
     );
 
-    let mut pool = mock_nameserver_pool(
+    let pool = mock_nameserver_pool(
         vec![udp_nameserver],
         vec![tcp_nameserver],
         None,
@@ -225,7 +225,7 @@ fn test_datagram_stream_upgrade_on_truncation_despite_udp() {
         Default::default(),
     );
 
-    let mut pool = mock_nameserver_pool(
+    let pool = mock_nameserver_pool(
         vec![udp_nameserver],
         vec![tcp_nameserver],
         None,
@@ -260,7 +260,7 @@ fn test_datagram_fails_to_stream() {
 
     let mut options = ResolverOpts::default();
     options.try_tcp_on_error = true;
-    let mut pool = mock_nameserver_pool(vec![udp_nameserver], vec![tcp_nameserver], None, options);
+    let pool = mock_nameserver_pool(vec![udp_nameserver], vec![tcp_nameserver], None, options);
 
     let request = message(query, vec![], vec![], vec![]);
     let future = pool.send(request).first_answer();
@@ -292,7 +292,7 @@ fn test_tcp_fallback_only_on_truncated() {
         Default::default(),
     );
 
-    let mut pool = mock_nameserver_pool(
+    let pool = mock_nameserver_pool(
         vec![udp_nameserver],
         vec![tcp_nameserver],
         None,
@@ -380,7 +380,7 @@ fn test_trust_nx_responses_fails() {
         true,
     );
 
-    let mut pool = mock_nameserver_pool(
+    let pool = mock_nameserver_pool(
         vec![fail_nameserver, succeed_nameserver],
         vec![],
         None,
@@ -435,7 +435,7 @@ fn test_noerror_doesnt_leak() {
     let mut options = ResolverOpts::default();
     options.num_concurrent_reqs = 1;
     options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
-    let mut pool = mock_nameserver_pool(
+    let pool = mock_nameserver_pool(
         vec![udp_nameserver, second_nameserver],
         vec![],
         None,
@@ -500,7 +500,7 @@ fn test_distrust_nx_responses() {
         false,
     );
 
-    let mut pool = mock_nameserver_pool(
+    let pool = mock_nameserver_pool(
         vec![error_nameserver, fallback_nameserver],
         vec![],
         None,
@@ -564,7 +564,7 @@ fn test_user_provided_server_order() {
         Default::default(),
     );
 
-    let mut pool = mock_nameserver_pool(
+    let pool = mock_nameserver_pool(
         vec![preferred_nameserver, secondary_nameserver],
         vec![],
         None,
@@ -609,7 +609,7 @@ fn test_return_error_from_highest_priority_nameserver() {
             mock_nameserver(vec![Err(response)], ResolverOpts::default())
         })
         .collect();
-    let mut pool = mock_nameserver_pool(name_servers, vec![], None, ResolverOpts::default());
+    let pool = mock_nameserver_pool(name_servers, vec![], None, ResolverOpts::default());
 
     let request = message(query, vec![], vec![], vec![]);
     let future = pool.send(request).first_answer();
@@ -704,7 +704,7 @@ fn test_concurrent_requests_2_conns() {
     );
     let udp2_nameserver = mock_nameserver_on_send(vec![], options, on_send);
 
-    let mut pool = mock_nameserver_pool_on_send(
+    let pool = mock_nameserver_pool_on_send(
         vec![udp2_nameserver, udp1_nameserver],
         vec![],
         None,
@@ -747,7 +747,7 @@ fn test_concurrent_requests_more_than_conns() {
     );
     let udp2_nameserver = mock_nameserver_on_send(vec![], options, on_send);
 
-    let mut pool = mock_nameserver_pool_on_send(
+    let pool = mock_nameserver_pool_on_send(
         vec![udp2_nameserver, udp1_nameserver],
         vec![],
         None,
@@ -790,7 +790,7 @@ fn test_concurrent_requests_1_conn() {
     );
     let udp2_nameserver = udp1_nameserver.clone();
 
-    let mut pool = mock_nameserver_pool_on_send(
+    let pool = mock_nameserver_pool_on_send(
         vec![udp2_nameserver, udp1_nameserver],
         vec![],
         None,
@@ -833,7 +833,7 @@ fn test_concurrent_requests_0_conn() {
     );
     let udp2_nameserver = udp1_nameserver.clone();
 
-    let mut pool = mock_nameserver_pool_on_send(
+    let pool = mock_nameserver_pool_on_send(
         vec![udp2_nameserver, udp1_nameserver],
         vec![],
         None,

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -645,7 +645,7 @@ impl OnSendBarrier {
 
 impl OnSend for OnSendBarrier {
     fn on_send<E>(
-        &mut self,
+        &self,
         response: Result<DnsResponse, E>,
     ) -> Pin<Box<dyn Future<Output = Result<DnsResponse, E>> + Send>>
     where

--- a/tests/integration-tests/tests/retry_dns_handle_tests.rs
+++ b/tests/integration-tests/tests/retry_dns_handle_tests.rs
@@ -23,7 +23,7 @@ impl DnsHandle for TestClient {
     type Response = Box<dyn Stream<Item = Result<DnsResponse, Self::Error>> + Send + Unpin>;
     type Error = ResolveError;
 
-    fn send<R: Into<DnsRequest>>(&mut self, _: R) -> Self::Response {
+    fn send<R: Into<DnsRequest>>(&self, _: R) -> Self::Response {
         let i = self.attempts.load(Ordering::SeqCst);
 
         if i > self.retries || self.retries - i == 0 {

--- a/tests/integration-tests/tests/retry_dns_handle_tests.rs
+++ b/tests/integration-tests/tests/retry_dns_handle_tests.rs
@@ -42,7 +42,7 @@ impl DnsHandle for TestClient {
 // The RetryDnsHandle should retry the same nameserver on IO errors, e.g. timeouts.
 #[test]
 fn retry_on_retryable_error() {
-    let mut handle = RetryDnsHandle::new(
+    let handle = RetryDnsHandle::new(
         TestClient {
             retries: 1,
             error_response: ResolveError::from(std::io::Error::from(std::io::ErrorKind::TimedOut)),
@@ -66,7 +66,7 @@ fn dont_retry_on_negative_response() {
         .set_response_code(ResponseCode::NoError);
     let error = ResolveError::from_response(DnsResponse::from_message(response).unwrap(), false)
         .expect_err("NODATA should be an error");
-    let mut client = RetryDnsHandle::new(
+    let client = RetryDnsHandle::new(
         TestClient {
             retries: 1,
             error_response: error,

--- a/tests/integration-tests/tests/truncation_tests.rs
+++ b/tests/integration-tests/tests/truncation_tests.rs
@@ -30,7 +30,7 @@ async fn test_truncation() {
 
     // Create the UDP client.
     let stream = UdpClientStream::<UdpSocket>::new(nameserver);
-    let (mut client, bg) = AsyncClient::connect(stream).await.unwrap();
+    let (client, bg) = AsyncClient::connect(stream).await.unwrap();
 
     // Run the client exchange in the background.
     tokio::spawn(bg);


### PR DESCRIPTION
following #1933 

making the trait non mut so usage of it doesn't need Mutex