### PR TITLE
Add root certificates to the binary crate

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -32,7 +32,7 @@ codecov = { repository = "bluejekyll/trust-dns", branch = "main", service = "git
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["sqlite", "resolver"]
+default = ["sqlite", "resolver", "native-certs"]
 dnssec-openssl = ["dnssec", "trust-dns-client/dnssec-openssl", "trust-dns-proto/dnssec-openssl", "trust-dns-server/dnssec-openssl"]
 dnssec-ring = ["dnssec", "trust-dns-client/dnssec-ring", "trust-dns-proto/dnssec-ring", "trust-dns-server/dnssec-ring"]
 dnssec = []
@@ -59,6 +59,9 @@ tls = ["dns-over-openssl"]
 
 # WARNING: there is a bug in the mutual tls auth code at the moment see issue #100
 # mtls = ["trust-dns-client/mtls"]
+
+webpki-roots = ["trust-dns-client/webpki-roots"]
+native-certs = ["trust-dns-client/native-certs"]
 
 [[bin]]
 name = "trust-dns"


### PR DESCRIPTION
I'm not entirely sure I tested the same thing, but the following now works for me:
```
cargo run --bin dns -F dns-over-quic,resolver,recursor,native-certs -- -p quic -n 94.140.14.140:853 -t unfiltered.adguard-dns.com --debug query dns.google A
```

Interestingly, building with the `webpki-roots` feature, gives me an incredibly confusing error:
```
Package `trust-dns-integration v0.23.0 (/home/daxpedda/Documents/Projects/Game Experiment/trust-dns/tests/integration-tests)` does not have feature `webpki-roots`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
```

Fixes #2000.
Cc @hingbong.