### PR TITLE
Fixes caching bug when CNAME leads to negative response

### DIFF
--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -245,7 +245,10 @@ where
             Ok(Records::CnameChain {
                 next: future,
                 min_ttl: ttl,
-            }) => client.cname(future.await?, query, ttl),
+            }) => match future.await {
+                Ok(lookup) => client.cname(lookup, query, ttl),
+                Err(e) => client.cache(query, Err(e)),
+            },
             Ok(Records::Exists(rdata)) => client.cache(query, Ok(rdata)),
             Err(e) => client.cache(query, Err(e)),
         }


### PR DESCRIPTION
What this PR does:
* Fixes: https://github.com/bluejekyll/trust-dns/issues/1331