### PR TITLE
fix: Prevent task reaping from blocking

### DIFF
--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -482,7 +482,10 @@ pub mod tokio_runtime {
 
     /// Reap finished tasks from a `JoinSet`, without awaiting or blocking.
     fn reap_tasks(join_set: &mut JoinSet<Result<(), ProtoError>>) {
-        while FutureExt::now_or_never(join_set.join_next()).is_some() {}
+        while FutureExt::now_or_never(join_set.join_next())
+            .flatten()
+            .is_some()
+        {}
     }
 
     /// Default ConnectionProvider with `GenericConnection`.


### PR DESCRIPTION
Previously, the `reap_tasks` function could cause a tokio task to spinloop.

This is because `FutureExt::now_or_never` returns an Option<T> where T is the inner future's resolution type. If `join_set.join_next()` returned None, indicating there are no longer tasks to join, the `FutureExt::now_or_never` would return `Some(None)`.

Then, the `is_some()` spinloop in this function would see the `Some(None)` and busy loop calling `FutureExt::now_or_never`.

The fix here is to use `Option::flatten` to transform the nested Option. Now, the call to `reap_tasks` will only loop when the inner `join_set.join_next` returns `Some(..)`, indicating that a task is already complete. When there are no tasks complete, or when the `JoinSet` is empty and returns `None`, the `reap_tasks` function will immediately yield.