### PR TITLE
Update `quinn-proto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85af4ed6ee5a89f26a26086e9089a6643650544c025158449a3626ebf72884b3"
+checksum = "2c78e758510582acc40acb90458401172d41f1016f8c9dde89e49677afb7eec1"
 dependencies = [
  "bytes",
  "rand",


### PR DESCRIPTION
Partly fixes the currently broken CI.