### PR TITLE
proto/rr: do not deserialize `ClientSubnet`s with invalid prefixes

### DIFF
--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -678,6 +678,9 @@ impl<'a> BinDecodable<'a> for ClientSubnet {
                 let addr_len =
                     (source_prefix / 8 + if source_prefix % 8 > 0 { 1 } else { 0 }) as usize;
                 let mut octets = Ipv4Addr::UNSPECIFIED.octets();
+                if addr_len > octets.len() {
+                    return Err(ProtoErrorKind::Message("Invalid address length").into());
+                }
                 for octet in octets.iter_mut().take(addr_len) {
                     *octet = decoder.read_u8()?.unverified();
                 }
@@ -694,6 +697,9 @@ impl<'a> BinDecodable<'a> for ClientSubnet {
                 let addr_len =
                     (source_prefix / 8 + if source_prefix % 8 > 0 { 1 } else { 0 }) as usize;
                 let mut octets = Ipv6Addr::UNSPECIFIED.octets();
+                if addr_len > octets.len() {
+                    return Err(ProtoErrorKind::Message("Invalid address length").into());
+                }
                 for octet in octets.iter_mut().take(addr_len) {
                     *octet = decoder.read_u8()?.unverified();
                 }


### PR DESCRIPTION
When serializing a `ClientSubnet`, if the source prefix is larger than the address itself, we return an error. However, when deserializing the same type we will happily take an invalid prefix. Fix this consistency issue by rejecting invalid prefixes during deserialization.

Before, this would cause the following fuzzing harness to fail, given the appropriate input:

```rust
#![no_main]

use libfuzzer_sys::fuzz_target;
use trust_dns_proto::rr::rdata::opt::ClientSubnet;
use trust_dns_proto::serialize::binary::BinDecodable;
use trust_dns_proto::serialize::binary::BinEncodable;

fuzz_target!(|data: &[u8]| {
    if let Ok(net) = ClientSubnet::from_bytes(data) {
        net.to_bytes().unwrap();
    }
});
```

This would also impact (de)serialization of other types which embed `ClientSubnet`s.