### PR TITLE
[DON'T MERGE] Remove `Default` from `ResolverOpts`

### DIFF
--- a/crates/async-std-resolver/README.md
+++ b/crates/async-std-resolver/README.md
@@ -30,7 +30,7 @@ async fn main() {
   // Construct a new Resolver with default configuration options
   let resolver = resolver(
     config::ResolverConfig::default(),
-    config::ResolverOpts::default(),
+    config::ResolverOpts::new(),
   ).await;
 
   // Lookup the IP addresses associated with a name.

--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -54,7 +54,7 @@
 //!   // Construct a new Resolver with default configuration options
 //!   let resolver = resolver(
 //!     config::ResolverConfig::default(),
-//!     config::ResolverOpts::default(),
+//!     config::ResolverOpts::new(),
 //!   ).await;
 //!
 //!   // Lookup the IP addresses associated with a name.

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -452,7 +452,7 @@ impl Recursor {
 }
 
 fn recursor_opts() -> ResolverOpts {
-    let mut options = ResolverOpts::default();
+    let mut options = ResolverOpts::new();
     options.ndots = 0;
     options.edns0 = true;
     options.validate = false; // we'll need to do any dnssec validation differently in a recursor (top-down rather than bottom-up)

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -26,7 +26,7 @@ use trust_dns_resolver::Resolver;
 use trust_dns_resolver::config::*;
 
 // Construct a new Resolver with default configuration options
-let mut resolver = Resolver::new(ResolverConfig::default(), ResolverOpts::default()).unwrap();
+let mut resolver = Resolver::new(ResolverConfig::default(), ResolverOpts::new()).unwrap();
 
 // On Unix/Posix systems, this will read the /etc/resolv.conf
 // let mut resolver = Resolver::from_system_conf().unwrap();
@@ -64,7 +64,7 @@ A default TLS configuration is available for Cloudflare's `1.1.1.1` DNS service 
 
 ```rust
 // Construct a new Resolver with default configuration options
-let mut resolver = Resolver::new(ResolverConfig::cloudflare_tls(), ResolverOpts::default()).unwrap();
+let mut resolver = Resolver::new(ResolverConfig::cloudflare_tls(), ResolverOpts::new()).unwrap();
 
 /// see example above...
 ```

--- a/crates/resolver/examples/custom_provider.rs
+++ b/crates/resolver/examples/custom_provider.rs
@@ -80,7 +80,7 @@ async fn lookup_test<R: ConnectionProvider>(resolver: AsyncResolver<R>) {
 async fn main() {
     let resolver = AsyncResolver::new(
         ResolverConfig::google(),
-        ResolverOpts::default(),
+        ResolverOpts::new(),
         GenericConnector::new(PrintProvider::default()),
     );
     lookup_test(resolver).await;
@@ -89,7 +89,7 @@ async fn main() {
     {
         let resolver2 = AsyncResolver::new(
             ResolverConfig::cloudflare_https(),
-            ResolverOpts::default(),
+            ResolverOpts::new(),
             GenericConnector::new(PrintProvider::default()),
         );
         lookup_test(resolver2).await;

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -30,7 +30,7 @@ async fn tokio_main() {
             // Get a new resolver with the google nameservers as the upstream recursive resolvers
             AsyncResolver::tokio(
                 ResolverConfig::quad9(),
-                ResolverOpts::default(),
+                ResolverOpts::new(),
                 //runtime.handle().clone(),
             )
         }

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -54,7 +54,7 @@ static GLOBAL_DNS_RESOLVER: Lazy<TokioAsyncResolver> = Lazy::new(|| {
                 // Get a new resolver with the google nameservers as the upstream recursive resolvers
                 TokioAsyncResolver::new(
                     ResolverConfig::google(),
-                    ResolverOpts::default(),
+                    ResolverOpts::new(),
                     runtime.handle().clone(),
                 )
             }

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -29,7 +29,7 @@ fn main() {
             // Get a new resolver with the google nameservers as the upstream recursive resolvers
             AsyncResolver::new(
                 ResolverConfig::google(),
-                ResolverOpts::default(),
+                ResolverOpts::new(),
                 runtime.handle().clone(),
             )
         }

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -468,7 +468,7 @@ pub mod testing {
         mut exec: E,
         handle: R,
     ) {
-        let resolver = AsyncResolver::<R>::new(config, ResolverOpts::default(), handle);
+        let resolver = AsyncResolver::<R>::new(config, ResolverOpts::new(), handle);
 
         let response = exec
             .block_on(resolver.lookup_ip("www.example.com."))
@@ -492,7 +492,7 @@ pub mod testing {
     /// Test IP lookup from IP literals.
     pub fn ip_lookup_test<E: Executor, R: ConnectionProvider>(mut exec: E, handle: R) {
         let resolver =
-            AsyncResolver::<R>::new(ResolverConfig::default(), ResolverOpts::default(), handle);
+            AsyncResolver::<R>::new(ResolverConfig::default(), ResolverOpts::new(), handle);
 
         let response = exec
             .block_on(resolver.lookup_ip("10.1.0.2"))
@@ -524,7 +524,7 @@ pub mod testing {
         // AsyncResolver works correctly.
         use std::thread;
         let resolver =
-            AsyncResolver::<R>::new(ResolverConfig::default(), ResolverOpts::default(), handle);
+            AsyncResolver::<R>::new(ResolverConfig::default(), ResolverOpts::new(), handle);
 
         let resolver_one = resolver.clone();
         let resolver_two = resolver;
@@ -579,7 +579,7 @@ pub mod testing {
             ResolverOpts {
                 validate: true,
                 try_tcp_on_error: true,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -619,7 +619,7 @@ pub mod testing {
             ResolverOpts {
                 validate: true,
                 ip_strategy: LookupIpStrategy::Ipv4Only,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -715,7 +715,7 @@ pub mod testing {
             ResolverConfig::from_parts(Some(domain), search, name_servers),
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv4Only,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -750,7 +750,7 @@ pub mod testing {
                 // our name does have 2, the default should be fine, let's just narrow the test criteria a bit.
                 ndots: 2,
                 ip_strategy: LookupIpStrategy::Ipv4Only,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -789,7 +789,7 @@ pub mod testing {
                 // matches kubernetes default
                 ndots: 5,
                 ip_strategy: LookupIpStrategy::Ipv4Only,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -829,7 +829,7 @@ pub mod testing {
             ResolverConfig::from_parts(Some(domain), search, name_servers),
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv4Only,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -868,7 +868,7 @@ pub mod testing {
             ResolverConfig::from_parts(Some(domain), search, name_servers),
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv4Only,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -891,7 +891,7 @@ pub mod testing {
     /// Test idna.
     pub fn idna_test<E: Executor + Send + 'static, R: ConnectionProvider>(mut exec: E, handle: R) {
         let resolver =
-            AsyncResolver::<R>::new(ResolverConfig::default(), ResolverOpts::default(), handle);
+            AsyncResolver::<R>::new(ResolverConfig::default(), ResolverOpts::new(), handle);
 
         let response = exec
             .block_on(resolver.lookup_ip("中国.icom.museum."))
@@ -911,7 +911,7 @@ pub mod testing {
             ResolverConfig::default(),
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv4thenIpv6,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -936,7 +936,7 @@ pub mod testing {
             ResolverConfig::default(),
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv6thenIpv4,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -965,7 +965,7 @@ pub mod testing {
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv4Only,
                 ndots: 5,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -994,7 +994,7 @@ pub mod testing {
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv4Only,
                 ndots: 5,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -1026,7 +1026,7 @@ pub mod testing {
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv4Only,
                 ndots: 5,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             handle,
         );
@@ -1256,7 +1256,7 @@ mod tests {
         let mut config = ResolverConfig::default();
         config.add_search(Name::from_ascii("example.com.").unwrap());
         let resolver =
-            AsyncResolver::<TokioConnectionProvider>::new(config, ResolverOpts::default(), handle);
+            AsyncResolver::<TokioConnectionProvider>::new(config, ResolverOpts::new(), handle);
         let tor_address = [
             Name::from_ascii("2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion")
                 .unwrap(),

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -849,11 +849,7 @@ impl Default for ServerOrderingStrategy {
 
 /// Configuration for the Resolver
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde-config",
-    derive(Serialize, Deserialize),
-    serde(default)
-)]
+#[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize))]
 #[allow(missing_copy_implementations)]
 #[non_exhaustive]
 pub struct ResolverOpts {
@@ -925,11 +921,12 @@ pub struct ResolverOpts {
     pub shuffle_dns_servers: bool,
 }
 
-impl Default for ResolverOpts {
+impl ResolverOpts {
     /// Default values for the Resolver configuration.
     ///
     /// This follows the resolv.conf defaults as defined in the [Linux man pages](http://man7.org/linux/man-pages/man5/resolv.conf.5.html)
-    fn default() -> Self {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
         Self {
             ndots: 1,
             timeout: Duration::from_secs(5),

--- a/crates/resolver/src/dns_sd.rs
+++ b/crates/resolver/src/dns_sd.rs
@@ -172,7 +172,7 @@ mod tests {
             ResolverConfig::default(),
             ResolverOpts {
                 ip_strategy: LookupIpStrategy::Ipv6thenIpv4,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             TokioHandle::default(),
         )

--- a/crates/resolver/src/https.rs
+++ b/crates/resolver/src/https.rs
@@ -90,7 +90,7 @@ mod tests {
             config,
             ResolverOpts {
                 try_tcp_on_error: true,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             TokioConnectionProvider::default(),
         );

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -49,7 +49,7 @@
 //! use trust_dns_resolver::config::*;
 //!
 //! // Construct a new Resolver with default configuration options
-//! let resolver = Resolver::new(ResolverConfig::default(), ResolverOpts::default()).unwrap();
+//! let resolver = Resolver::new(ResolverConfig::default(), ResolverOpts::new()).unwrap();
 //!
 //! // Lookup the IP addresses associated with a name.
 //! // The final dot forces this to be an FQDN, otherwise the search rules as specified
@@ -111,7 +111,7 @@
 //! let resolver = io_loop.block_on(async {
 //!     TokioAsyncResolver::tokio(
 //!         ResolverConfig::default(),
-//!         ResolverOpts::default())
+//!         ResolverOpts::new())
 //! });
 //!
 //! // Lookup the IP addresses associated with a name.
@@ -152,7 +152,7 @@
 //! # let resolver = io_loop.block_on(async {
 //! #    TokioAsyncResolver::tokio(
 //! #        ResolverConfig::default(),
-//! #        ResolverOpts::default())
+//! #        ResolverOpts::new())
 //! # });
 //! #
 //! let ips = io_loop.block_on(resolver.lookup_ip("www.example.com.")).unwrap();
@@ -213,7 +213,7 @@
 //!
 //! // Construct a new Resolver with default configuration options
 //! # #[cfg(feature = "dns-over-tls")]
-//! let mut resolver = Resolver::new(ResolverConfig::cloudflare_tls(), ResolverOpts::default()).unwrap();
+//! let mut resolver = Resolver::new(ResolverConfig::cloudflare_tls(), ResolverOpts::new()).unwrap();
 //!
 //! // see example above...
 //! # }

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -282,7 +282,7 @@ mod tests {
         let name_server = future::lazy(|_| {
             GenericNameServer::new(
                 config,
-                ResolverOpts::default(),
+                ResolverOpts::new(),
                 TokioConnectionProvider::default(),
             )
         });
@@ -305,7 +305,7 @@ mod tests {
     fn test_failed_name_server() {
         let options = ResolverOpts {
             timeout: Duration::from_millis(1), // this is going to fail, make it fail fast...
-            ..ResolverOpts::default()
+            ..ResolverOpts::new()
         };
         let config = NameServerConfig {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 252),

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -518,7 +518,7 @@ mod tests {
         let io_loop = Runtime::new().unwrap();
         let pool = GenericNameServerPool::tokio_from_config(
             &resolver_config,
-            ResolverOpts::default(),
+            ResolverOpts::new(),
             TokioRuntimeProvider::new(),
         );
 
@@ -575,7 +575,7 @@ mod tests {
 
         let opts = ResolverOpts {
             try_tcp_on_error: true,
-            ..ResolverOpts::default()
+            ..ResolverOpts::new()
         };
         let ns_config = { tcp };
         let name_server = GenericNameServer::new(ns_config, opts.clone(), conn_provider);

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -98,7 +98,7 @@ impl Resolver {
     /// A new `Resolver` or an error if there was an error with the configuration.
     #[allow(clippy::should_implement_trait)]
     pub fn default() -> io::Result<Self> {
-        Self::new(ResolverConfig::default(), ResolverOpts::default())
+        Self::new(ResolverConfig::default(), ResolverOpts::new())
     }
 
     /// Constructs a new Resolver with the system configuration.
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn test_lookup() {
-        let resolver = Resolver::new(ResolverConfig::default(), ResolverOpts::default()).unwrap();
+        let resolver = Resolver::new(ResolverConfig::default(), ResolverOpts::new()).unwrap();
 
         let response = resolver.lookup_ip("www.example.com.").unwrap();
         println!("response records: {response:?}");

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -109,7 +109,7 @@ fn into_resolver_config(
         ndots: parsed_config.ndots as usize,
         timeout: Duration::from_secs(u64::from(parsed_config.timeout)),
         attempts: parsed_config.attempts as usize,
-        ..ResolverOpts::default()
+        ..ResolverOpts::new()
     };
 
     Ok((config, options))
@@ -165,7 +165,7 @@ mod tests {
         cfg.add_name_server(nameservers[0].clone());
         cfg.add_name_server(nameservers[1].clone());
         assert_eq!(cfg.name_servers(), parsed.0.name_servers());
-        assert_eq!(ResolverOpts::default(), parsed.1);
+        assert_eq!(ResolverOpts::new(), parsed.1);
     }
 
     #[test]
@@ -174,7 +174,7 @@ mod tests {
         let mut cfg = empty_config();
         cfg.add_search(Name::from_str("localnet.").unwrap());
         assert_eq!(cfg.search(), parsed.0.search());
-        assert_eq!(ResolverOpts::default(), parsed.1);
+        assert_eq!(ResolverOpts::new(), parsed.1);
     }
 
     #[test]
@@ -189,14 +189,14 @@ mod tests {
             cfg.add_name_server(nameservers[0].clone());
             cfg.add_name_server(nameservers[1].clone());
             assert_eq!(cfg.name_servers(), parsed.0.name_servers());
-            assert_eq!(ResolverOpts::default(), parsed.1);
+            assert_eq!(ResolverOpts::new(), parsed.1);
         }
 
         // This is the important part, that the invalid `--` is skipped during parsing
         {
             cfg.add_search(Name::from_str("lan").unwrap());
             assert_eq!(cfg.search(), parsed.0.search());
-            assert_eq!(ResolverOpts::default(), parsed.1);
+            assert_eq!(ResolverOpts::new(), parsed.1);
         }
     }
 
@@ -206,7 +206,7 @@ mod tests {
         let mut cfg = empty_config();
         cfg.add_search(Name::from_str_relaxed("Speedport_000.").unwrap());
         assert_eq!(cfg.search(), parsed.0.search());
-        assert_eq!(ResolverOpts::default(), parsed.1);
+        assert_eq!(ResolverOpts::new(), parsed.1);
     }
 
     #[test]
@@ -215,7 +215,7 @@ mod tests {
         let mut cfg = empty_config();
         cfg.set_domain(Name::from_str("example.com").unwrap());
         assert_eq!(cfg, parsed.0);
-        assert_eq!(ResolverOpts::default(), parsed.1);
+        assert_eq!(ResolverOpts::new(), parsed.1);
     }
 
     #[test]

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -44,7 +44,7 @@ mod tests {
             config,
             ResolverOpts {
                 try_tcp_on_error: true,
-                ..ResolverOpts::default()
+                ..ResolverOpts::new()
             },
             TokioConnectionProvider::default(),
         );

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -8,7 +8,7 @@
 use std::io;
 
 use tracing::{debug, info};
-use trust_dns_resolver::name_server::TokioConnectionProvider;
+use trust_dns_resolver::{config::ResolverOpts, name_server::TokioConnectionProvider};
 
 use crate::{
     authority::{
@@ -54,7 +54,7 @@ impl ForwardAuthority {
         info!("loading forwarder config: {}", origin);
 
         let name_servers = config.name_servers.clone();
-        let mut options = config.options.clone().unwrap_or_default();
+        let mut options = config.options.clone().unwrap_or_else(ResolverOpts::new);
 
         // See RFC 1034, Section 4.3.2:
         // "If the data at the node is a CNAME, and QTYPE doesn't match

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -135,18 +135,18 @@ fn test_datagram() {
     let tcp_message = message(query.clone(), vec![tcp_record], vec![], vec![]);
     let udp_nameserver = mock_nameserver(
         vec![Ok(DnsResponse::from_message(udp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
     );
     let tcp_nameserver = mock_nameserver(
         vec![Ok(DnsResponse::from_message(tcp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     let pool = mock_nameserver_pool(
         vec![udp_nameserver],
         vec![tcp_nameserver],
         None,
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     // lookup on UDP succeeds, any other would fail
@@ -173,18 +173,18 @@ fn test_datagram_stream_upgrades_on_truncation() {
 
     let udp_nameserver = mock_nameserver(
         vec![Ok(DnsResponse::from_message(udp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
     );
     let tcp_nameserver = mock_nameserver(
         vec![Ok(DnsResponse::from_message(tcp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     let pool = mock_nameserver_pool(
         vec![udp_nameserver],
         vec![tcp_nameserver],
         None,
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     // lookup on UDP succeeds, any other would fail
@@ -218,18 +218,18 @@ fn test_datagram_stream_upgrade_on_truncation_despite_udp() {
 
     let udp_nameserver = mock_nameserver(
         vec![Ok(DnsResponse::from_message(udp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
     );
     let tcp_nameserver = mock_nameserver(
         vec![Ok(DnsResponse::from_message(tcp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     let pool = mock_nameserver_pool(
         vec![udp_nameserver],
         vec![tcp_nameserver],
         None,
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     // lookup on UDP succeeds, any other would fail
@@ -252,13 +252,13 @@ fn test_datagram_fails_to_stream() {
 
     let tcp_message = message(query.clone(), vec![tcp_record.clone()], vec![], vec![]);
 
-    let udp_nameserver = mock_nameserver(vec![udp_message], Default::default());
+    let udp_nameserver = mock_nameserver(vec![udp_message], ResolverOpts::new());
     let tcp_nameserver = mock_nameserver(
         vec![Ok(DnsResponse::from_message(tcp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
     );
 
-    let mut options = ResolverOpts::default();
+    let mut options = ResolverOpts::new();
     options.try_tcp_on_error = true;
     let pool = mock_nameserver_pool(vec![udp_nameserver], vec![tcp_nameserver], None, options);
 
@@ -285,18 +285,18 @@ fn test_tcp_fallback_only_on_truncated() {
             DnsResponse::from_message(udp_message).unwrap(),
             false,
         )],
-        Default::default(),
+        ResolverOpts::new(),
     );
     let tcp_nameserver = mock_nameserver(
         vec![Ok(DnsResponse::from_message(tcp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     let pool = mock_nameserver_pool(
         vec![udp_nameserver],
         vec![tcp_nameserver],
         None,
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     let request = message(query, vec![], vec![], vec![]);
@@ -371,12 +371,12 @@ fn test_trust_nx_responses_fails() {
     // Fail the first UDP request.
     let fail_nameserver = mock_nameserver_trust_nx(
         vec![Ok(DnsResponse::from_message(nx_message).unwrap())],
-        ResolverOpts::default(),
+        ResolverOpts::new(),
         true,
     );
     let succeed_nameserver = mock_nameserver_trust_nx(
         vec![Ok(DnsResponse::from_message(success_msg).unwrap())],
-        ResolverOpts::default(),
+        ResolverOpts::new(),
         true,
     );
 
@@ -384,7 +384,7 @@ fn test_trust_nx_responses_fails() {
         vec![fail_nameserver, succeed_nameserver],
         vec![],
         None,
-        ResolverOpts::default(),
+        ResolverOpts::new(),
     );
 
     // Lookup on UDP should fail, since we trust nx responses.
@@ -422,17 +422,17 @@ fn test_noerror_doesnt_leak() {
 
     let udp_nameserver = mock_nameserver_trust_nx(
         vec![Ok(DnsResponse::from_message(udp_message).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
         true,
     );
     // Provide a fake A record; if this nameserver is queried the test should fail.
     let second_nameserver = mock_nameserver_trust_nx(
         vec![Ok(DnsResponse::from_message(incorrect_success_msg).unwrap())],
-        Default::default(),
+        ResolverOpts::new(),
         true,
     );
 
-    let mut options = ResolverOpts::default();
+    let mut options = ResolverOpts::new();
     options.num_concurrent_reqs = 1;
     options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
     let pool = mock_nameserver_pool(
@@ -487,7 +487,7 @@ fn test_distrust_nx_responses() {
                 Ok(DnsResponse::from_message(error_message).unwrap())
             })
             .collect(),
-        ResolverOpts::default(),
+        ResolverOpts::new(),
         false,
     );
 
@@ -496,7 +496,7 @@ fn test_distrust_nx_responses() {
     let success_message = message(query.clone(), vec![v4_record.clone()], vec![], vec![]);
     let fallback_nameserver = mock_nameserver_trust_nx(
         vec![Ok(DnsResponse::from_message(success_message).unwrap()); RETRYABLE_ERRORS.len()],
-        ResolverOpts::default(),
+        ResolverOpts::new(),
         false,
     );
 
@@ -504,7 +504,7 @@ fn test_distrust_nx_responses() {
         vec![error_nameserver, fallback_nameserver],
         vec![],
         None,
-        ResolverOpts::default(),
+        ResolverOpts::new(),
     );
     for response_code in RETRYABLE_ERRORS.iter() {
         let request = message(query.clone(), vec![], vec![], vec![]);
@@ -523,7 +523,7 @@ fn test_distrust_nx_responses() {
 fn test_user_provided_server_order() {
     use trust_dns_proto::rr::Record;
 
-    let mut options = ResolverOpts::default();
+    let mut options = ResolverOpts::new();
 
     options.num_concurrent_reqs = 1;
     options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
@@ -556,12 +556,12 @@ fn test_user_provided_server_order() {
     let preferred_nameserver = mock_nameserver_with_addr(
         to_dns_response(preferred_server_records.clone()),
         Ipv4Addr::new(128, 0, 0, 1).into(),
-        Default::default(),
+        ResolverOpts::new(),
     );
     let secondary_nameserver = mock_nameserver_with_addr(
         to_dns_response(secondary_server_records.clone()),
         Ipv4Addr::new(129, 0, 0, 1).into(),
-        Default::default(),
+        ResolverOpts::new(),
     );
 
     let pool = mock_nameserver_pool(
@@ -606,10 +606,10 @@ fn test_return_error_from_highest_priority_nameserver() {
                 true,
             )
             .expect_err("error code should result in resolve error");
-            mock_nameserver(vec![Err(response)], ResolverOpts::default())
+            mock_nameserver(vec![Err(response)], ResolverOpts::new())
         })
         .collect();
-    let pool = mock_nameserver_pool(name_servers, vec![], None, ResolverOpts::default());
+    let pool = mock_nameserver_pool(name_servers, vec![], None, ResolverOpts::new());
 
     let request = message(query, vec![], vec![], vec![]);
     let future = pool.send(request).first_answer();
@@ -682,7 +682,7 @@ where
 
 #[test]
 fn test_concurrent_requests_2_conns() {
-    let mut options = ResolverOpts::default();
+    let mut options = ResolverOpts::new();
 
     // there are only 2 conns, so this matches that count
     options.num_concurrent_reqs = 2;
@@ -725,7 +725,7 @@ fn test_concurrent_requests_2_conns() {
 
 #[test]
 fn test_concurrent_requests_more_than_conns() {
-    let mut options = ResolverOpts::default();
+    let mut options = ResolverOpts::new();
 
     // there are only two conns, but this requests 3 concurrent requests, only 2 called
     options.num_concurrent_reqs = 3;
@@ -768,7 +768,7 @@ fn test_concurrent_requests_more_than_conns() {
 
 #[test]
 fn test_concurrent_requests_1_conn() {
-    let mut options = ResolverOpts::default();
+    let mut options = ResolverOpts::new();
 
     // there are two connections, but no concurrency requested
     options.num_concurrent_reqs = 1;
@@ -811,7 +811,7 @@ fn test_concurrent_requests_1_conn() {
 
 #[test]
 fn test_concurrent_requests_0_conn() {
-    let mut options = ResolverOpts::default();
+    let mut options = ResolverOpts::new();
 
     // there are two connections, but no concurrency requested, 0==1
     options.num_concurrent_reqs = 0;

--- a/util/src/resolve.rs
+++ b/util/src/resolve.rs
@@ -334,7 +334,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .join(", ");
 
     // configure the resolver options
-    let mut options = sys_options.unwrap_or_default();
+    let mut options = sys_options.unwrap_or_else(ResolverOpts::new);
     if opts.happy {
         options.ip_strategy = trust_dns_resolver::config::LookupIpStrategy::Ipv4AndIpv6;
     }


### PR DESCRIPTION
As discussed in https://github.com/bluejekyll/trust-dns/pull/2031.